### PR TITLE
Fix `.numbered` errors

### DIFF
--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/attributes/location/LocationLabelProperty.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/attributes/location/LocationLabelProperty.kt
@@ -11,7 +11,7 @@ import com.quarkdown.core.property.Property
  * Examples of these nodes are figures and tables. For instance, depending on the document's [NumberingFormat],
  * an element may be labeled as `1.1`, `1.2`, `1.3`, `2.1`, etc.
  * @param value the formatted label
- * @see com.quarkdown.core.context.hooks.LocationAwareLabelStorerHook for the storing stage
+ * @see com.quarkdown.core.context.hooks.location.LocationAwareLabelStorerHook for the storing stage
  */
 data class LocationLabelProperty(
     override val value: String,

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/attributes/location/LocationTrackableNode.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/attributes/location/LocationTrackableNode.kt
@@ -30,7 +30,7 @@ fun LocationTrackableNode.getLocation(context: Context): SectionLocation? = cont
  * Registers the location of this node within the document handled by [context].
  * @param context context where location data is stored
  * @param location location to set
- * @see com.quarkdown.core.context.hooks.LocationAwarenessHook
+ * @see com.quarkdown.core.context.hooks.location.LocationAwarenessHook
  */
 fun LocationTrackableNode.setLocation(
     context: MutableContext,
@@ -52,7 +52,7 @@ fun LocationTrackableNode.getLocationLabel(context: Context): String? = context.
  * according to [this] node's [NumberingFormat].
  * @param context context where location data is stored
  * @param label formatted location to set
- * @see com.quarkdown.core.context.hooks.LocationAwareLabelStorerHook
+ * @see com.quarkdown.core.context.hooks.location.LocationAwareLabelStorerHook
  */
 fun LocationTrackableNode.setLocationLabel(
     context: MutableContext,

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/attributes/location/SectionLocationProperty.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/attributes/location/SectionLocationProperty.kt
@@ -6,7 +6,7 @@ import com.quarkdown.core.property.Property
  * [Property] that is assigned to each node that requests its location to be tracked ([LocationTrackableNode]).
  * It contains the node's location in the document, in terms of section indices.
  * @see SectionLocation
- * @see com.quarkdown.core.context.hooks.LocationAwarenessHook for the storing stage
+ * @see com.quarkdown.core.context.hooks.location.LocationAwarenessHook for the storing stage
  */
 data class SectionLocationProperty(
     override val value: SectionLocation,

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/quarkdown/block/Numbered.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/quarkdown/block/Numbered.kt
@@ -11,7 +11,7 @@ import com.quarkdown.core.visitor.node.NodeVisitor
  * and the amount of occurrences according to its [key].
  * @param key name to group (and count) numbered nodes
  * @param children supplier of the node content given the evaluated [SectionLocation], formatted according to the active [DocumentNumbering]
- * @see com.quarkdown.core.context.hooks.LocationAwareLabelStorerHook for storing locations
+ * @see com.quarkdown.core.context.hooks.location.LocationAwareLabelStorerHook for storing locations
  * @see com.quarkdown.core.document.numbering.NumberingFormat
  */
 class Numbered(

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/quarkdown/block/Numbered.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/quarkdown/block/Numbered.kt
@@ -15,13 +15,13 @@ import com.quarkdown.core.visitor.node.NodeVisitor
  * but rather during the AST traversal.
  *
  * This is because in order to evaluate the children, we need to know the location of the node in the document,
- * which is not known until the AST is fully traversed by [LocationAwareLabelStorerHook].
+ * which is not known until the AST is fully traversed by [com.quarkdown.core.context.hooks.location.LocationAwareLabelStorerHook].
  *
- * After the traversal, the [NumberedEvaluatorHook] will evaluate and assign the [children] of this node, ready to be rendered.
+ * After the traversal, the [com.quarkdown.core.context.hooks.location.NumberedEvaluatorHook] will evaluate and assign the [children] of this node, ready to be rendered.
  *
  * Since the evaluation does not happen within [com.quarkdown.core.function.call.FunctionCallNodeExpander],
  * errors thrown during the evaluation will have to be caught externally. This is handled by the hook itself,
- * which append an error box (the same produced from the expander) to [children].
+ * which appends an error box (the same produced from the expander) to [children].
  * From the user's perspective, this does not have any effect.
  * @param key name to group (and count) numbered nodes
  * @param childrenSupplier supplier of the node content given the evaluated [SectionLocation], formatted according to the active [DocumentNumbering]

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/quarkdown/block/Numbered.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/quarkdown/block/Numbered.kt
@@ -1,5 +1,6 @@
 package com.quarkdown.core.ast.quarkdown.block
 
+import com.quarkdown.core.ast.NestableNode
 import com.quarkdown.core.ast.Node
 import com.quarkdown.core.ast.attributes.location.LocationTrackableNode
 import com.quarkdown.core.ast.attributes.location.SectionLocation
@@ -9,14 +10,31 @@ import com.quarkdown.core.visitor.node.NodeVisitor
 /**
  * Node that can be numbered depending on its location in the document
  * and the amount of occurrences according to its [key].
+ *
+ * This node is peculiar, as it's the only node whose children are not evaluated directly during the function call expansion stage,
+ * but rather during the AST traversal.
+ *
+ * This is because in order to evaluate the children, we need to know the location of the node in the document,
+ * which is not known until the AST is fully traversed by [LocationAwareLabelStorerHook].
+ *
+ * After the traversal, the [NumberedEvaluatorHook] will evaluate and assign the [children] of this node, ready to be rendered.
+ *
+ * Since the evaluation does not happen within [com.quarkdown.core.function.call.FunctionCallNodeExpander],
+ * errors thrown during the evaluation will have to be caught externally. This is handled by the hook itself,
+ * which append an error box (the same produced from the expander) to [children].
+ * From the user's perspective, this does not have any effect.
  * @param key name to group (and count) numbered nodes
- * @param children supplier of the node content given the evaluated [SectionLocation], formatted according to the active [DocumentNumbering]
+ * @param childrenSupplier supplier of the node content given the evaluated [SectionLocation], formatted according to the active [DocumentNumbering]
  * @see com.quarkdown.core.context.hooks.location.LocationAwareLabelStorerHook for storing locations
+ * @see com.quarkdown.core.context.hooks.location.NumberedEvaluatorHook for evaluating [childrenSupplier]
  * @see com.quarkdown.core.document.numbering.NumberingFormat
  */
 class Numbered(
     val key: String,
-    val children: (location: String) -> List<Node>,
-) : LocationTrackableNode {
+    internal val childrenSupplier: (location: String) -> List<Node>,
+) : NestableNode,
+    LocationTrackableNode {
+    override var children: List<Node> = emptyList()
+
     override fun <T> accept(visitor: NodeVisitor<T>): T = visitor.visit(this)
 }

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/context/hooks/location/LocationAwareLabelStorerHook.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/context/hooks/location/LocationAwareLabelStorerHook.kt
@@ -1,4 +1,4 @@
-package com.quarkdown.core.context.hooks
+package com.quarkdown.core.context.hooks.location
 
 import com.quarkdown.core.ast.attributes.location.LocationTrackableNode
 import com.quarkdown.core.ast.attributes.location.SectionLocation

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/context/hooks/location/LocationAwarenessHook.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/context/hooks/location/LocationAwarenessHook.kt
@@ -1,4 +1,4 @@
-package com.quarkdown.core.context.hooks
+package com.quarkdown.core.context.hooks.location
 
 import com.quarkdown.core.ast.attributes.location.LocationTrackableNode
 import com.quarkdown.core.ast.attributes.location.SectionLocation

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/context/hooks/location/NumberedEvaluatorHook.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/context/hooks/location/NumberedEvaluatorHook.kt
@@ -1,0 +1,33 @@
+package com.quarkdown.core.context.hooks.location
+
+import com.quarkdown.core.ast.attributes.location.getLocationLabel
+import com.quarkdown.core.ast.iterator.AstIteratorHook
+import com.quarkdown.core.ast.iterator.ObservableAstIterator
+import com.quarkdown.core.ast.quarkdown.block.Numbered
+import com.quarkdown.core.context.Context
+import com.quarkdown.core.pipeline.error.PipelineException
+import com.quarkdown.core.pipeline.error.asNode
+
+/**
+ * Hook that evaluates the [Numbered] nodes in the document.
+ * If the evaluation fails, it attaches an error box, as in a regular function call expansion.
+ * This needs to be attached **after** the [LocationAwareLabelStorerHook] has populated the location labels.
+ * @param context context to retrieve the location label from
+ * @see Numbered to understand why it needs evaluation
+ */
+class NumberedEvaluatorHook(
+    private val context: Context,
+) : AstIteratorHook {
+    override fun attach(iterator: ObservableAstIterator) {
+        iterator.on<Numbered> { node ->
+            val label = node.getLocationLabel(context) ?: ""
+            node.children =
+                try {
+                    node.childrenSupplier(label)
+                } catch (e: PipelineException) {
+                    // Set an error box as the node's child if the evaluation fails.
+                    listOf(e.asNode(context))
+                }
+        }
+    }
+}

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/flavor/quarkdown/QuarkdownTreeIteratorFactory.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/flavor/quarkdown/QuarkdownTreeIteratorFactory.kt
@@ -2,10 +2,10 @@ package com.quarkdown.core.flavor.quarkdown
 
 import com.quarkdown.core.ast.iterator.ObservableAstIterator
 import com.quarkdown.core.context.MutableContext
-import com.quarkdown.core.context.hooks.LocationAwareLabelStorerHook
-import com.quarkdown.core.context.hooks.LocationAwarenessHook
 import com.quarkdown.core.context.hooks.MediaStorerHook
 import com.quarkdown.core.context.hooks.TableOfContentsGeneratorHook
+import com.quarkdown.core.context.hooks.location.LocationAwareLabelStorerHook
+import com.quarkdown.core.context.hooks.location.LocationAwarenessHook
 import com.quarkdown.core.flavor.TreeIteratorFactory
 import com.quarkdown.core.flavor.base.BaseMarkdownTreeIteratorFactory
 

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/flavor/quarkdown/QuarkdownTreeIteratorFactory.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/flavor/quarkdown/QuarkdownTreeIteratorFactory.kt
@@ -6,6 +6,7 @@ import com.quarkdown.core.context.hooks.MediaStorerHook
 import com.quarkdown.core.context.hooks.TableOfContentsGeneratorHook
 import com.quarkdown.core.context.hooks.location.LocationAwareLabelStorerHook
 import com.quarkdown.core.context.hooks.location.LocationAwarenessHook
+import com.quarkdown.core.context.hooks.location.NumberedEvaluatorHook
 import com.quarkdown.core.flavor.TreeIteratorFactory
 import com.quarkdown.core.flavor.base.BaseMarkdownTreeIteratorFactory
 
@@ -18,6 +19,7 @@ class QuarkdownTreeIteratorFactory : TreeIteratorFactory {
             .default(context)
             .attach(LocationAwarenessHook(context))
             .attach(LocationAwareLabelStorerHook(context))
+            .attach(NumberedEvaluatorHook(context))
             .attach(TableOfContentsGeneratorHook(context))
             .apply {
                 if (context.attachedPipeline?.options?.enableMediaStorage == true) {

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/function/call/FunctionCallNodeExpander.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/function/call/FunctionCallNodeExpander.kt
@@ -2,13 +2,12 @@ package com.quarkdown.core.function.call
 
 import com.quarkdown.core.ast.Node
 import com.quarkdown.core.ast.quarkdown.FunctionCallNode
-import com.quarkdown.core.ast.quarkdown.block.Box
 import com.quarkdown.core.context.MutableContext
-import com.quarkdown.core.function.error.FunctionException
 import com.quarkdown.core.function.value.output.OutputValueVisitorFactory
 import com.quarkdown.core.function.value.output.node.NodeOutputValueVisitorFactory
 import com.quarkdown.core.pipeline.error.PipelineErrorHandler
 import com.quarkdown.core.pipeline.error.PipelineException
+import com.quarkdown.core.pipeline.error.asNode
 
 /**
  * Given a [FunctionCallNode] from the AST, this expander resolves its referenced function, executes it
@@ -48,18 +47,8 @@ class FunctionCallNodeExpander(
             val outputNode = call.execute().accept(mapper)
             appendOutput(node, outputNode)
         } catch (e: PipelineException) {
-            // If the function call is invalid.
-
-            // The function that the error originated from.
-            // Note that sourceFunction might be different from call.function if the error comes from a nested function call down the stack.
-            val sourceFunction = (e as? FunctionException)?.function
-
-            // The error is handled by the error handler strategy.
-            errorHandler.handle(e, sourceFunction) {
-                // Shows an error message box in the final document.
-                // If the exception is linked to a function, its name appears in the error title.
-                appendOutput(node, Box.error(e.richMessage, title = sourceFunction?.name))
-            }
+            // If the function call is invalid, shows an error box.
+            appendOutput(node, e.asNode(errorHandler))
         }
     }
 

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/function/value/AdaptableValue.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/function/value/AdaptableValue.kt
@@ -4,7 +4,8 @@ package com.quarkdown.core.function.value
  * If a [Value] subclass is adaptable, it can be converted to another [Value]
  * in case the parameter of the function it is passed to expects a different type.
  *
- * For example, a [DictionaryValue] can be adapted to an [IterableValue].
+ * For example, a [DictionaryValue] can be adapted to an [IterableValue],
+ * and a [MarkdownContentValue] can be adapted to a [NodeValue].
  *
  * @param T type of the value to adapt to
  */

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/function/value/MarkdownContentValue.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/function/value/MarkdownContentValue.kt
@@ -7,7 +7,9 @@ import com.quarkdown.core.function.expression.visitor.ExpressionVisitor
 /**
  * A sub-AST that contains Markdown nodes. This is usually accepted in 'body' parameters.
  */
-data class MarkdownContentValue(override val unwrappedValue: MarkdownContent) : InputValue<MarkdownContent> {
+data class MarkdownContentValue(
+    override val unwrappedValue: MarkdownContent,
+) : InputValue<MarkdownContent> {
     override fun <T> accept(visitor: ExpressionVisitor<T>): T = visitor.visit(this)
 
     /**
@@ -29,7 +31,9 @@ fun MarkdownContent.wrappedAsValue() = MarkdownContentValue(this)
 /**
  * A sub-AST that contains Markdown nodes. This is usually accepted in 'body' parameters.
  */
-data class InlineMarkdownContentValue(override val unwrappedValue: InlineMarkdownContent) : InputValue<InlineMarkdownContent> {
+data class InlineMarkdownContentValue(
+    override val unwrappedValue: InlineMarkdownContent,
+) : InputValue<InlineMarkdownContent> {
     override fun <T> accept(visitor: ExpressionVisitor<T>): T = visitor.visit(this)
 
     /**

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/function/value/NodeValue.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/function/value/NodeValue.kt
@@ -1,5 +1,6 @@
 package com.quarkdown.core.function.value
 
+import com.quarkdown.core.ast.MarkdownContent
 import com.quarkdown.core.ast.Node
 import com.quarkdown.core.function.expression.Expression
 import com.quarkdown.core.function.expression.visitor.ExpressionVisitor
@@ -11,10 +12,13 @@ import com.quarkdown.core.function.value.output.OutputValueVisitor
 data class NodeValue(
     override val unwrappedValue: Node,
 ) : OutputValue<Node>,
-    Expression {
+    Expression,
+    AdaptableValue<MarkdownContentValue> {
     override fun <O> accept(visitor: OutputValueVisitor<O>): O = visitor.visit(this)
 
     override fun <T> accept(visitor: ExpressionVisitor<T>): T = visitor.visit(this)
+
+    override fun adapt(): MarkdownContentValue = MarkdownContentValue(MarkdownContent(listOf(unwrappedValue)))
 }
 
 /**

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/function/value/data/Lambda.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/function/value/data/Lambda.kt
@@ -6,6 +6,7 @@ import com.quarkdown.core.function.error.InvalidLambdaArgumentCountException
 import com.quarkdown.core.function.library.Library
 import com.quarkdown.core.function.reflect.DynamicValueConverter
 import com.quarkdown.core.function.reflect.FromDynamicType
+import com.quarkdown.core.function.value.AdaptableValue
 import com.quarkdown.core.function.value.Destructurable
 import com.quarkdown.core.function.value.DynamicValue
 import com.quarkdown.core.function.value.NoneValue
@@ -134,10 +135,11 @@ open class Lambda(
         // Invoke the lambda action and convert the result to a static type.
         val result = invokeDynamic(*values)
 
-        return if (result is DynamicValue) {
-            DynamicValueConverter(result).convertTo(T::class, parentContext)
-        } else {
-            result
+        return when (result) {
+            is V -> result
+            is DynamicValue -> DynamicValueConverter(result).convertTo(T::class, parentContext)
+            is AdaptableValue<*> -> result.adapt()
+            else -> result
         } as? V
             ?: throw IllegalArgumentException("Unexpected lambda result: expected ${V::class}, found ${result::class}")
     }

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/pipeline/error/BasePipelineErrorHandler.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/pipeline/error/BasePipelineErrorHandler.kt
@@ -7,14 +7,13 @@ import com.quarkdown.core.log.Log
  * Simple pipeline error handler that logs the error message.
  */
 class BasePipelineErrorHandler : PipelineErrorHandler {
-    override fun handle(
+    override fun <T> handle(
         error: PipelineException,
         sourceFunction: Function<*>?,
-        action: () -> Unit,
-    ) {
+        action: () -> T,
+    ): T {
         val message = error.message ?: "Unknown error"
         Log.error(message)
-
-        action()
+        return action()
     }
 }

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/pipeline/error/PipelineErrorHandler.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/pipeline/error/PipelineErrorHandler.kt
@@ -13,10 +13,11 @@ interface PipelineErrorHandler {
      * @param action additional custom error handler
      * @see BasePipelineErrorHandler
      * @see StrictPipelineErrorHandler
+     * @return the result of the action
      */
-    fun handle(
+    fun <T> handle(
         error: PipelineException,
         sourceFunction: Function<*>?,
-        action: () -> Unit,
-    )
+        action: () -> T,
+    ): T
 }

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/pipeline/error/PipelineException.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/pipeline/error/PipelineException.kt
@@ -1,7 +1,11 @@
 package com.quarkdown.core.pipeline.error
 
 import com.quarkdown.core.ast.InlineContent
+import com.quarkdown.core.ast.Node
 import com.quarkdown.core.ast.dsl.buildInline
+import com.quarkdown.core.ast.quarkdown.block.Box
+import com.quarkdown.core.context.Context
+import com.quarkdown.core.function.error.FunctionException
 import com.quarkdown.core.util.toPlainText
 
 /**
@@ -10,6 +14,28 @@ import com.quarkdown.core.util.toPlainText
  * @param code error code. If the program is running in strict mode and thus is killed,
  *             it defines the process exit code
  */
-open class PipelineException(val richMessage: InlineContent, val code: Int) : Exception(richMessage.toPlainText()) {
+open class PipelineException(
+    val richMessage: InlineContent,
+    val code: Int,
+) : Exception(richMessage.toPlainText()) {
     constructor(message: String, code: Int) : this(buildInline { text(message) }, code)
 }
+
+fun PipelineException.asNode(errorHandler: PipelineErrorHandler): Node {
+    // The function that the error originated from.
+    // Note that sourceFunction might be different from call.function if the error comes from a nested function call down the stack.
+    val sourceFunction = (this as? FunctionException)?.function
+
+    // The error is handled by the error handler strategy.
+    return errorHandler.handle(this, sourceFunction) {
+        // Shows an error message box in the final document.
+        // If the exception is linked to a function, its name appears in the error title.
+        Box.error(richMessage, title = sourceFunction?.name)
+    }
+}
+
+fun PipelineException.asNode(context: Context): Node =
+    context.attachedPipeline
+        ?.options
+        ?.errorHandler
+        ?.let(::asNode) ?: throw this

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/pipeline/error/PipelineException.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/pipeline/error/PipelineException.kt
@@ -21,19 +21,25 @@ open class PipelineException(
     constructor(message: String, code: Int) : this(buildInline { text(message) }, code)
 }
 
+/**
+ * Converts [this] exception to a renderable [Node], and performs the error handling provided by the [errorHandler] strategy.
+ * @param errorHandler strategy to handle the error
+ * @return [this] exception as a renderable [Node]
+ */
 fun PipelineException.asNode(errorHandler: PipelineErrorHandler): Node {
-    // The function that the error originated from.
-    // Note that sourceFunction might be different from call.function if the error comes from a nested function call down the stack.
+    // The function that the error originated from, if any.
     val sourceFunction = (this as? FunctionException)?.function
 
-    // The error is handled by the error handler strategy.
     return errorHandler.handle(this, sourceFunction) {
-        // Shows an error message box in the final document.
-        // If the exception is linked to a function, its name appears in the error title.
         Box.error(richMessage, title = sourceFunction?.name)
     }
 }
 
+/**
+ * @param context context to use to retrieve the error handler from
+ * @throws [this] exception if the context does not have an attached pipeline to retrieve the error handler from
+ * @see asNode
+ */
 fun PipelineException.asNode(context: Context): Node =
     context.attachedPipeline
         ?.options

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/pipeline/error/StrictPipelineErrorHandler.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/pipeline/error/StrictPipelineErrorHandler.kt
@@ -8,11 +8,11 @@ import com.quarkdown.core.log.Log
  * In a regular pipeline, this will cause the program to exit (see `QuarkdownCli` from the `cli` module).
  */
 class StrictPipelineErrorHandler : PipelineErrorHandler {
-    override fun handle(
+    override fun <T> handle(
         error: PipelineException,
         sourceFunction: Function<*>?,
-        action: () -> Unit,
-    ) {
+        action: () -> T,
+    ): Nothing {
         Log.error("An error occurred while in strict mode (error code ${error.code})")
         sourceFunction?.let { Log.error("Originated from function: ${it.name}") }
         throw error

--- a/quarkdown-core/src/test/kotlin/com/quarkdown/core/LambdaTest.kt
+++ b/quarkdown-core/src/test/kotlin/com/quarkdown/core/LambdaTest.kt
@@ -1,0 +1,150 @@
+package com.quarkdown.core
+
+import com.quarkdown.core.ast.MarkdownContent
+import com.quarkdown.core.ast.base.inline.Text
+import com.quarkdown.core.context.MutableContext
+import com.quarkdown.core.context.ScopeContext
+import com.quarkdown.core.flavor.quarkdown.QuarkdownFlavor
+import com.quarkdown.core.function.value.MarkdownContentValue
+import com.quarkdown.core.function.value.NodeValue
+import com.quarkdown.core.function.value.StringValue
+import com.quarkdown.core.function.value.VoidValue
+import com.quarkdown.core.function.value.data.Lambda
+import com.quarkdown.core.function.value.data.LambdaParameter
+import com.quarkdown.core.function.value.wrappedAsValue
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFails
+import kotlin.test.assertIs
+import kotlin.test.assertNotEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+/**
+ * Tests for [Lambda] invocation.
+ */
+class LambdaTest {
+    private val context = MutableContext(QuarkdownFlavor)
+
+    @Test
+    fun `no parameters, no return`() {
+        val lambda =
+            Lambda(context) { args, ctx ->
+                assertNotEquals(context, ctx)
+                assertIs<ScopeContext>(ctx)
+                VoidValue
+            }
+        lambda.invoke<Unit, VoidValue>()
+    }
+
+    @Test
+    fun `no parameters, with return`() {
+        val lambda =
+            Lambda(context) { args, _ ->
+                StringValue("Hello")
+            }
+        assertEquals(
+            "Hello",
+            lambda.invoke<String, StringValue>().unwrappedValue,
+        )
+    }
+
+    @Test
+    fun `one explicit parameter`() {
+        val lambda =
+            Lambda(
+                context,
+                listOf(LambdaParameter("myparam")),
+            ) { args, ctx ->
+                assertEquals(1, args.size)
+                assertNotNull(ctx.getFunctionByName("myparam"))
+                VoidValue
+            }
+        assertNull(context.getFunctionByName("myparam"))
+        lambda.invoke<Unit, VoidValue>("Hello".wrappedAsValue())
+    }
+
+    @Test
+    fun `one implicit parameter`() {
+        val lambda =
+            Lambda(context) { args, ctx ->
+                assertEquals(1, args.size)
+                assertNotNull(ctx.getFunctionByName("1"))
+                VoidValue
+            }
+        assertNull(context.getFunctionByName("1"))
+        lambda.invoke<Unit, VoidValue>("Hello".wrappedAsValue())
+    }
+
+    @Test
+    fun `optional parameter`() {
+        val lambda =
+            Lambda(
+                context,
+                listOf(LambdaParameter("myparam", true)),
+            ) { args, ctx ->
+                StringValue((args.singleOrNull() as? StringValue)?.unwrappedValue ?: "none")
+            }
+        assertEquals(
+            "Hello",
+            lambda.invoke<String, StringValue>("Hello".wrappedAsValue()).unwrappedValue,
+        )
+        assertEquals(
+            "none",
+            lambda.invoke<String, StringValue>().unwrappedValue,
+        )
+    }
+
+    @Test
+    fun `two parameters, one optional`() {
+        val lambda =
+            Lambda(
+                context,
+                listOf(
+                    LambdaParameter("myparam1"),
+                    LambdaParameter("myparam2", true),
+                ),
+            ) { args, ctx ->
+                StringValue(
+                    (0..1).joinToString {
+                        (args[it] as? StringValue)?.unwrappedValue ?: "none"
+                    },
+                )
+            }
+        assertEquals(
+            "Hello, world",
+            lambda
+                .invoke<String, StringValue>(
+                    "Hello".wrappedAsValue(),
+                    "world".wrappedAsValue(),
+                ).unwrappedValue,
+        )
+        assertEquals(
+            "Hello, none",
+            lambda.invoke<String, StringValue>("Hello".wrappedAsValue()).unwrappedValue,
+        )
+        assertFails {
+            lambda.invoke<String, StringValue>()
+        }
+        assertFails {
+            lambda.invoke<String, StringValue>("Hello".wrappedAsValue(), "world".wrappedAsValue(), "extra".wrappedAsValue())
+        }
+    }
+
+    /**
+     * @see com.quarkdown.core.function.value.AdaptableValue
+     */
+    @Test
+    fun `adapted result`() {
+        val lambda =
+            Lambda(context) { args, ctx ->
+                NodeValue(Text("Hello"))
+            }
+        assertIs<Text>(
+            lambda
+                .invoke<MarkdownContent, MarkdownContentValue>()
+                .unwrappedValue.children
+                .single(),
+        )
+    }
+}

--- a/quarkdown-core/src/test/kotlin/com/quarkdown/core/TreeTraversalTest.kt
+++ b/quarkdown-core/src/test/kotlin/com/quarkdown/core/TreeTraversalTest.kt
@@ -17,8 +17,8 @@ import com.quarkdown.core.ast.iterator.AstIteratorHook
 import com.quarkdown.core.ast.iterator.ObservableAstIterator
 import com.quarkdown.core.ast.quarkdown.block.Numbered
 import com.quarkdown.core.context.MutableContext
-import com.quarkdown.core.context.hooks.LocationAwareLabelStorerHook
-import com.quarkdown.core.context.hooks.LocationAwarenessHook
+import com.quarkdown.core.context.hooks.location.LocationAwareLabelStorerHook
+import com.quarkdown.core.context.hooks.location.LocationAwarenessHook
 import com.quarkdown.core.document.numbering.DocumentNumbering
 import com.quarkdown.core.document.numbering.NumberingFormat
 import com.quarkdown.core.flavor.quarkdown.QuarkdownFlavor

--- a/quarkdown-html/src/main/kotlin/com/quarkdown/rendering/html/HtmlTagBuilder.kt
+++ b/quarkdown-html/src/main/kotlin/com/quarkdown/rendering/html/HtmlTagBuilder.kt
@@ -1,12 +1,12 @@
 package com.quarkdown.rendering.html
 
 import com.quarkdown.core.ast.Node
-import com.quarkdown.core.rendering.html.BaseHtmlNodeRenderer
 import com.quarkdown.core.rendering.tag.TagBuilder
 import com.quarkdown.core.rendering.tag.tagBuilder
 import com.quarkdown.core.util.indent
 import com.quarkdown.rendering.html.css.CssBuilder
 import com.quarkdown.rendering.html.css.css
+import com.quarkdown.rendering.html.node.BaseHtmlNodeRenderer
 
 /**
  * String used to indent nested code.

--- a/quarkdown-html/src/main/kotlin/com/quarkdown/rendering/html/extension/HtmlRendererFactoryVisitor.kt
+++ b/quarkdown-html/src/main/kotlin/com/quarkdown/rendering/html/extension/HtmlRendererFactoryVisitor.kt
@@ -5,7 +5,7 @@ import com.quarkdown.core.flavor.RendererFactoryVisitor
 import com.quarkdown.core.flavor.base.BaseMarkdownRendererFactory
 import com.quarkdown.core.flavor.quarkdown.QuarkdownRendererFactory
 import com.quarkdown.core.rendering.NodeRenderer
-import com.quarkdown.core.rendering.html.BaseHtmlNodeRenderer
+import com.quarkdown.rendering.html.node.BaseHtmlNodeRenderer
 import com.quarkdown.rendering.html.node.QuarkdownHtmlNodeRenderer
 
 /**

--- a/quarkdown-html/src/main/kotlin/com/quarkdown/rendering/html/node/BaseHtmlNodeRenderer.kt
+++ b/quarkdown-html/src/main/kotlin/com/quarkdown/rendering/html/node/BaseHtmlNodeRenderer.kt
@@ -1,4 +1,4 @@
-package com.quarkdown.core.rendering.html
+package com.quarkdown.rendering.html.node
 
 import com.quarkdown.core.ast.AstRoot
 import com.quarkdown.core.ast.base.block.BlankNode

--- a/quarkdown-html/src/main/kotlin/com/quarkdown/rendering/html/node/QuarkdownHtmlNodeRenderer.kt
+++ b/quarkdown-html/src/main/kotlin/com/quarkdown/rendering/html/node/QuarkdownHtmlNodeRenderer.kt
@@ -41,6 +41,8 @@ import com.quarkdown.core.context.localization.localizeOrNull
 import com.quarkdown.core.context.shouldAutoPageBreak
 import com.quarkdown.core.document.numbering.DocumentNumbering
 import com.quarkdown.core.document.numbering.NumberingFormat
+import com.quarkdown.core.pipeline.error.PipelineException
+import com.quarkdown.core.pipeline.error.asNode
 import com.quarkdown.core.rendering.html.BaseHtmlNodeRenderer
 import com.quarkdown.core.rendering.tag.buildMultiTag
 import com.quarkdown.core.rendering.tag.buildTag
@@ -210,9 +212,14 @@ class QuarkdownHtmlNodeRenderer(
         }
 
     override fun visit(node: Numbered) =
-        buildMultiTag {
-            // Evaluate content with the node's location as an argument.
-            +node.children(node.getLocationLabel(context) ?: "")
+        try {
+            buildMultiTag {
+                // Evaluate content with the node's location as an argument.
+                +node.children(node.getLocationLabel(context) ?: "")
+            }
+        } catch (e: PipelineException) {
+            // Show error box if the evaluation fails.
+            e.asNode(context).accept(this)
         }
 
     override fun visit(node: FullColumnSpan) = div("full-column-span", node.children)

--- a/quarkdown-html/src/main/kotlin/com/quarkdown/rendering/html/node/QuarkdownHtmlNodeRenderer.kt
+++ b/quarkdown-html/src/main/kotlin/com/quarkdown/rendering/html/node/QuarkdownHtmlNodeRenderer.kt
@@ -41,8 +41,6 @@ import com.quarkdown.core.context.localization.localizeOrNull
 import com.quarkdown.core.context.shouldAutoPageBreak
 import com.quarkdown.core.document.numbering.DocumentNumbering
 import com.quarkdown.core.document.numbering.NumberingFormat
-import com.quarkdown.core.pipeline.error.PipelineException
-import com.quarkdown.core.pipeline.error.asNode
 import com.quarkdown.core.rendering.html.BaseHtmlNodeRenderer
 import com.quarkdown.core.rendering.tag.buildMultiTag
 import com.quarkdown.core.rendering.tag.buildTag
@@ -212,14 +210,8 @@ class QuarkdownHtmlNodeRenderer(
         }
 
     override fun visit(node: Numbered) =
-        try {
-            buildMultiTag {
-                // Evaluate content with the node's location as an argument.
-                +node.children(node.getLocationLabel(context) ?: "")
-            }
-        } catch (e: PipelineException) {
-            // Show error box if the evaluation fails.
-            e.asNode(context).accept(this)
+        buildMultiTag {
+            +node.children
         }
 
     override fun visit(node: FullColumnSpan) = div("full-column-span", node.children)

--- a/quarkdown-html/src/main/kotlin/com/quarkdown/rendering/html/node/QuarkdownHtmlNodeRenderer.kt
+++ b/quarkdown-html/src/main/kotlin/com/quarkdown/rendering/html/node/QuarkdownHtmlNodeRenderer.kt
@@ -41,7 +41,6 @@ import com.quarkdown.core.context.localization.localizeOrNull
 import com.quarkdown.core.context.shouldAutoPageBreak
 import com.quarkdown.core.document.numbering.DocumentNumbering
 import com.quarkdown.core.document.numbering.NumberingFormat
-import com.quarkdown.core.rendering.html.BaseHtmlNodeRenderer
 import com.quarkdown.core.rendering.tag.buildMultiTag
 import com.quarkdown.core.rendering.tag.buildTag
 import com.quarkdown.core.rendering.tag.tagBuilder

--- a/quarkdown-test/src/test/kotlin/com/quarkdown/test/NumberingTest.kt
+++ b/quarkdown-test/src/test/kotlin/com/quarkdown/test/NumberingTest.kt
@@ -553,6 +553,32 @@ class NumberingTest {
      * To understand why this is a special case, see [com.quarkdown.core.ast.quarkdown.block.Numbered]'s documentation.
      */
     @Test
+    fun `custom numbering on node`() {
+        execute(
+            """
+            .numbering
+                - key: 1
+            
+            .numbered {key}
+                num:
+                .container
+                    Hello, .num
+            """.trimIndent(),
+            errorHandler = BasePipelineErrorHandler(),
+        ) {
+            assertEquals(
+                "<div class=\"container\">" +
+                    "<p>Hello, 1</p>" +
+                    "</div>",
+                it,
+            )
+        }
+    }
+
+    /**
+     * To understand why this is a special case, see [com.quarkdown.core.ast.quarkdown.block.Numbered]'s documentation.
+     */
+    @Test
     fun `error handling in custom numbering`() {
         execute(
             """

--- a/quarkdown-test/src/test/kotlin/com/quarkdown/test/NumberingTest.kt
+++ b/quarkdown-test/src/test/kotlin/com/quarkdown/test/NumberingTest.kt
@@ -1,9 +1,11 @@
 package com.quarkdown.test
 
+import com.quarkdown.core.pipeline.error.BasePipelineErrorHandler
 import com.quarkdown.test.util.DEFAULT_OPTIONS
 import com.quarkdown.test.util.execute
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 /**
  * Tests for numbering of headings, figures, tables and other elements.
@@ -467,7 +469,6 @@ class NumberingTest {
 
     @Test
     fun `localized numbering captions`() {
-        // Localized kind names.
         execute(
             """
             .noautopagebreak
@@ -503,7 +504,6 @@ class NumberingTest {
 
     @Test
     fun `custom numbering`() {
-        // Custom elements.
         execute(
             """
             .noautopagebreak
@@ -546,6 +546,25 @@ class NumberingTest {
                     "<p>Hey, B!</p>",
                 it,
             )
+        }
+    }
+
+    /**
+     * To understand why this is a special case, see [com.quarkdown.core.ast.quarkdown.block.Numbered]'s documentation.
+     */
+    @Test
+    fun `error handling in custom numbering`() {
+        execute(
+            """
+            .numbering
+                - key: 1
+            
+            .numbered {key}
+                .sum {1} {a}
+            """.trimIndent(),
+            errorHandler = BasePipelineErrorHandler(),
+        ) {
+            assertTrue(it.startsWith("<div class=\"box error\"><header><h4>Error: sum</h4>"))
         }
     }
 }


### PR DESCRIPTION
- Fixed unhandled exceptions thrown within the body of `.numbered`;
- Fixed an error thrown when the body of `.numbered` is of `Node` type;
- Refactored the evaluation of `Numbered` nodes, which now happens during the AST traversal stage instead of the rendering one.