### PR TITLE
Fix error on webserver shutdown

### DIFF
--- a/quarkdown-server/src/main/kotlin/com/quarkdown/server/LocalFileWebServer.kt
+++ b/quarkdown-server/src/main/kotlin/com/quarkdown/server/LocalFileWebServer.kt
@@ -78,7 +78,6 @@ class LocalFileWebServer(
                         }
                     }.onFailure { exception ->
                         log.error("WebSocket error: ${exception.message}")
-                    }.also {
                         job.cancel()
                     }
                 }


### PR DESCRIPTION
This PR fixes an error that may be thrown when forcely shutting down Quarkdown's webserver. 