### PR TITLE
Fix multiline headings wrapping around their number

### DIFF
--- a/quarkdown-html/src/main/resources/render/theme/global.css
+++ b/quarkdown-html/src/main/resources/render/theme/global.css
@@ -425,6 +425,8 @@ body.quarkdown-paged:not(:has(.pagedjs_page)) {
     font-family: var(--qd-heading-font);
     margin: var(--qd-heading-margin);
     text-transform: none !important;
+    display: flex;
+    flex-direction: row;
 }
 
 .quarkdown-slides section > :is(h1, h2, h3, h4, h5, h6):first-child {

--- a/quarkdown-html/src/main/resources/render/theme/layout/beamer.css
+++ b/quarkdown-html/src/main/resources/render/theme/layout/beamer.css
@@ -103,6 +103,10 @@
     border: 0.1em solid;
 }
 
+[data-location]::before {
+    padding-right: 1rem;
+}
+
 /* Table of contents */
 
 .quarkdown nav a:not(:hover) {

--- a/quarkdown-html/src/main/resources/render/theme/layout/latex.css
+++ b/quarkdown-html/src/main/resources/render/theme/layout/latex.css
@@ -191,7 +191,7 @@ blockquote {
 }
 
 [data-location]::before {
-    padding-right: 0.85rem;
+    padding-right: 2.15rem;
 }
 
 /* Table of contents */


### PR DESCRIPTION
This PR fixes multiline headings wrapping around their location number, if numbering is enabled.