### PR TITLE
Add `.includeall`

### DIFF
--- a/mock/main.qmd
+++ b/mock/main.qmd
@@ -3,21 +3,22 @@
 <!-- Change here to paged/slides/plain to test a different document type -->
 .doctype {paged}
 
-.include {setup.qmd}
-.include {headings.qmd}
-.include {paragraphs.qmd}
-.include {lists.qmd}
-.include {images.qmd}
-.include {tables.qmd}
-.include {code.qmd}
-.include {textformatting.qmd}
-.include {colorpreview.qmd}
-.include {quotes.qmd}
-.include {boxes.qmd}
-.include {math.qmd}
-.include {mermaid.qmd}
-.include {collapsibles.qmd}
-.include {errors.qmd}
-.include {separators.qmd}
-.include {alignment.qmd}
-.include {stacks.qmd}
+.includeall
+    - setup.qmd
+    - headings.qmd
+    - paragraphs.qmd
+    - lists.qmd
+    - images.qmd
+    - tables.qmd
+    - code.qmd
+    - textformatting.qmd
+    - colorpreview.qmd
+    - quotes.qmd
+    - boxes.qmd
+    - math.qmd
+    - mermaid.qmd
+    - collapsibles.qmd
+    - errors.qmd
+    - separators.qmd
+    - alignment.qmd
+    - stacks.qmd

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Ecosystem.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Ecosystem.kt
@@ -5,10 +5,15 @@ import com.quarkdown.core.context.MutableContext
 import com.quarkdown.core.function.library.loader.Module
 import com.quarkdown.core.function.library.loader.moduleOf
 import com.quarkdown.core.function.reflect.annotation.Injected
+import com.quarkdown.core.function.reflect.annotation.Name
+import com.quarkdown.core.function.value.GeneralCollectionValue
+import com.quarkdown.core.function.value.IterableValue
 import com.quarkdown.core.function.value.NodeValue
 import com.quarkdown.core.function.value.OutputValue
+import com.quarkdown.core.function.value.Value
 import com.quarkdown.core.function.value.VoidValue
 import com.quarkdown.core.function.value.factory.ValueFactory
+import com.quarkdown.stdlib.internal.asString
 import java.io.Reader
 
 /**
@@ -18,6 +23,7 @@ import java.io.Reader
 val Ecosystem: Module =
     moduleOf(
         ::include,
+        ::includeAll,
     )
 
 /**
@@ -47,7 +53,7 @@ internal fun includeResource(
  * The context of the main file is shared to the sub-file and vice versa, allowing for sharing of variables, functions and other declarations.
  * @param path either a path (relative or absolute with extension) to the file to include, or the name of a loadable library
  * @return the content of the file as a node if a file is included, or nothing if a library is loaded
- * @throws IllegalArgumentException if the loaded Quarkdown source cannot be evaluated or if it cannot be evaluated into a suitable output value
+ * @throws IllegalArgumentException if the loaded Quarkdown source cannot be evaluated
  * @wiki Including other Quarkdown files
  */
 fun include(
@@ -61,3 +67,20 @@ fun include(
     val file = file(context, path)
     return includeResource(context, file.bufferedReader())
 }
+
+/**
+ * Performs a bulk include of the given paths via [include].
+ * @param paths paths to the files or library names to include
+ * @return a [GeneralCollectionValue] containing the output of the included files
+ * @throws IllegalArgumentException if any of the loaded sources cannot be evaluated
+ * @see include for information about file inclusion
+ * @wiki Including other Quarkdown files
+ */
+@Name("includeall")
+fun includeAll(
+    @Injected context: MutableContext,
+    paths: Iterable<Value<*>>,
+): IterableValue<OutputValue<*>> =
+    paths
+        .map { include(context, it.asString()) }
+        .let(::GeneralCollectionValue)

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Ecosystem.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Ecosystem.kt
@@ -42,8 +42,8 @@ fun includeResource(
 /**
  * This function has two behaviors:
  * - Reads a Quarkdown file and includes its parsed content in the current document.
- *   Loadable libraries are fetched from the library folder (`--libs` option).
- * - Loads a present but unloaded library into the current context.
+ * - Loads a library into the current context. Loadable libraries are fetched from the library folder (`--libs` option).
+ *
  * The context of the main file is shared to the sub-file and vice versa, allowing for sharing of variables, functions and other declarations.
  * @param path either a path (relative or absolute with extension) to the file to include, or the name of a loadable library
  * @return the content of the file as a node if a file is included, or nothing if a library is loaded

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/internal/Types.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/internal/Types.kt
@@ -5,10 +5,19 @@ import com.quarkdown.core.function.value.Value
 // Types utilities for the stdlib.
 
 /**
+ * Converts [Value] to a [String].
+ */
+internal fun Value<*>.asString(): String =
+    when (val value = unwrappedValue) {
+        is Value<*> -> value.asString()
+        else -> value.toString()
+    }
+
+/**
  * Converts [Value] to a [Double].
  * @return the value as a double, or 0 if the value is not numeric
  */
-fun Value<*>.asDouble(): Double =
+internal fun Value<*>.asDouble(): Double =
     when (val value = unwrappedValue) {
         is Number -> value.toDouble()
         else -> value.toString().toDoubleOrNull()

--- a/quarkdown-test/src/test/kotlin/com/quarkdown/test/EcosystemTest.kt
+++ b/quarkdown-test/src/test/kotlin/com/quarkdown/test/EcosystemTest.kt
@@ -6,6 +6,9 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFails
 
+private const val OUTPUT_1 = "<h1>Title</h1><p>Some <em>text</em>.</p>"
+private const val OUTPUT_3 = "<h2>Included</h2><pre><code>code\ncode</code></pre>"
+
 /**
  * Tests for including files and libraries.
  */
@@ -19,7 +22,7 @@ class EcosystemTest {
             """.trimIndent(),
         ) {
             assertEquals(
-                "<h1>Title</h1><p>Some <em>text</em>.</p>",
+                OUTPUT_1,
                 it,
             )
         }
@@ -47,7 +50,7 @@ class EcosystemTest {
             """.trimIndent(),
         ) {
             assertEquals(
-                "<h1>Main</h1><h2>Included</h2><pre><code>code\ncode</code></pre>",
+                "<h1>Main</h1>$OUTPUT_3",
                 it,
             )
         }
@@ -134,8 +137,10 @@ class EcosystemTest {
                 it,
             )
         }
+    }
 
-        // Not included.
+    @Test
+    fun `invocation of unincluded library`() {
         assertFails {
             execute(
                 """
@@ -146,8 +151,11 @@ class EcosystemTest {
                 errorHandler = StrictPipelineErrorHandler(),
             ) {}
         }
+    }
 
-        // Included but not available.
+    @Test
+    fun `inclusion of unexisting library`() {
+        // Not available in the environment.
         assertFails {
             execute(
                 """
@@ -157,6 +165,43 @@ class EcosystemTest {
                 errorHandler = StrictPipelineErrorHandler(),
                 useDummyLibraryDirectory = true,
             ) {}
+        }
+    }
+
+    @Test
+    fun `include multiple sources`() {
+        execute(
+            """
+            .noautopagebreak
+            .include {include/include-1.md}
+            .include {include/include-3.md}
+            
+            .hello {world}
+            """.trimIndent(),
+        ) {
+            assertEquals(
+                "$OUTPUT_1$OUTPUT_3<p>Hello, world!</p>",
+                it,
+            )
+        }
+    }
+
+    @Test
+    fun `include multiple sources via bulk`() {
+        execute(
+            """
+            .noautopagebreak
+            .includeall
+                - include/include-1.md
+                - include/include-3.md
+            
+            .hello {world}
+            """.trimIndent(),
+        ) {
+            assertEquals(
+                "$OUTPUT_1$OUTPUT_3<p>Hello, world!</p>",
+                it,
+            )
         }
     }
 }


### PR DESCRIPTION
This PR adds the `.includeall` function which performs a bulk-include of a list of paths.