### PR TITLE
Fix project creator not using the canonical directory name 

### DIFF
--- a/quarkdown-cli/src/main/kotlin/com/quarkdown/cli/creator/command/CreateProjectCommand.kt
+++ b/quarkdown-cli/src/main/kotlin/com/quarkdown/cli/creator/command/CreateProjectCommand.kt
@@ -96,7 +96,7 @@ class CreateProjectCommand : CliktCommand("create") {
         )
 
     private fun createProjectCreator(): ProjectCreator {
-        val mainFileName = this.mainFileName ?: directory.name
+        val mainFileName = this.mainFileName ?: directory.canonicalFile.name
         return ProjectCreator(
             templateProcessorFactory = DefaultProjectCreatorTemplateProcessorFactory(this.createDocumentInfo()),
             initialContentSupplier =

--- a/quarkdown-cli/src/test/kotlin/com/quarkdown/cli/ProjectCreatorCommandTest.kt
+++ b/quarkdown-cli/src/test/kotlin/com/quarkdown/cli/ProjectCreatorCommandTest.kt
@@ -21,12 +21,11 @@ class ProjectCreatorCommandTest : TempDirectory() {
 
     private fun test(
         additionalArgs: Array<String> = emptyArray(),
+        fixedMainFileName: Boolean = true,
         directory: File = super.directory,
     ) {
         command.test(
-            directory.absolutePath,
-            "--main-file",
-            "main",
+            directory.resolve(".").absolutePath, // Testing canonical path.
             "--name",
             "test",
             "--authors",
@@ -40,14 +39,17 @@ class ProjectCreatorCommandTest : TempDirectory() {
             "--layout-theme",
             "latex",
             *additionalArgs,
+            *if (fixedMainFileName) arrayOf("--main-file", "main") else emptyArray(),
         )
         assertTrue(directory.exists())
 
         println(directory.listFiles()!!.map { it.name })
 
-        assertTrue("main.qmd" in directory.listFiles()!!.map { it.name })
+        val mainFileName = (if (fixedMainFileName) "main" else directory.name) + ".qmd"
 
-        val main = directory.listFiles()!!.first { it.name == "main.qmd" }.readText()
+        assertTrue(mainFileName in directory.listFiles()!!.map { it.name })
+
+        val main = directory.listFiles()!!.first { it.name == mainFileName }.readText()
         assertTrue(main.startsWith(".docname {test}"))
         assertTrue("- Aaa" in main)
         assertTrue("- Bbb" in main)
@@ -60,6 +62,12 @@ class ProjectCreatorCommandTest : TempDirectory() {
     @Test
     fun default() {
         test()
+        assertEquals(2, directory.listFiles()!!.size)
+    }
+
+    @Test
+    fun `default with relative name`() {
+        test(fixedMainFileName = false)
         assertEquals(2, directory.listFiles()!!.size)
     }
 

--- a/quarkdown-cli/src/test/kotlin/com/quarkdown/cli/ProjectCreatorCommandTest.kt
+++ b/quarkdown-cli/src/test/kotlin/com/quarkdown/cli/ProjectCreatorCommandTest.kt
@@ -24,8 +24,9 @@ class ProjectCreatorCommandTest : TempDirectory() {
         fixedMainFileName: Boolean = true,
         directory: File = super.directory,
     ) {
+        // resolve(".") tests the canonical path instead of the actual one.
         command.test(
-            directory.resolve(".").absolutePath, // Testing canonical path.
+            directory.resolve(".").absolutePath,
             "--name",
             "test",
             "--authors",


### PR DESCRIPTION
When running `quarkdown create [dir]` without the `--main-file` option, the main qmd file name would be the same as its parent directory.

Until now, the name would not use the canonical path, meaning that running `quarkdown create .` would incorrectly create the main file `..qmd`.  