### PR TITLE
Let Quarkdoc add links to wiki pages 

### DIFF
--- a/quarkdown-quarkdoc/src/main/kotlin/com/quarkdown/quarkdoc/dokka/QuarkdocDokkaPlugin.kt
+++ b/quarkdown-quarkdoc/src/main/kotlin/com/quarkdown/quarkdoc/dokka/QuarkdocDokkaPlugin.kt
@@ -1,6 +1,7 @@
 package com.quarkdown.quarkdoc.dokka
 
 import com.quarkdown.quarkdoc.dokka.page.DocumentTypeConstraintsPageTransformer
+import com.quarkdown.quarkdoc.dokka.page.WikiLinkPageTransformer
 import com.quarkdown.quarkdoc.dokka.signature.QuarkdownSignatureProvider
 import com.quarkdown.quarkdoc.dokka.transformers.enumeration.EnumParameterEntryListerTransformer
 import com.quarkdown.quarkdoc.dokka.transformers.enumeration.EnumStorer
@@ -127,6 +128,13 @@ class QuarkdocDokkaPlugin : DokkaPlugin() {
      */
     val documentTypeConstraintsPageTransformer by extending {
         CoreExtensions.pageTransformer providing ::DocumentTypeConstraintsPageTransformer
+    }
+
+    /**
+     * Generates a new section for the `@wiki` documentation tag with a link to the corresponding wiki page.
+     */
+    val wikiLinkPageTransformer by extending {
+        CoreExtensions.pageTransformer providing ::WikiLinkPageTransformer
     }
 
     /**

--- a/quarkdown-quarkdoc/src/main/kotlin/com/quarkdown/quarkdoc/dokka/page/WikiLinkPageTransformer.kt
+++ b/quarkdown-quarkdoc/src/main/kotlin/com/quarkdown/quarkdoc/dokka/page/WikiLinkPageTransformer.kt
@@ -1,0 +1,50 @@
+package com.quarkdown.quarkdoc.dokka.page
+
+import com.quarkdown.quarkdoc.dokka.util.findDeep
+import org.jetbrains.dokka.base.translators.documentables.PageContentBuilder
+import org.jetbrains.dokka.model.DFunction
+import org.jetbrains.dokka.model.Documentable
+import org.jetbrains.dokka.model.doc.CustomTagWrapper
+import org.jetbrains.dokka.model.doc.Text
+import org.jetbrains.dokka.plugability.DokkaContext
+import java.net.URLEncoder
+
+private const val TAG_NAME = "wiki"
+
+/**
+ * The root URL of the Quarkdown wiki to link to.
+ */
+const val WIKI_ROOT = "https://github.com/iamgio/quarkdown/wiki/"
+
+/**
+ * Transformer that generates a new section for the `@wiki` documentation tag of a function,
+ * with a link to the corresponding wiki page.
+ */
+class WikiLinkPageTransformer(
+    context: DokkaContext,
+) : NewSectionDocumentablePageTransformer<DFunction, String>("Wiki page", context) {
+    override fun extractDocumentable(documentables: List<Documentable>) = documentables.firstOrNull() as? DFunction
+
+    /**
+     * Extracts the wiki page name from the `@wiki` documentation tag, if present.
+     * For example: `@wiki home` -> `home`
+     */
+    override fun extractData(documentable: DFunction): String? {
+        val wikiTag: CustomTagWrapper =
+            documentable.documentation.values
+                .firstOrNull()
+                ?.findDeep<CustomTagWrapper> { it.name == TAG_NAME }
+                ?: return null
+
+        return wikiTag.root.findDeep<Text>()?.body
+    }
+
+    override fun createSection(
+        data: String,
+        documentable: DFunction,
+        builder: PageContentBuilder.DocumentableContentBuilder,
+    ) = builder.buildGroup {
+        val url = WIKI_ROOT + URLEncoder.encode(data, Charsets.UTF_8)
+        link(data, url)
+    }
+}

--- a/quarkdown-quarkdoc/src/main/kotlin/com/quarkdown/quarkdoc/dokka/util/KDoc.kt
+++ b/quarkdown-quarkdoc/src/main/kotlin/com/quarkdown/quarkdoc/dokka/util/KDoc.kt
@@ -1,0 +1,12 @@
+package com.quarkdown.quarkdoc.dokka.util
+
+import org.jetbrains.dokka.model.WithChildren
+import org.jetbrains.dokka.model.withDescendants
+
+/**
+ * Finds the first child of type [T] in the documentation tree, starting from [this] root.
+ * @param predicate optional predicate to filter the children of type [T]
+ * @return the first child of type [T] that matches the predicate, if any
+ */
+inline fun <reified T> WithChildren<*>.findDeep(crossinline predicate: (T) -> Boolean = { true }): T? =
+    withDescendants().firstOrNull { it is T && predicate(it) } as? T

--- a/quarkdown-quarkdoc/src/test/kotlin/com/quarkdown/quarkdoc/dokka/WikiLinkTransformerTest.kt
+++ b/quarkdown-quarkdoc/src/test/kotlin/com/quarkdown/quarkdoc/dokka/WikiLinkTransformerTest.kt
@@ -1,0 +1,58 @@
+package com.quarkdown.quarkdoc.dokka
+
+import com.quarkdown.quarkdoc.dokka.page.WIKI_ROOT
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertFalse
+
+/**
+ * Tests for the `@wiki` documentation tag.
+ */
+class WikiLinkTransformerTest : QuarkdocDokkaTest() {
+    @Test
+    fun `no wiki`() {
+        test(
+            """
+            /**
+             *
+             */
+            fun func() = Unit
+            """.trimIndent(),
+            "func",
+        ) {
+            assertFalse("Wiki page" in it)
+        }
+    }
+
+    @Test
+    fun wiki() {
+        test(
+            """
+            /**
+             * @wiki home
+             */
+            fun func() = Unit
+            """.trimIndent(),
+            "func",
+        ) {
+            assertContains(it, "Wiki page")
+            assertContains(it, WIKI_ROOT + "home")
+        }
+    }
+
+    @Test
+    fun `wiki with escape`() {
+        test(
+            """
+            /**
+             * @wiki home: page
+             */
+            fun func() = Unit
+            """.trimIndent(),
+            "func",
+        ) {
+            assertContains(it, "Wiki page")
+            assertContains(it, WIKI_ROOT + "home%3A+page")
+        }
+    }
+}

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Data.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Data.kt
@@ -55,6 +55,7 @@ internal fun file(
  *                  If not specified or infinite, the whole file is read
  * @return a string value of the text extracted from the file
  * @throws IllegalArgumentException if [lineRange] is out of bounds
+ * @wiki File data
  */
 fun read(
     @Injected context: Context,
@@ -86,6 +87,7 @@ fun read(
 /**
  * @param path path of the CSV file (with extension) to show
  * @return a table whose content is loaded from the file located in [path]
+ * @wiki File data
  */
 fun csv(
     @Injected context: Context,

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Dictionary.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Dictionary.kt
@@ -34,6 +34,7 @@ val Dictionary: Module =
  * ```
  * @param dictionary dictionary to initialize
  * @return the dictionary
+ * @wiki Dictionary
  */
 fun dictionary(dictionary: Map<String, OutputValue<*>>): DictionaryValue<*> = DictionaryValue(dictionary.toMutableMap())
 

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Document.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Document.kt
@@ -89,6 +89,7 @@ private fun <T> Context.modifyOrEchoDocumentInfo(
  * If it's `null`, the name of the current document type is returned.
  * @param type (optional) type to assign to the document
  * @return the lowercase name of the current document type if [type] is `null`
+ * @wiki Document metadata
  */
 @Name("doctype")
 fun docType(
@@ -110,6 +111,7 @@ fun docType(
  * If it's `null`, the current document name is returned.
  * @param name (optional) name to assign to the document
  * @return the current document name if [name] is `null`
+ * @wiki Document metadata
  */
 @Name("docname")
 fun docName(
@@ -127,6 +129,7 @@ fun docName(
  * If it's `null`, the current document author is returned.
  * @param author (optional) author to assign to the document
  * @return the current document author if [author] is `null`
+ * @wiki Document metadata
  */
 @Name("docauthor")
 fun docAuthor(
@@ -158,6 +161,7 @@ fun docAuthor(
  * @param authors (optional) authors to assign to the document.
  * Each dictionary entry contains the author's name associated with a nested dictionary of additional information.
  * @return the current document authors if [authors] is `null`
+ * @wiki Document metadata
  */
 @Name("docauthors")
 fun docAuthors(
@@ -199,6 +203,7 @@ fun docAuthors(
  *               to assign to the document
  * @return the localized name of the current document locale if [locale] is `null`
  * @throws IllegalArgumentException if the locale tag is not invalid or not found
+ * @wiki Localization
  */
 @Name("doclang")
 fun docLanguage(
@@ -220,6 +225,7 @@ fun docLanguage(
  * @param color (optional) color scheme to assign (searched in `resources/render/theme/color`)
  * @param layout (optional) layout format to assign (searched in `resources/render/theme/layout`)
  * @throws IOPipelineException if any of the theme components isn't resolved
+ * @wiki Theme
  */
 fun theme(
     @Injected context: Context,
@@ -266,7 +272,8 @@ fun theme(
  * - `headings`, used for headings (titles) and [tableOfContents] entries;
  * - `figures`, used for captioned images;
  * - `tables`, used for captioned tables.
- * Any other key can be addressed by other elements (see [numbered])
+ * Any other key can be addressed by custom elements (see [numbered]).
+ * @wiki Numbering
  */
 fun numbering(
     @Injected context: Context,
@@ -294,12 +301,19 @@ fun numbering(
 /**
  * Disables numbering across the document, in case a default numbering is set.
  * @see numbering
+ * @wiki Numbering
  */
 @Name("nonumbering")
 fun disableNumbering(
     @Injected context: Context,
 ) = numbering(context, emptyMap())
 
+/**
+ * Creates a new global TeX macro that can be accessed within math blocks.
+ * @param name name of the macro
+ * @param macro TeX code
+ * @wiki TeX macros
+ */
 @Name("texmacro")
 fun texMacro(
     @Injected context: Context,
@@ -322,6 +336,7 @@ fun texMacro(
  * @param columns positive number of columns on each page.
  *                If set and greater than 1, the layout becomes multi-column. If < 1, the value is discarded
  * @param alignment horizontal alignment of the content on each page
+ * @wiki Page format
  */
 @Name("pageformat")
 fun pageFormat(
@@ -356,6 +371,7 @@ fun pageFormat(
  * @param position position of the content within the page
  * @param content content to be displayed on each page
  * @return a wrapped [PageMarginContentInitializer] node
+ * @wiki Page margin content
  */
 @Name("pagemargin")
 fun pageMarginContent(
@@ -372,6 +388,7 @@ fun pageMarginContent(
  * Shortcut for [pageMarginContent] with [PageMarginPosition.BOTTOM_CENTER] as its position.
  * @see pageMarginContent
  * @return a wrapped [PageMarginContentInitializer] node with its position set to bottom center
+ * @wiki Page margin content
  */
 fun footer(content: MarkdownContent): NodeValue =
     pageMarginContent(
@@ -383,7 +400,8 @@ fun footer(content: MarkdownContent): NodeValue =
  * Displays the index (beginning from 1) of the page this element lies in.
  * In case the current document type does not support page counting (e.g. plain document),
  * a placeholder is used.
- * @return a [PageCounter] node
+ * @return a new [PageCounter] node
+ * @wiki Page counter
  */
 @Name("currentpage")
 fun currentPage() = PageCounter(PageCounter.Target.CURRENT).wrappedAsValue()
@@ -392,7 +410,8 @@ fun currentPage() = PageCounter(PageCounter.Target.CURRENT).wrappedAsValue()
  * Displays the total amount of pages in the document.
  * In case the current document type does not support page counting (e.g. plain document),
  * a placeholder is used.
- * @return a [PageCounter] node
+ * @return a new [PageCounter] node
+ * @wiki Page counter
  */
 @Name("totalpages")
 fun totalPages() = PageCounter(PageCounter.Target.TOTAL).wrappedAsValue()
@@ -404,6 +423,7 @@ fun totalPages() = PageCounter(PageCounter.Target.TOTAL).wrappedAsValue()
  * @param maxDepth heading depth to force page breaks for (positive only).
  * @throws IllegalArgumentException if [maxDepth] is a negative value
  * @see disableAutoPageBreak
+ * @wiki Page break
  */
 @Name("autopagebreak")
 fun autoPageBreak(
@@ -421,6 +441,7 @@ fun autoPageBreak(
 /**
  * Disables automatic page breaks when a heading is found.
  * @see autoPageBreak
+ * @wiki Page break
  */
 @Name("noautopagebreak")
 fun disableAutoPageBreak(
@@ -434,6 +455,7 @@ fun disableAutoPageBreak(
  * @param name name of the marker
  * @return a wrapped [Heading] marker node
  * @see tableOfContents
+ * @wiki Table of contents
  */
 fun marker(name: InlineMarkdownContent) = Heading.marker(name.children).wrappedAsValue()
 
@@ -444,6 +466,7 @@ fun marker(name: InlineMarkdownContent) = Heading.marker(name.children).wrappedA
  * @param focusedItem if set, adds focus to the item of the table of contents with the same text content as this argument.
  *                    Inline style (strong, emphasis, etc.) is ignored when comparing the text content.
  * @return a wrapped [TableOfContents] node
+ * @wiki Table of contents
  */
 @Name("tableofcontents")
 fun tableOfContents(

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Ecosystem.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Ecosystem.kt
@@ -27,7 +27,7 @@ val Ecosystem: Module =
  * @param reader reader of the raw Quarkdown source to include
  * @return the content of the file as a node
  */
-fun includeResource(
+internal fun includeResource(
     context: Context,
     reader: Reader,
 ): NodeValue {
@@ -48,6 +48,7 @@ fun includeResource(
  * @param path either a path (relative or absolute with extension) to the file to include, or the name of a loadable library
  * @return the content of the file as a node if a file is included, or nothing if a library is loaded
  * @throws IllegalArgumentException if the loaded Quarkdown source cannot be evaluated or if it cannot be evaluated into a suitable output value
+ * @wiki Including other Quarkdown files
  */
 fun include(
     @Injected context: MutableContext,

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Flow.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Flow.kt
@@ -43,7 +43,8 @@ val Flow: Module =
 /**
  * @param condition whether the content should be added to the document
  * @param body content to append if [condition] is verified. Accepts 0 parameters.
- * @return the evaluation of [body] if [condition] is `true`, otherwise nothing
+ * @return the evaluation of [body] if [condition] is `true`, nothing otherwise
+ * @wiki Conditional statements
  */
 @Name("if")
 @Suppress("ktlint:standard:function-naming")
@@ -59,7 +60,8 @@ fun `if`(
 /**
  * @param condition whether the content should be added to the document
  * @param body content to append if [condition] is not verified. Accepts 0 parameters.
- * @return [body] if [condition] is `false`, otherwise nothing
+ * @return [body] if [condition] is `false`, nothing otherwise
+ * @wiki Conditional statements
  */
 @Name("ifnot")
 fun ifNot(
@@ -107,6 +109,7 @@ fun ifNot(
  * @param iterable collection to iterate
  * @param body content, output of each iteration. Accepts 1 parameter (the current element).
  * @return a collection that contains the output of each iteration
+ * @wiki Loops
  */
 @Name("foreach")
 fun forEach(
@@ -124,6 +127,7 @@ fun forEach(
  * @param times amount of times to repeat the content
  * @param body content, output of each iteration. Accepts 1 parameter (the current element).
  * @return a collection that contains the output of each iteration
+ * @wiki Loops
  */
 fun repeat(
     times: Int,
@@ -166,6 +170,7 @@ private const val CUSTOM_FUNCTION_LIBRARY_NAME_PREFIX = "__func__"
  *
  * @param name name of the function
  * @param body content of the function. Function parameters must be **explicit** lambda parameters
+ * @wiki Declaring functions
  */
 fun function(
     @Injected context: MutableContext,
@@ -200,6 +205,7 @@ fun function(
  * Variables can be referenced just like functions, via `.variablename`.
  * @param name name of the variable
  * @param value value to assign
+ * @wiki Variables
  */
 @Name("var")
 fun variable(
@@ -260,6 +266,7 @@ fun variable(
  * @param value value to use as a temporary variable
  * @param body content to evaluate with the temporary variable. Accepts 1 parameter ([value] itself)
  * @return the evaluation of [body] with [value] as a parameter
+ * @wiki Let
  */
 fun let(
     value: DynamicValue,

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Injection.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Injection.kt
@@ -16,8 +16,8 @@ val Injection: Module =
 
 /**
  * Creates an HTML element, which is rendered as-is without any additional processing or escaping.
- *
  * @param content raw HTML content to inject
- * @return the HTML node
+ * @return a new [Html] node
+ * @wiki HTML
  */
 fun html(content: String) = Html(content).wrappedAsValue()

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Layout.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Layout.kt
@@ -70,7 +70,8 @@ val Layout: Module =
  * @param textAlignment alignment of the text. [alignment] if unset
  * @param float floating position of the container within the parent. Not floating if unset
  * @param body content to group
- * @return the new container node
+ * @return the new [Container] node
+ * @wiki Container
  */
 fun container(
     width: Size? = null,
@@ -110,8 +111,9 @@ fun container(
  * Aligns content and text within its parent.
  * @param alignment content alignment anchor and text alignment
  * @param body content to center
- * @return the new aligned container
+ * @return the new aligned [Container] node
  * @see container
+ * @wiki Align
  */
 fun align(
     alignment: Container.Alignment,
@@ -126,8 +128,9 @@ fun align(
 /**
  * Centers content and text within its parent.
  * @param body content to center
- * @return the new aligned container
+ * @return the new aligned [Container] node
  * @see align
+ * @wiki Align
  */
 fun center(body: MarkdownContent) = align(Container.Alignment.CENTER, body)
 
@@ -135,7 +138,8 @@ fun center(body: MarkdownContent) = align(Container.Alignment.CENTER, body)
  * Turns content into a floating element, allowing subsequent content to wrap around it.
  * @param alignment floating position
  * @param body content to float
- * @return the new floating container
+ * @return the new floating [Container] node
+ * @wiki Float
  */
 fun float(
     alignment: Container.FloatAlignment,
@@ -152,9 +156,10 @@ fun float(
  * @param crossAxisAlignment content alignment along the cross axis
  * @param gap blank space between children. If omitted, the default value is used
  * @param body content to stack
- * @return the new stacked block
+ * @return the new [Stacked] node
  * @see row
  * @see column
+ * @see grid
  */
 private fun stack(
     layout: Stacked.Layout,
@@ -170,7 +175,8 @@ private fun stack(
  * @param crossAxisAlignment content alignment along the cross axis
  * @param gap blank space between children. If omitted, the default value is used
  * @param body content to stack
- * @return the new stacked block
+ * @return the new [Stacked] node
+ * @wiki Stacks
  */
 fun row(
     @Name("alignment") mainAxisAlignment: Stacked.MainAxisAlignment = Stacked.MainAxisAlignment.START,
@@ -185,7 +191,8 @@ fun row(
  * @param crossAxisAlignment content alignment along the cross axis
  * @param gap blank space between children. If omitted, the default value is used
  * @param body content to stack
- * @return the new stacked block
+ * @return the new [Stacked] node
+ * @wiki Stacks
  */
 fun column(
     @Name("alignment") mainAxisAlignment: Stacked.MainAxisAlignment = Stacked.MainAxisAlignment.START,
@@ -197,12 +204,14 @@ fun column(
 /**
  * Stacks content in a grid layout.
  * Each child is placed in a cell in a row, and a row ends when its cell count reaches [columnCount].
- * @param columnCount number of columns. Must be greater than 0
+ * @param columnCount positive number of columns
  * @param mainAxisAlignment content alignment along the main axis
  * @param crossAxisAlignment content alignment along the cross axis
  * @param gap blank space between rows and columns. If omitted, the default value is used
  * @param body content to stack
- * @return the new stacked block
+ * @return the new [Stacked] node
+ * @throws IllegalArgumentException if [columnCount] is non-positive
+ * @wiki Stacks
  */
 fun grid(
     @Name("columns") columnCount: Int,
@@ -219,7 +228,8 @@ fun grid(
  * If the document has a multi-column layout (set via [pageFormat]), makes content span across all columns in a multi-column layout.
  * If the document has a single-column layout, the effect is the same as [container].
  * @param body content to span across all columns
- * @return the new full column span node
+ * @return the new [FullColumnSpan] span node
+ * @wiki Multi-column layout
  */
 @Name("fullspan")
 fun fullColumnSpan(body: MarkdownContent) = FullColumnSpan(body.children).wrappedAsValue()
@@ -230,7 +240,7 @@ fun fullColumnSpan(body: MarkdownContent) = FullColumnSpan(body.children).wrappe
  * If both dimensions are unset, a blank character is used, which can be useful for spacing and adding line breaks.
  * @param width width of the square. If unset, it defaults to zero
  * @param height height of the square. If unset, it defaults to zero
- * @return the new whitespace node
+ * @return the new [Whitespace] node
  */
 fun whitespace(
     width: Size? = null,
@@ -240,7 +250,8 @@ fun whitespace(
 /**
  * Applies a clipping path to its content.
  * @param clip clip type to apply
- * @return the new clipped block
+ * @return the new [Clipped] block
+ * @wiki Clip
  */
 fun clip(
     clip: Clipped.Clip,
@@ -257,7 +268,8 @@ fun clip(
  * @param backgroundColor background color. If unset, the box uses the default color
  * @param foregroundColor foreground (text) color. If unset, the box uses the default color
  * @param body box content
- * @return the new box node
+ * @return the new [Box] node
+ * @wiki Box
  */
 fun box(
     @Injected context: Context,
@@ -290,6 +302,7 @@ fun box(
  * @param title title of the block
  * @param open whether the block is open at the beginning
  * @return the new [Collapse] node
+ * @wiki Collapsible
  */
 fun collapse(
     title: InlineMarkdownContent,
@@ -303,6 +316,7 @@ fun collapse(
  * @param short content to show when the node is collapsed
  * @param open whether the block is open at the beginning
  * @return the new [InlineCollapse] node
+ * @wiki Collapsible
  */
 @Name("textcollapse")
 fun inlineCollapse(
@@ -316,6 +330,8 @@ fun inlineCollapse(
  * and the amount of occurrences according to its [key].
  * @param key name to group (and count) numbered nodes
  * @param body content, with the formatted location of this element (as a string) as an argument
+ * @return the new [Numbered] node
+ * @wiki Numbering
  */
 fun numbered(
     key: String,
@@ -345,6 +361,7 @@ fun numbered(
  *
  * @param subTables independent tables (as Markdown sources) that will be parsed and joined together into a single table
  * @return a new [Table] node
+ * @wiki Table generator
  */
 fun table(
     @Injected context: Context,

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Localization.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Localization.kt
@@ -101,6 +101,7 @@ private fun mergeLocalizationTables(
  * @param contents dictionary of locales and their key-value entries
  * @throws IllegalArgumentException if the contents are not in the correct format,
  * or if the table name is already defined and [merge] is false
+ * @wiki Localization
  */
 fun localization(
     @Injected context: MutableContext,
@@ -144,6 +145,7 @@ fun localization(
  * @return the localized value
  * @throws com.quarkdown.core.localization.LocalizationException if an error occurs during the lookup
  * @see localization
+ * @wiki Localization
  */
 fun localize(
     @Injected context: Context,

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Mermaid.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Mermaid.kt
@@ -37,7 +37,7 @@ private fun mermaidFigure(
  * Creates a Mermaid diagram.
  * @param caption optional caption. If a caption is present, the diagram will be numbered as a figure.
  * @param code the Mermaid code of the diagram
- * @return the generated diagram node
+ * @return a new [MermaidDiagramFigure] node
  */
 fun mermaid(
     caption: String? = null,
@@ -152,6 +152,7 @@ private fun StringBuilder.axis(
  *               or a list of lists of points, which will be plotted as multiple lines.
  * @return the generated diagram node
  * @throws IllegalArgumentException if both [xrange] and [xtags] are set
+ * @wiki XY chart
  */
 @Name("xychart")
 fun xyChart(

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Optionality.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Optionality.kt
@@ -26,18 +26,22 @@ val Optionality: Module =
 
 /**
  * @return a value which represents nothing
+ * @wiki None
  */
 fun none() = NoneValue
 
 /**
  * @param value value to check
  * @return whether [value] represents a `None` value
+ * @see [none]
  */
 internal fun isNone(value: Any?) = value == null || value is None || value is NoneValue
 
 /**
  * @param value value to check
  * @return whether [value] represents a [none] value
+ * @see [none]
+ * @wiki None
  */
 @Name("isnone")
 fun isNone(value: DynamicValue): BooleanValue = isNone(value.unwrappedValue).wrappedAsValue()
@@ -47,6 +51,7 @@ fun isNone(value: DynamicValue): BooleanValue = isNone(value.unwrappedValue).wra
  * @param fallback value to return if [value] is [none]
  * @return [value] if it is not none, [fallback] otherwise
  * @see isNone
+ * @wiki None
  */
 fun otherwise(
     value: DynamicValue,
@@ -60,6 +65,7 @@ fun otherwise(
  * It should accept one argument, which is [value], and return a value.
  * @return the result of [mapping] executed on [value] if [value] is not [none], [none] otherwise
  * @see isNone
+ * @wiki None
  */
 @Name("ifpresent")
 fun ifPresent(
@@ -83,6 +89,7 @@ fun ifPresent(
  * @param value value to check
  * @param condition condition to check, which accepts one argument ([value]) and returns a boolean
  * @return [value] if the result of [condition] is true, [none] otherwise
+ * @wiki None
  */
 @Name("takeif")
 fun takeIf(

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Slides.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Slides.kt
@@ -28,7 +28,8 @@ val Slides: Module =
  * @param showControls whether navigation controls should be shown
  * @param transitionStyle global transition style between slides
  * @param transitionSpeed global transition speed between slides
- * @return a wrapped [SlidesConfigurationInitializer] node
+ * @return a new [SlidesConfigurationInitializer] node
+ * @wiki Slides configuration
  */
 @OnlyForDocumentType(DocumentType.SLIDES)
 @Name("slides")
@@ -50,7 +51,8 @@ fun setSlidesConfiguration(
  * Multiple fragments in the same slide are shown in order on distinct user interactions.
  * @param behavior visibility type of the fragment and how it reacts to user interactions
  * @param content content to show/hide
- * @return the fragment node
+ * @return a new [SlidesFragment] node
+ * @wiki Slides fragment
  */
 @OnlyForDocumentType(DocumentType.SLIDES)
 fun fragment(

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/TableComputation.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/TableComputation.kt
@@ -164,7 +164,8 @@ private fun reconstructTable(
  * @param column index of the column (starting from 1)
  * @param order sorting order (`ascending` or `descending`)
  * @param content table to sort
- * @return the sorted table
+ * @return the sorted [Table] node
+ * @wiki Table manipulation
  */
 @Name("tablesort")
 fun tableSort(
@@ -210,7 +211,8 @@ fun tableSort(
  * @param column index of the column (starting from 1)
  * @param filter a lambda function that returns a boolean value. When `true`, the rows is to be kept.
  * The lambda accepts a single argument, which is the cell value of the column.
- * @return the filtered table
+ * @return the filtered [Table] node
+ * @wiki Table manipulation
  */
 @Name("tablefilter")
 fun tableFilter(
@@ -255,7 +257,8 @@ fun tableFilter(
  * @param column index of the column (starting from 1)
  * @param compute a lambda function that returns any value, which is the output of the computation.
  * The lambda accepts a single argument, which is the ordered collection of cell values of the column.
- * @return the computed table, of size `columns * (rows + 1)`
+ * @return the computed [Table] node, of size `columns * (rows + 1)`
+ * @wiki Table manipulation
  */
 @Name("tablecompute")
 fun tableCompute(
@@ -305,6 +308,7 @@ fun tableCompute(
  * @param column index of the column (starting from 1)
  * @param content table to extract the column from
  * @return the extracted cells
+ * @wiki Table manipulation
  */
 @Name("tablecolumn")
 fun tableColumn(
@@ -345,6 +349,7 @@ fun tableColumn(
  *
  * @param content table to extract the columns from
  * @return the extracted cells, grouped by column
+ * @wiki Table manipulation
  */
 @Name("tablecolumns")
 fun tableColumns(


### PR DESCRIPTION
This PR makes Quarkdoc able to read `@wiki` tags in the KDoc of native Quarkdown functions.  
Functions with said tag will feature a link to the corresponding page of Quarkdown's [wiki](https://github.com/iamgio/quarkdown/wiki) in their documentation page.

The `@wiki` tag has been set to all the stdlib functions with an active wiki page.