### PR TITLE
Allow caption position customization

### DIFF
--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/quarkdown/invisible/PageMarginContentInitializer.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/quarkdown/invisible/PageMarginContentInitializer.kt
@@ -2,7 +2,7 @@ package com.quarkdown.core.ast.quarkdown.invisible
 
 import com.quarkdown.core.ast.NestableNode
 import com.quarkdown.core.ast.Node
-import com.quarkdown.core.document.page.PageMarginPosition
+import com.quarkdown.core.document.layout.page.PageMarginPosition
 import com.quarkdown.core.visitor.node.NodeVisitor
 
 /**

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/document/DocumentInfo.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/document/DocumentInfo.kt
@@ -1,5 +1,6 @@
 package com.quarkdown.core.document
 
+import com.quarkdown.core.document.layout.DocumentLayoutInfo
 import com.quarkdown.core.document.numbering.DocumentNumbering
 import com.quarkdown.core.document.tex.TexInfo
 import com.quarkdown.core.localization.Locale

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/document/DocumentInfo.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/document/DocumentInfo.kt
@@ -1,7 +1,6 @@
 package com.quarkdown.core.document
 
 import com.quarkdown.core.document.numbering.DocumentNumbering
-import com.quarkdown.core.document.page.PageFormatInfo
 import com.quarkdown.core.document.tex.TexInfo
 import com.quarkdown.core.localization.Locale
 
@@ -23,8 +22,8 @@ data class DocumentInfo(
     var locale: Locale? = null,
     var numbering: DocumentNumbering? = null,
     var theme: DocumentTheme? = null,
-    val pageFormat: PageFormatInfo = PageFormatInfo(),
     val tex: TexInfo = TexInfo(),
+    val layout: DocumentLayoutInfo = DocumentLayoutInfo(),
 ) {
     /**
      * The numbering formats of the document if set by the user,

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/document/DocumentLayoutInfo.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/document/DocumentLayoutInfo.kt
@@ -1,0 +1,12 @@
+package com.quarkdown.core.document
+
+import com.quarkdown.core.document.page.PageFormatInfo
+
+/**
+ * Mutable information about the layout options of a document.
+ * When any of the fields is `null`, the default value supplied by the underlying renderer is used.
+ * @param pageFormat format of the pages of the document
+ */
+data class DocumentLayoutInfo(
+    val pageFormat: PageFormatInfo = PageFormatInfo(),
+)

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/document/DocumentType.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/document/DocumentType.kt
@@ -1,8 +1,8 @@
 package com.quarkdown.core.document
 
+import com.quarkdown.core.document.layout.page.PageOrientation
 import com.quarkdown.core.document.numbering.DocumentNumbering
 import com.quarkdown.core.document.numbering.NumberingFormat
-import com.quarkdown.core.document.page.PageOrientation
 
 /**
  * Type of produced document, which affects its post-rendering stage.

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/document/layout/DocumentLayoutInfo.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/document/layout/DocumentLayoutInfo.kt
@@ -1,6 +1,6 @@
-package com.quarkdown.core.document
+package com.quarkdown.core.document.layout
 
-import com.quarkdown.core.document.page.PageFormatInfo
+import com.quarkdown.core.document.layout.page.PageFormatInfo
 
 /**
  * Mutable information about the layout options of a document.

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/document/layout/DocumentLayoutInfo.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/document/layout/DocumentLayoutInfo.kt
@@ -1,12 +1,15 @@
 package com.quarkdown.core.document.layout
 
+import com.quarkdown.core.document.layout.caption.CaptionPositionInfo
 import com.quarkdown.core.document.layout.page.PageFormatInfo
 
 /**
  * Mutable information about the layout options of a document.
  * When any of the fields is `null`, the default value supplied by the underlying renderer is used.
  * @param pageFormat format of the pages of the document
+ * @param captionPosition position of captions of figures, tables, and more in the document
  */
 data class DocumentLayoutInfo(
     val pageFormat: PageFormatInfo = PageFormatInfo(),
+    val captionPosition: CaptionPositionInfo = CaptionPositionInfo(),
 )

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/document/layout/caption/CaptionPosition.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/document/layout/caption/CaptionPosition.kt
@@ -1,0 +1,16 @@
+package com.quarkdown.core.document.layout.caption
+
+import com.quarkdown.core.rendering.representable.RenderRepresentable
+import com.quarkdown.core.rendering.representable.RenderRepresentableVisitor
+
+/**
+ * Possible positions of captions, relative to the element they describe.
+ * @see CaptionPositionInfo
+ */
+enum class CaptionPosition : RenderRepresentable {
+    TOP,
+    BOTTOM,
+    ;
+
+    override fun <T> accept(visitor: RenderRepresentableVisitor<T>): T = visitor.visit(this)
+}

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/document/layout/caption/CaptionPositionInfo.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/document/layout/caption/CaptionPositionInfo.kt
@@ -1,0 +1,18 @@
+package com.quarkdown.core.document.layout.caption
+
+/**
+ * Mutable information about the position of captions of [com.quarkdown.core.ast.quarkdown.CaptionableNode] nodes in a document.
+ * @param default default relative position of captions
+ * @param figures position of captions for [com.quarkdown.core.ast.quarkdown.block.Figure], if different from the default
+ * @param tables position of captions for [com.quarkdown.core.ast.base.block.Table], if different from the default
+ */
+data class CaptionPositionInfo(
+    var default: CaptionPosition = CaptionPosition.BOTTOM,
+    var figures: CaptionPosition? = null,
+    var tables: CaptionPosition? = null,
+) {
+    /**
+     * @return the value of [property] if it is not `null`, otherwise the [default] value.
+     */
+    fun getOrDefault(property: CaptionPositionInfo.() -> CaptionPosition?): CaptionPosition = property() ?: default
+}

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/document/layout/page/PageFormatInfo.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/document/layout/page/PageFormatInfo.kt
@@ -1,4 +1,4 @@
-package com.quarkdown.core.document.page
+package com.quarkdown.core.document.layout.page
 
 import com.quarkdown.core.ast.quarkdown.block.Container.Alignment
 import com.quarkdown.core.document.size.Size

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/document/layout/page/PageMarginPosition.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/document/layout/page/PageMarginPosition.kt
@@ -1,4 +1,4 @@
-package com.quarkdown.core.document.page
+package com.quarkdown.core.document.layout.page
 
 import com.quarkdown.core.rendering.representable.RenderRepresentable
 import com.quarkdown.core.rendering.representable.RenderRepresentableVisitor

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/document/layout/page/PageOrientation.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/document/layout/page/PageOrientation.kt
@@ -1,4 +1,4 @@
-package com.quarkdown.core.document.page
+package com.quarkdown.core.document.layout.page
 
 /**
  * The orientation of a page.

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/document/layout/page/PageSizeFormat.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/document/layout/page/PageSizeFormat.kt
@@ -1,4 +1,4 @@
-package com.quarkdown.core.document.page
+package com.quarkdown.core.document.layout.page
 
 import com.quarkdown.core.document.size.BoundingBox
 import com.quarkdown.core.document.size.by
@@ -9,7 +9,9 @@ import com.quarkdown.core.document.size.mm
  * Standard page sizes.
  * @param bounds size the page
  */
-enum class PageSizeFormat(private val bounds: BoundingBox) {
+enum class PageSizeFormat(
+    private val bounds: BoundingBox,
+) {
     A0(841.0.mm by 1189.0.mm),
     A1(594.0.mm by 841.0.mm),
     A2(420.0.mm by 594.0.mm),

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/document/page/PageFormatInfo.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/document/page/PageFormatInfo.kt
@@ -5,7 +5,7 @@ import com.quarkdown.core.document.size.Size
 import com.quarkdown.core.document.size.Sizes
 
 /**
- * Mutable information about the format of all pages of a paged document.
+ * Mutable information about the format of all pages of a document.
  * When any of the fields is `null`, the default value supplied by the underlying renderer is used.
  * @param pageWidth width of each page
  * @param pageHeight height of each page

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/rendering/representable/RenderRepresentableVisitor.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/rendering/representable/RenderRepresentableVisitor.kt
@@ -8,7 +8,7 @@ import com.quarkdown.core.ast.quarkdown.block.Container
 import com.quarkdown.core.ast.quarkdown.block.SlidesFragment
 import com.quarkdown.core.ast.quarkdown.block.Stacked
 import com.quarkdown.core.ast.quarkdown.inline.TextTransformData
-import com.quarkdown.core.document.page.PageMarginPosition
+import com.quarkdown.core.document.layout.page.PageMarginPosition
 import com.quarkdown.core.document.size.Size
 import com.quarkdown.core.document.size.Sizes
 import com.quarkdown.core.document.slides.Transition

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/rendering/representable/RenderRepresentableVisitor.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/rendering/representable/RenderRepresentableVisitor.kt
@@ -8,6 +8,7 @@ import com.quarkdown.core.ast.quarkdown.block.Container
 import com.quarkdown.core.ast.quarkdown.block.SlidesFragment
 import com.quarkdown.core.ast.quarkdown.block.Stacked
 import com.quarkdown.core.ast.quarkdown.inline.TextTransformData
+import com.quarkdown.core.document.layout.caption.CaptionPosition
 import com.quarkdown.core.document.layout.page.PageMarginPosition
 import com.quarkdown.core.document.size.Size
 import com.quarkdown.core.document.size.Sizes
@@ -27,6 +28,8 @@ interface RenderRepresentableVisitor<T> {
     fun visit(sizes: Sizes): T
 
     fun visit(alignment: Table.Alignment): T
+
+    fun visit(position: CaptionPosition): T
 
     fun visit(borderStyle: Container.BorderStyle): T
 

--- a/quarkdown-html/src/main/kotlin/com/quarkdown/rendering/html/css/CssRepresentableVisitor.kt
+++ b/quarkdown-html/src/main/kotlin/com/quarkdown/rendering/html/css/CssRepresentableVisitor.kt
@@ -8,6 +8,7 @@ import com.quarkdown.core.ast.quarkdown.block.Container
 import com.quarkdown.core.ast.quarkdown.block.SlidesFragment
 import com.quarkdown.core.ast.quarkdown.block.Stacked
 import com.quarkdown.core.ast.quarkdown.inline.TextTransformData
+import com.quarkdown.core.document.layout.caption.CaptionPosition
 import com.quarkdown.core.document.layout.page.PageMarginPosition
 import com.quarkdown.core.document.size.Size
 import com.quarkdown.core.document.size.Sizes
@@ -37,6 +38,8 @@ class CssRepresentableVisitor : RenderRepresentableVisitor<String> {
         }
 
     override fun visit(alignment: Table.Alignment) = alignment.kebabCaseName
+
+    override fun visit(position: CaptionPosition) = position.kebabCaseName
 
     override fun visit(borderStyle: Container.BorderStyle) =
         when (borderStyle) {

--- a/quarkdown-html/src/main/kotlin/com/quarkdown/rendering/html/css/CssRepresentableVisitor.kt
+++ b/quarkdown-html/src/main/kotlin/com/quarkdown/rendering/html/css/CssRepresentableVisitor.kt
@@ -8,7 +8,7 @@ import com.quarkdown.core.ast.quarkdown.block.Container
 import com.quarkdown.core.ast.quarkdown.block.SlidesFragment
 import com.quarkdown.core.ast.quarkdown.block.Stacked
 import com.quarkdown.core.ast.quarkdown.inline.TextTransformData
-import com.quarkdown.core.document.page.PageMarginPosition
+import com.quarkdown.core.document.layout.page.PageMarginPosition
 import com.quarkdown.core.document.size.Size
 import com.quarkdown.core.document.size.Sizes
 import com.quarkdown.core.document.slides.Transition

--- a/quarkdown-html/src/main/kotlin/com/quarkdown/rendering/html/post/HtmlPostRenderer.kt
+++ b/quarkdown-html/src/main/kotlin/com/quarkdown/rendering/html/post/HtmlPostRenderer.kt
@@ -83,30 +83,27 @@ class HtmlPostRenderer(
                 context.attributes.hasMath,
             )
             // Page format.
-            conditional(TemplatePlaceholders.HAS_PAGE_SIZE, context.documentInfo.pageFormat.hasSize)
+            val pageFormat = context.documentInfo.layout.pageFormat
+            conditional(TemplatePlaceholders.HAS_PAGE_SIZE, pageFormat.hasSize)
             optionalValue(
                 TemplatePlaceholders.PAGE_WIDTH,
-                context.documentInfo.pageFormat.pageWidth
-                    ?.asCSS,
+                pageFormat.pageWidth?.asCSS,
             )
             optionalValue(
                 TemplatePlaceholders.PAGE_HEIGHT,
-                context.documentInfo.pageFormat.pageHeight
-                    ?.asCSS,
+                pageFormat.pageHeight?.asCSS,
             )
             optionalValue(
                 TemplatePlaceholders.PAGE_MARGIN,
-                context.documentInfo.pageFormat.margin
-                    ?.asCSS,
+                pageFormat.margin?.asCSS,
             )
             optionalValue(
                 TemplatePlaceholders.COLUMN_COUNT,
-                context.documentInfo.pageFormat.columnCount,
+                pageFormat.columnCount,
             )
             optionalValue(
                 TemplatePlaceholders.HORIZONTAL_ALIGNMENT,
-                context.documentInfo.pageFormat.alignment
-                    ?.asCSS,
+                pageFormat.alignment?.asCSS,
             )
             iterable(
                 TemplatePlaceholders.TEX_MACROS,

--- a/quarkdown-html/src/main/resources/render/theme/global.css
+++ b/quarkdown-html/src/main/resources/render/theme/global.css
@@ -188,6 +188,7 @@ body.quarkdown-paged:not(:has(.pagedjs_page)) {
 .quarkdown figure {
     display: flex;
     flex-direction: column;
+    align-items: center;
 }
 
 .quarkdown figure > :not(figcaption) {

--- a/quarkdown-html/src/main/resources/render/theme/global.css
+++ b/quarkdown-html/src/main/resources/render/theme/global.css
@@ -185,6 +185,25 @@ body.quarkdown-paged:not(:has(.pagedjs_page)) {
     margin-bottom: 1em;
 }
 
+.quarkdown figure {
+    display: flex;
+    flex-direction: column;
+}
+
+.quarkdown figure > :not(figcaption) {
+    order: 1;
+}
+
+.quarkdown figure > figcaption.caption-top {
+    order: 0;
+    margin-bottom: 0.5em;
+}
+
+.quarkdown figure > figcaption.caption-bottom {
+    order: 2;
+    margin-top: 0.5em;
+}
+
 .quarkdown :is(figure, .mermaid) {
     text-align: center;
 }
@@ -331,18 +350,29 @@ body.quarkdown-paged:not(:has(.pagedjs_page)) {
     content: var(--qd-quote-attribution-prefix);
 }
 
-.quarkdown table {
-    caption-side: bottom;
-}
-
 .quarkdown table :is(th, td):not([align]) {
     text-align: var(--qd-table-default-cell-alignment);
 }
 
+.quarkdown table:has(> caption.caption-top) {
+    caption-side: top;
+}
+
+.quarkdown table:has(> caption.caption-bottom) {
+    caption-side: bottom;
+}
+
 .quarkdown table > caption {
-    margin-top: 1em;
     white-space: nowrap;
     overflow-x: hidden;
+}
+
+.quarkdown table > caption.caption-top {
+    margin-bottom: 1em;
+}
+
+.quarkdown table > caption.caption-bottom {
+    margin-top: 1em;
 }
 
 .quarkdown hr {

--- a/quarkdown-html/src/test/kotlin/com/quarkdown/rendering/html/HtmlPostRendererTest.kt
+++ b/quarkdown-html/src/test/kotlin/com/quarkdown/rendering/html/HtmlPostRendererTest.kt
@@ -241,11 +241,13 @@ class HtmlPostRendererTest {
         context.documentInfo.locale = LocaleLoader.SYSTEM.fromName("english")
         context.documentInfo.type = DocumentType.SLIDES
         context.attributes.markMathPresence()
-        context.documentInfo.pageFormat.pageWidth = 8.5.inch
-        context.documentInfo.pageFormat.pageHeight = 11.0.inch
-        context.documentInfo.pageFormat.margin = Sizes(1.0.inch)
-        context.documentInfo.tex.macros["\\R"] = "\\mathbb{R}"
-        context.documentInfo.tex.macros["\\Z"] = "\\mathbb{Z}"
+        with(context.documentInfo) {
+            layout.pageFormat.pageWidth = 8.5.inch
+            layout.pageFormat.pageHeight = 11.0.inch
+            layout.pageFormat.margin = Sizes(1.0.inch)
+            tex.macros["\\R"] = "\\mathbb{R}"
+            tex.macros["\\Z"] = "\\mathbb{Z}"
+        }
 
         val postRenderer =
             HtmlPostRenderer(context) {

--- a/quarkdown-html/src/test/resources/rendering/block/table.html
+++ b/quarkdown-html/src/test/resources/rendering/block/table.html
@@ -95,7 +95,7 @@
             </td>
         </tr>
     </tbody>
-    <caption>
+    <caption class="caption-bottom">
         Table &#39;caption&#39;.
     </caption>
 </table>

--- a/quarkdown-html/src/test/resources/rendering/quarkdown/figure.html
+++ b/quarkdown-html/src/test/resources/rendering/quarkdown/figure.html
@@ -1,6 +1,6 @@
 <figure>
     <img src="/url" alt="" title="" />
-    <figcaption>
+    <figcaption class="caption-bottom">
     </figcaption>
 </figure>
 
@@ -8,7 +8,7 @@
 
 <figure>
     <img src="/url" alt="" title="Title" />
-    <figcaption>
+    <figcaption class="caption-bottom">
         Title
     </figcaption>
 </figure>
@@ -17,7 +17,7 @@
 
 <figure>
     <img src="/url" alt="" title="Title" style="width: 150.0px; height: 100.0px;" />
-    <figcaption>
+    <figcaption class="caption-bottom">
         Title
     </figcaption>
 </figure>

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Data.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Data.kt
@@ -86,12 +86,14 @@ fun read(
 
 /**
  * @param path path of the CSV file (with extension) to show
+ * @param caption caption of the table, if any
  * @return a table whose content is loaded from the file located in [path]
  * @wiki File data
  */
 fun csv(
     @Injected context: Context,
     path: String,
+    caption: String? = null,
 ): NodeValue {
     val file = file(context, path)
     val columns = mutableMapOf<String, MutableList<String>>()
@@ -115,6 +117,7 @@ fun csv(
                     cells.map { cell -> Table.Cell(listOf(Text(cell.trim()))) },
                 )
             },
+            caption,
         )
 
     return table.wrappedAsValue()

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Document.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Document.kt
@@ -14,11 +14,11 @@ import com.quarkdown.core.document.DocumentAuthor
 import com.quarkdown.core.document.DocumentInfo
 import com.quarkdown.core.document.DocumentTheme
 import com.quarkdown.core.document.DocumentType
+import com.quarkdown.core.document.layout.page.PageMarginPosition
+import com.quarkdown.core.document.layout.page.PageOrientation
+import com.quarkdown.core.document.layout.page.PageSizeFormat
 import com.quarkdown.core.document.numbering.DocumentNumbering
 import com.quarkdown.core.document.numbering.NumberingFormat
-import com.quarkdown.core.document.page.PageMarginPosition
-import com.quarkdown.core.document.page.PageOrientation
-import com.quarkdown.core.document.page.PageSizeFormat
 import com.quarkdown.core.document.size.Size
 import com.quarkdown.core.document.size.Sizes
 import com.quarkdown.core.function.library.loader.Module

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Document.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Document.kt
@@ -349,7 +349,7 @@ fun pageFormat(
     columns: Int? = null,
     alignment: Container.Alignment? = null,
 ): VoidValue {
-    with(context.documentInfo.pageFormat) {
+    with(context.documentInfo.layout.pageFormat) {
         // If, for instance, the document is landscape and the given format is portrait,
         // the format is converted to landscape.
         val formatBounds = format?.getBounds(orientation)

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Document.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Document.kt
@@ -14,6 +14,7 @@ import com.quarkdown.core.document.DocumentAuthor
 import com.quarkdown.core.document.DocumentInfo
 import com.quarkdown.core.document.DocumentTheme
 import com.quarkdown.core.document.DocumentType
+import com.quarkdown.core.document.layout.caption.CaptionPosition
 import com.quarkdown.core.document.layout.page.PageMarginPosition
 import com.quarkdown.core.document.layout.page.PageOrientation
 import com.quarkdown.core.document.layout.page.PageSizeFormat
@@ -51,6 +52,7 @@ val Document: Module =
         ::theme,
         ::numbering,
         ::disableNumbering,
+        ::captionPosition,
         ::texMacro,
         ::pageFormat,
         ::pageMarginContent,
@@ -307,6 +309,28 @@ fun numbering(
 fun disableNumbering(
     @Injected context: Context,
 ) = numbering(context, emptyMap())
+
+/**
+ * Sets the position of captions, relative to the content they describe.
+ * @param default the default position for all captions. Defaults to [CaptionPosition.BOTTOM]
+ * @param figures caption position for figures. If set, overrides [default] for figures.
+ * @param tables caption position for tables. If set, overrides [default] for tables.
+ * @wiki Caption position
+ */
+@Name("captionposition")
+fun captionPosition(
+    @Injected context: Context,
+    default: CaptionPosition? = null,
+    figures: CaptionPosition? = null,
+    tables: CaptionPosition? = null,
+): VoidValue {
+    with(context.documentInfo.layout.captionPosition) {
+        this.default = default ?: this.default
+        this.figures = figures ?: this.figures
+        this.tables = tables ?: this.tables
+    }
+    return VoidValue
+}
 
 /**
  * Creates a new global TeX macro that can be accessed within math blocks.

--- a/quarkdown-test/src/test/kotlin/com/quarkdown/test/CaptionTest.kt
+++ b/quarkdown-test/src/test/kotlin/com/quarkdown/test/CaptionTest.kt
@@ -1,0 +1,45 @@
+package com.quarkdown.test
+
+import com.quarkdown.test.util.execute
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ *
+ */
+class CaptionTest {
+    @Test
+    fun figure() {
+        execute(
+            """
+            ![](https://example.com/image.png "Figure caption")
+            """.trimIndent(),
+        ) {
+            assertEquals(
+                "<figure><img src=\"https://example.com/image.png\" alt=\"\" title=\"Figure caption\" />" +
+                    "<figcaption>Figure caption</figcaption></figure>",
+                it,
+            )
+        }
+    }
+
+    @Test
+    fun table() {
+        execute(
+            """
+            | Header 1 | Header 2 | Header 3 |
+            |----------|:--------:|----------|
+            | Cell 1   | Cell 2   | Cell 3   |
+            "Table caption"
+            """.trimIndent(),
+        ) {
+            assertEquals(
+                "<table><thead><tr><th>Header 1</th><th align=\"center\">Header 2</th>" +
+                    "<th>Header 3</th></tr></thead><tbody><tr><td>Cell 1</td>" +
+                    "<td align=\"center\">Cell 2</td><td>Cell 3</td></tr></tbody>" +
+                    "<caption>Table caption</caption></table>",
+                it,
+            )
+        }
+    }
+}

--- a/quarkdown-test/src/test/kotlin/com/quarkdown/test/CaptionTest.kt
+++ b/quarkdown-test/src/test/kotlin/com/quarkdown/test/CaptionTest.kt
@@ -5,7 +5,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 
 /**
- *
+ * Tests for [com.quarkdown.core.ast.quarkdown.CaptionableNode]s.
  */
 class CaptionTest {
     @Test
@@ -17,7 +17,7 @@ class CaptionTest {
         ) {
             assertEquals(
                 "<figure><img src=\"https://example.com/image.png\" alt=\"\" title=\"Figure caption\" />" +
-                    "<figcaption>Figure caption</figcaption></figure>",
+                    "<figcaption class=\"caption-bottom\">Figure caption</figcaption></figure>",
                 it,
             )
         }
@@ -32,7 +32,7 @@ class CaptionTest {
             """.trimIndent(),
         ) {
             assertEquals(
-                "<figure><p>Hello</p><figcaption>Figure caption</figcaption></figure>",
+                "<figure><p>Hello</p><figcaption class=\"caption-bottom\">Figure caption</figcaption></figure>",
                 it,
             )
         }
@@ -52,7 +52,62 @@ class CaptionTest {
                 "<table><thead><tr><th>Header 1</th><th align=\"center\">Header 2</th>" +
                     "<th>Header 3</th></tr></thead><tbody><tr><td>Cell 1</td>" +
                     "<td align=\"center\">Cell 2</td><td>Cell 3</td></tr></tbody>" +
-                    "<caption>Table caption</caption></table>",
+                    "<caption class=\"caption-bottom\">Table caption</caption></table>",
+                it,
+            )
+        }
+    }
+
+    @Test
+    fun `all captions on top`() {
+        execute(
+            """
+            .captionposition default:{top}
+            
+            ![](https://example.com/image.png "Figure caption")
+            
+            | Header 1 | Header 2 |
+            |----------|----------|
+            | Cell 1   | Cell 2   |
+            "Table caption"
+            
+            .mermaid caption:{Mermaid caption}
+                graph TD
+            """.trimIndent(),
+        ) {
+            assertEquals(
+                "<figure><img src=\"https://example.com/image.png\" alt=\"\" title=\"Figure caption\" />" +
+                    "<figcaption class=\"caption-top\">Figure caption</figcaption></figure>" +
+                    "<table><thead><tr><th>Header 1</th><th>Header 2</th></tr></thead>" +
+                    "<tbody><tr><td>Cell 1</td><td>Cell 2</td></tr></tbody>" +
+                    "<caption class=\"caption-top\">Table caption</caption></table>" +
+                    "<figure><pre class=\"mermaid fill-height\">graph TD</pre>" +
+                    "<figcaption class=\"caption-top\">Mermaid caption</figcaption></figure>",
+                it,
+            )
+        }
+    }
+
+    @Test
+    fun `all captions on top but figures`() {
+        execute(
+            """
+            .captionposition default:{top} figures:{bottom}
+            
+            ![](https://example.com/image.png "Figure caption")
+            
+            | Header 1 | Header 2 |
+            |----------|----------|
+            | Cell 1   | Cell 2   |
+            "Table caption"
+            """.trimIndent(),
+        ) {
+            assertEquals(
+                "<figure><img src=\"https://example.com/image.png\" alt=\"\" title=\"Figure caption\" />" +
+                    "<figcaption class=\"caption-bottom\">Figure caption</figcaption></figure>" +
+                    "<table><thead><tr><th>Header 1</th><th>Header 2</th></tr></thead>" +
+                    "<tbody><tr><td>Cell 1</td><td>Cell 2</td></tr></tbody>" +
+                    "<caption class=\"caption-top\">Table caption</caption></table>",
                 it,
             )
         }

--- a/quarkdown-test/src/test/kotlin/com/quarkdown/test/CaptionTest.kt
+++ b/quarkdown-test/src/test/kotlin/com/quarkdown/test/CaptionTest.kt
@@ -24,6 +24,21 @@ class CaptionTest {
     }
 
     @Test
+    fun `figure via function`() {
+        execute(
+            """
+            .figure caption:{Figure caption}
+                Hello
+            """.trimIndent(),
+        ) {
+            assertEquals(
+                "<figure><p>Hello</p><figcaption>Figure caption</figcaption></figure>",
+                it,
+            )
+        }
+    }
+
+    @Test
     fun table() {
         execute(
             """

--- a/quarkdown-test/src/test/kotlin/com/quarkdown/test/DocumentTest.kt
+++ b/quarkdown-test/src/test/kotlin/com/quarkdown/test/DocumentTest.kt
@@ -71,8 +71,8 @@ class DocumentTest {
             assertEquals("minimal", documentInfo.theme?.layout)
 
             PageSizeFormat.A3.getBounds(PageOrientation.LANDSCAPE).let { bounds ->
-                assertEquals(bounds.width, documentInfo.pageFormat.pageWidth)
-                assertEquals(bounds.height, documentInfo.pageFormat.pageHeight)
+                assertEquals(bounds.width, documentInfo.layout.pageFormat.pageWidth)
+                assertEquals(bounds.height, documentInfo.layout.pageFormat.pageHeight)
             }
 
             assertEquals(
@@ -80,11 +80,11 @@ class DocumentTest {
                     vertical = Size(3.0, Size.Unit.CENTIMETERS),
                     horizontal = Size(2.0, Size.Unit.PIXELS),
                 ),
-                documentInfo.pageFormat.margin,
+                documentInfo.layout.pageFormat.margin,
             )
 
-            assertEquals(4, documentInfo.pageFormat.columnCount)
-            assertEquals(Alignment.END, documentInfo.pageFormat.alignment)
+            assertEquals(4, documentInfo.layout.pageFormat.columnCount)
+            assertEquals(Alignment.END, documentInfo.layout.pageFormat.alignment)
         }
     }
 

--- a/quarkdown-test/src/test/kotlin/com/quarkdown/test/DocumentTest.kt
+++ b/quarkdown-test/src/test/kotlin/com/quarkdown/test/DocumentTest.kt
@@ -6,8 +6,8 @@ import com.quarkdown.core.ast.attributes.presence.hasMath
 import com.quarkdown.core.ast.quarkdown.block.Container.Alignment
 import com.quarkdown.core.document.DocumentAuthor
 import com.quarkdown.core.document.DocumentType
-import com.quarkdown.core.document.page.PageOrientation
-import com.quarkdown.core.document.page.PageSizeFormat
+import com.quarkdown.core.document.layout.page.PageOrientation
+import com.quarkdown.core.document.layout.page.PageSizeFormat
 import com.quarkdown.core.document.size.Size
 import com.quarkdown.core.document.size.Sizes
 import com.quarkdown.test.util.execute

--- a/quarkdown-test/src/test/kotlin/com/quarkdown/test/MediaStorageTest.kt
+++ b/quarkdown-test/src/test/kotlin/com/quarkdown/test/MediaStorageTest.kt
@@ -47,7 +47,7 @@ class MediaStorageTest {
                     "<figure>" +
                     "<img src=\"media/https-raw.githubusercontent.com-iamgio-quarkdown-project-files-images-ticon-light.svg\" " +
                     "alt=\"Icon\" title=\"The Quarkdown icon\" />" +
-                    "<figcaption>The Quarkdown icon</figcaption>" +
+                    "<figcaption class=\"caption-bottom\">The Quarkdown icon</figcaption>" +
                     "</figure>" +
                     "<figure>" +
                     "<img src=\"media/https-raw.githubusercontent.com-iamgio-quarkdown-project-files-images-tbanner-light.svg\" " +

--- a/quarkdown-test/src/test/kotlin/com/quarkdown/test/MermaidTest.kt
+++ b/quarkdown-test/src/test/kotlin/com/quarkdown/test/MermaidTest.kt
@@ -41,7 +41,7 @@ class MermaidTest {
         ) {
             assertEquals(
                 "${MERMAID_OPEN}graph TD\n    A-->B\n    A-->C</pre>" +
-                    "<figcaption>My graph</figcaption></figure>",
+                    "<figcaption class=\"caption-bottom\">My graph</figcaption></figure>",
                 it,
             )
             assertTrue(attributes.hasMermaidDiagram)
@@ -58,7 +58,7 @@ class MermaidTest {
         ) {
             assertEquals(it.lines().first(), MERMAID_OPEN + "classDiagram")
             assertEquals(it.lines()[1], "    class Bank {")
-            assertContains(it, "<figcaption>My graph</figcaption></figure>")
+            assertContains(it, "<figcaption class=\"caption-bottom\">My graph</figcaption></figure>")
         }
     }
 

--- a/quarkdown-test/src/test/kotlin/com/quarkdown/test/NodesTest.kt
+++ b/quarkdown-test/src/test/kotlin/com/quarkdown/test/NodesTest.kt
@@ -239,7 +239,7 @@ class NodesTest {
             assertEquals(
                 "<figure>" +
                     "<img src=\"https://example.com/image.png\" alt=\"Alt text\" title=\"Title\" />" +
-                    "<figcaption>Title</figcaption>" +
+                    "<figcaption class=\"caption-bottom\">Title</figcaption>" +
                     "</figure>",
                 it,
             )
@@ -411,7 +411,7 @@ class NodesTest {
                 "<table><thead><tr><th>Header 1</th><th align=\"center\">Header 2</th>" +
                     "<th>Header 3</th></tr></thead><tbody><tr><td>Cell 1</td>" +
                     "<td align=\"center\">Cell 2</td><td>Cell 3</td></tr></tbody>" +
-                    "<caption>Table caption</caption></table>",
+                    "<caption class=\"caption-bottom\">Table caption</caption></table>",
                 it,
             )
         }

--- a/quarkdown-test/src/test/kotlin/com/quarkdown/test/NumberingTest.kt
+++ b/quarkdown-test/src/test/kotlin/com/quarkdown/test/NumberingTest.kt
@@ -495,11 +495,13 @@ class NumberingTest {
             assertEquals(
                 "<h1>A</h1>" +
                     "<figure id=\"figure-1.1\"><img src=\"img.png\" alt=\"\" title=\"Caption\" />" +
-                    "<figcaption class=\"caption-bottom\" data-element-label=\"1.1\" data-localized-kind=\"Figura\">Caption</figcaption>" +
+                    "<figcaption class=\"caption-bottom\" data-element-label=\"1.1\" data-localized-kind=\"Figura\">" +
+                    "Caption</figcaption>" +
                     "</figure>" +
                     "<table id=\"table-1.a\"><thead><tr><th>A</th><th>B</th><th>C</th></tr></thead>" +
                     "<tbody><tr><td>D</td><td>E</td><td>F</td></tr></tbody>" +
-                    "<caption class=\"caption-bottom\" data-element-label=\"1.a\" data-localized-kind=\"Tabella\">Caption</caption></table>",
+                    "<caption class=\"caption-bottom\" data-element-label=\"1.a\" data-localized-kind=\"Tabella\">" +
+                    "Caption</caption></table>",
                 it,
             )
         }

--- a/quarkdown-test/src/test/kotlin/com/quarkdown/test/NumberingTest.kt
+++ b/quarkdown-test/src/test/kotlin/com/quarkdown/test/NumberingTest.kt
@@ -28,7 +28,7 @@ class NumberingTest {
                 "<h1>A</h1>" +
                     "<h2>A/1</h2>" +
                     "<h1>B</h1>" +
-                    "<figure><img src=\"img.png\" alt=\"\" title=\"\" /><figcaption></figcaption></figure>",
+                    "<figure><img src=\"img.png\" alt=\"\" title=\"\" /><figcaption class=\"caption-bottom\"></figcaption></figure>",
                 it,
             )
         }
@@ -246,9 +246,11 @@ class NumberingTest {
                 "<h1>A</h1>" +
                     "<h2>A/1</h2>" +
                     "<h1>B</h1>" +
-                    "<figure><img src=\"img.png\" alt=\"\" title=\"Caption\" /><figcaption>Caption</figcaption></figure>" +
+                    "<figure><img src=\"img.png\" alt=\"\" title=\"Caption\" />" +
+                    "<figcaption class=\"caption-bottom\">Caption</figcaption></figure>" +
                     "<table><thead><tr><th>A</th><th>B</th><th>C</th></tr></thead>" +
-                    "<tbody><tr><td>D</td><td>E</td><td>F</td></tr></tbody><caption></caption></table>",
+                    "<tbody><tr><td>D</td><td>E</td><td>F</td></tr></tbody>" +
+                    "<caption class=\"caption-bottom\"></caption></table>",
                 it,
             )
         }
@@ -278,14 +280,14 @@ class NumberingTest {
             assertEquals(
                 "<h1 data-location=\"1\">A</h1>" +
                     "<figure id=\"figure-1.1\"><img src=\"img.png\" alt=\"\" title=\"Caption 1\" />" +
-                    "<figcaption data-element-label=\"1.1\">Caption 1</figcaption>" +
+                    "<figcaption class=\"caption-bottom\" data-element-label=\"1.1\">Caption 1</figcaption>" +
                     "</figure>" +
                     "<figure id=\"figure-1.2\"><img src=\"img.png\" alt=\"\" title=\"Caption 2\" />" +
-                    "<figcaption data-element-label=\"1.2\">Caption 2</figcaption>" +
+                    "<figcaption class=\"caption-bottom\" data-element-label=\"1.2\">Caption 2</figcaption>" +
                     "</figure>" +
                     "<h1 data-location=\"2\">B</h1>" +
                     "<figure id=\"figure-2.1\"><img src=\"img.png\" alt=\"\" title=\"\" />" +
-                    "<figcaption data-element-label=\"2.1\"></figcaption>" +
+                    "<figcaption class=\"caption-bottom\" data-element-label=\"2.1\"></figcaption>" +
                     "</figure>",
                 it,
             )
@@ -335,32 +337,33 @@ class NumberingTest {
         ) {
             assertEquals(
                 "<figure id=\"figure-0.0.a\"><img src=\"img.png\" alt=\"\" title=\"Caption\" />" +
-                    "<figcaption data-element-label=\"0.0.a\">Caption</figcaption>" +
+                    "<figcaption class=\"caption-bottom\" data-element-label=\"0.0.a\">Caption</figcaption>" +
                     "</figure>" +
                     "<h1 data-location=\"1\">A</h1>" +
                     "<figure id=\"figure-1.0.a\"><img src=\"img.png\" alt=\"\" title=\"Caption\" />" +
-                    "<figcaption data-element-label=\"1.0.a\">Caption</figcaption>" +
+                    "<figcaption class=\"caption-bottom\" data-element-label=\"1.0.a\">Caption</figcaption>" +
                     "</figure>" +
                     "<table id=\"table-1.0.a\"><thead><tr><th>A</th><th>B</th><th>C</th></tr></thead>" +
                     "<tbody><tr><td>D</td><td>E</td><td>F</td></tr></tbody>" +
-                    "<caption data-element-label=\"1.0.a\">Table caption</caption></table>" +
+                    "<caption class=\"caption-bottom\" data-element-label=\"1.0.a\">Table caption</caption></table>" +
                     "<h2>A/1</h2>" +
                     "<figure id=\"figure-1.A.a\"><img src=\"img.png\" alt=\"\" title=\"Caption\" />" +
-                    "<figcaption data-element-label=\"1.A.a\">Caption</figcaption>" +
+                    "<figcaption class=\"caption-bottom\" data-element-label=\"1.A.a\">Caption</figcaption>" +
                     "</figure>" +
                     "<h3>A/1/1</h3>" +
                     "<figure id=\"figure-1.A.b\"><img src=\"img.png\" alt=\"\" title=\"Caption\" />" +
-                    "<figcaption data-element-label=\"1.A.b\">Caption</figcaption>" +
+                    "<figcaption class=\"caption-bottom\" data-element-label=\"1.A.b\">Caption</figcaption>" +
                     "</figure>" +
                     "<table id=\"table-1.A.a\"><thead><tr><th>A</th><th>B</th><th>C</th></tr></thead>" +
-                    "<tbody><tr><td>D</td><td>E</td><td>F</td></tr></tbody><caption data-element-label=\"1.A.a\"></caption></table>" +
+                    "<tbody><tr><td>D</td><td>E</td><td>F</td></tr></tbody>" +
+                    "<caption class=\"caption-bottom\" data-element-label=\"1.A.a\"></caption></table>" +
                     "<h1 data-location=\"2\">B</h1>" +
                     "<figure id=\"figure-2.0.a\"><img src=\"img.png\" alt=\"\" title=\"Caption\" />" +
-                    "<figcaption data-element-label=\"2.0.a\">Caption</figcaption>" +
+                    "<figcaption class=\"caption-bottom\" data-element-label=\"2.0.a\">Caption</figcaption>" +
                     "</figure>" +
                     "<h3>B/0/1</h3>" +
                     "<figure id=\"figure-2.0.b\"><img src=\"img.png\" alt=\"\" title=\"Caption\" />" +
-                    "<figcaption data-element-label=\"2.0.b\">Caption</figcaption>" +
+                    "<figcaption class=\"caption-bottom\" data-element-label=\"2.0.b\">Caption</figcaption>" +
                     "</figure>",
                 it,
             )
@@ -397,11 +400,11 @@ class NumberingTest {
                     "<table><thead><tr><th>A</th><th>B</th><th>C</th></tr></thead>" +
                     "<tbody><tr><td>D</td><td>E</td><td>F</td></tr></tbody></table>" +
                     "<figure id=\"figure-1.1\"><img src=\"img.png\" alt=\"\" title=\"Caption\" />" +
-                    "<figcaption data-element-label=\"1.1\">Caption</figcaption>" +
+                    "<figcaption class=\"caption-bottom\" data-element-label=\"1.1\">Caption</figcaption>" +
                     "</figure>" +
                     "<table id=\"table-1.1\"><thead><tr><th>A</th><th>B</th><th>C</th></tr></thead>" +
                     "<tbody><tr><td>D</td><td>E</td><td>F</td></tr></tbody>" +
-                    "<caption data-element-label=\"1.1\">Caption</caption></table>",
+                    "<caption class=\"caption-bottom\" data-element-label=\"1.1\">Caption</caption></table>",
                 it,
             )
         }
@@ -432,14 +435,14 @@ class NumberingTest {
             assertEquals(
                 "<h1 data-location=\"1\">A</h1>" +
                     "<figure id=\"figure-1.1\"><img src=\"img.png\" alt=\"\" title=\"Caption 1\" />" +
-                    "<figcaption data-element-label=\"1.1\">Caption 1</figcaption>" +
+                    "<figcaption class=\"caption-bottom\" data-element-label=\"1.1\">Caption 1</figcaption>" +
                     "</figure>" +
                     "<figure id=\"figure-1.2\">" +
                     "<pre class=\"mermaid fill-height\">graph TD\n    A-->B\n    A-->C</pre>" +
-                    "<figcaption data-element-label=\"1.2\">Caption 2</figcaption>" +
+                    "<figcaption class=\"caption-bottom\" data-element-label=\"1.2\">Caption 2</figcaption>" +
                     "</figure>" +
                     "<figure id=\"figure-1.3\"><img src=\"img.png\" alt=\"\" title=\"Caption 3\" />" +
-                    "<figcaption data-element-label=\"1.3\">Caption 3</figcaption>" +
+                    "<figcaption class=\"caption-bottom\" data-element-label=\"1.3\">Caption 3</figcaption>" +
                     "</figure>",
                 it,
             )
@@ -460,7 +463,7 @@ class NumberingTest {
         ) {
             assertEquals(
                 "<figure id=\"figure-1\"><p>Hello, world!</p>" +
-                    "<figcaption data-element-label=\"1\" data-localized-kind=\"Figure\">" +
+                    "<figcaption class=\"caption-bottom\" data-element-label=\"1\" data-localized-kind=\"Figure\">" +
                     "My caption.</figcaption></figure>",
                 it,
             )
@@ -492,11 +495,11 @@ class NumberingTest {
             assertEquals(
                 "<h1>A</h1>" +
                     "<figure id=\"figure-1.1\"><img src=\"img.png\" alt=\"\" title=\"Caption\" />" +
-                    "<figcaption data-element-label=\"1.1\" data-localized-kind=\"Figura\">Caption</figcaption>" +
+                    "<figcaption class=\"caption-bottom\" data-element-label=\"1.1\" data-localized-kind=\"Figura\">Caption</figcaption>" +
                     "</figure>" +
                     "<table id=\"table-1.a\"><thead><tr><th>A</th><th>B</th><th>C</th></tr></thead>" +
                     "<tbody><tr><td>D</td><td>E</td><td>F</td></tr></tbody>" +
-                    "<caption data-element-label=\"1.a\" data-localized-kind=\"Tabella\">Caption</caption></table>",
+                    "<caption class=\"caption-bottom\" data-element-label=\"1.a\" data-localized-kind=\"Tabella\">Caption</caption></table>",
                 it,
             )
         }

--- a/quarkdown-test/src/test/kotlin/com/quarkdown/test/TableComputationTest.kt
+++ b/quarkdown-test/src/test/kotlin/com/quarkdown/test/TableComputationTest.kt
@@ -22,9 +22,13 @@ class TableComputationTest {
     private val lisa = "<tr><td>Lisa</td><td>32</td><td>LA</td></tr>"
     private val mike = "<tr><td>Mike</td><td>19</td><td>CHI</td></tr>"
 
-    private fun htmlTable(htmlContent: String) =
-        "<table><thead><tr><th>Name</th><th>Age</th><th>City</th></tr></thead>" +
-            "<tbody>$htmlContent</tbody></table>"
+    private fun htmlTable(
+        htmlContent: String,
+        caption: String? = null,
+    ) = "<table><thead><tr><th>Name</th><th>Age</th><th>City</th></tr></thead>" +
+        "<tbody>$htmlContent</tbody>" +
+        (caption?.let { "<caption class=\"caption-bottom\">$it</caption>" } ?: "") +
+        "</table>"
 
     @Test
     fun `plain sorting, ascending`() {
@@ -104,6 +108,19 @@ class TableComputationTest {
         execute(".csv {csv/people.csv}") {
             assertEquals(
                 htmlTable(john + lisa + mike),
+                it,
+            )
+        }
+    }
+
+    @Test
+    fun `csv with caption`() {
+        execute(".csv {csv/people.csv} caption:{People}") {
+            assertEquals(
+                htmlTable(
+                    john + lisa + mike,
+                    caption = "People",
+                ),
                 it,
             )
         }


### PR DESCRIPTION
This PR introduces the `.captionposition` function which overrides the global position (top/bottom) of captions, relative to the content they describe.

It accepts a `default` argument which applies the changes to all kinds of caption, plus node-specific `figures` and `tables` arguments.