### PR TITLE
Add `.paragraphstyle`

### DIFF
--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/document/layout/DocumentLayoutInfo.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/document/layout/DocumentLayoutInfo.kt
@@ -2,14 +2,17 @@ package com.quarkdown.core.document.layout
 
 import com.quarkdown.core.document.layout.caption.CaptionPositionInfo
 import com.quarkdown.core.document.layout.page.PageFormatInfo
+import com.quarkdown.core.document.layout.paragraph.ParagraphStyleInfo
 
 /**
  * Mutable information about the layout options of a document.
  * When any of the fields is `null`, the default value supplied by the underlying renderer is used.
  * @param pageFormat format of the pages of the document
+ * @param paragraphStyle style of paragraphs in the document
  * @param captionPosition position of captions of figures, tables, and more in the document
  */
 data class DocumentLayoutInfo(
     val pageFormat: PageFormatInfo = PageFormatInfo(),
+    val paragraphStyle: ParagraphStyleInfo = ParagraphStyleInfo(),
     val captionPosition: CaptionPositionInfo = CaptionPositionInfo(),
 )

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/document/layout/paragraph/ParagraphStyleInfo.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/document/layout/paragraph/ParagraphStyleInfo.kt
@@ -1,14 +1,12 @@
 package com.quarkdown.core.document.layout.paragraph
 
-import com.quarkdown.core.document.size.Size
-
 /**
  * Mutable information about the style of paragraphs in a document.
  * When any of the fields is `null`, the default value supplied by the underlying renderer is used.
- * @param spacing whitespace between paragraphs
- * @param indent whitespace at the start of each paragraph (following LaTeX's convention)
+ * @param spacing whitespace between paragraphs, multiplied by the font size
+ * @param indent whitespace at the start of each paragraph, following LaTeX's policy, multiplied by the font size
  */
 data class ParagraphStyleInfo(
-    var spacing: Size? = null,
-    var indent: Size? = null,
+    var spacing: Double? = null,
+    var indent: Double? = null,
 )

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/document/layout/paragraph/ParagraphStyleInfo.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/document/layout/paragraph/ParagraphStyleInfo.kt
@@ -1,0 +1,14 @@
+package com.quarkdown.core.document.layout.paragraph
+
+import com.quarkdown.core.document.size.Size
+
+/**
+ * Mutable information about the style of paragraphs in a document.
+ * When any of the fields is `null`, the default value supplied by the underlying renderer is used.
+ * @param spacing whitespace between paragraphs
+ * @param indent whitespace at the start of each paragraph (following LaTeX's convention)
+ */
+data class ParagraphStyleInfo(
+    var spacing: Size? = null,
+    var indent: Size? = null,
+)

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/rendering/template/TemplatePlaceholders.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/rendering/template/TemplatePlaceholders.kt
@@ -88,6 +88,16 @@ object TemplatePlaceholders {
     const val HORIZONTAL_ALIGNMENT = "HALIGNMENT"
 
     /**
+     * Whitespace height between paragraphs.
+     */
+    const val PARAGRAPH_SPACING = "PARAGRAPHSPACING"
+
+    /**
+     * Indentation width of the first line of paragraphs.
+     */
+    const val PARAGRAPH_INDENT = "PARAGRAPHINDENT"
+
+    /**
      * Custom user-defined TeX macros.
      */
     const val TEX_MACROS = "TEXMACRO"

--- a/quarkdown-html/src/main/kotlin/com/quarkdown/rendering/html/post/HtmlPostRenderer.kt
+++ b/quarkdown-html/src/main/kotlin/com/quarkdown/rendering/html/post/HtmlPostRenderer.kt
@@ -56,17 +56,17 @@ class HtmlPostRenderer(
                     ?.serverPort,
             )
             // Document metadata.
-            value(TemplatePlaceholders.TITLE, context.documentInfo.name ?: "Quarkdown")
-            optionalValue(TemplatePlaceholders.LANGUAGE, context.documentInfo.locale?.tag)
+            val document = context.documentInfo
+            value(TemplatePlaceholders.TITLE, document.name ?: "Quarkdown")
+            optionalValue(TemplatePlaceholders.LANGUAGE, document.locale?.tag)
             value(
                 TemplatePlaceholders.DOCUMENT_TYPE,
-                context.documentInfo.type.name
-                    .lowercase(),
+                document.type.name.lowercase(),
             )
             // "Paged" document rendering via PagesJS.
-            conditional(TemplatePlaceholders.IS_PAGED, context.documentInfo.type == DocumentType.PAGED)
+            conditional(TemplatePlaceholders.IS_PAGED, document.type == DocumentType.PAGED)
             // "Slides" document rendering via RevealJS.
-            conditional(TemplatePlaceholders.IS_SLIDES, context.documentInfo.type == DocumentType.SLIDES)
+            conditional(TemplatePlaceholders.IS_SLIDES, document.type == DocumentType.SLIDES)
             // HighlightJS is initialized only if needed.
             conditional(
                 TemplatePlaceholders.HAS_CODE,
@@ -83,7 +83,7 @@ class HtmlPostRenderer(
                 context.attributes.hasMath,
             )
             // Page format.
-            val pageFormat = context.documentInfo.layout.pageFormat
+            val pageFormat = document.layout.pageFormat
             conditional(TemplatePlaceholders.HAS_PAGE_SIZE, pageFormat.hasSize)
             optionalValue(
                 TemplatePlaceholders.PAGE_WIDTH,
@@ -107,11 +107,13 @@ class HtmlPostRenderer(
             )
             optionalValue(
                 TemplatePlaceholders.PARAGRAPH_SPACING,
-                "15em",
+                document.layout.paragraphStyle.spacing
+                    ?.asCSS,
             )
             optionalValue(
                 TemplatePlaceholders.PARAGRAPH_INDENT,
-                "15em",
+                document.layout.paragraphStyle.indent
+                    ?.asCSS,
             )
             iterable(
                 TemplatePlaceholders.TEX_MACROS,

--- a/quarkdown-html/src/main/kotlin/com/quarkdown/rendering/html/post/HtmlPostRenderer.kt
+++ b/quarkdown-html/src/main/kotlin/com/quarkdown/rendering/html/post/HtmlPostRenderer.kt
@@ -108,12 +108,14 @@ class HtmlPostRenderer(
             optionalValue(
                 TemplatePlaceholders.PARAGRAPH_SPACING,
                 document.layout.paragraphStyle.spacing
-                    ?.asCSS,
+                    ?.toString()
+                    ?.plus("em"),
             )
             optionalValue(
                 TemplatePlaceholders.PARAGRAPH_INDENT,
                 document.layout.paragraphStyle.indent
-                    ?.asCSS,
+                    ?.toString()
+                    ?.plus("em"),
             )
             iterable(
                 TemplatePlaceholders.TEX_MACROS,

--- a/quarkdown-html/src/main/kotlin/com/quarkdown/rendering/html/post/HtmlPostRenderer.kt
+++ b/quarkdown-html/src/main/kotlin/com/quarkdown/rendering/html/post/HtmlPostRenderer.kt
@@ -105,6 +105,14 @@ class HtmlPostRenderer(
                 TemplatePlaceholders.HORIZONTAL_ALIGNMENT,
                 pageFormat.alignment?.asCSS,
             )
+            optionalValue(
+                TemplatePlaceholders.PARAGRAPH_SPACING,
+                "15em",
+            )
+            optionalValue(
+                TemplatePlaceholders.PARAGRAPH_INDENT,
+                "15em",
+            )
             iterable(
                 TemplatePlaceholders.TEX_MACROS,
                 mapToJsObjectEntries(context.documentInfo.tex.macros),

--- a/quarkdown-html/src/main/resources/render/html-wrapper.html.template
+++ b/quarkdown-html/src/main/resources/render/html-wrapper.html.template
@@ -79,6 +79,11 @@
             [[if:PAGESIZE]]size: [[PAGEWIDTH]] [[PAGEHEIGHT]];[[endif:PAGESIZE]]
             [[if:PAGEMARGIN]]margin: [[PAGEMARGIN]];[[endif:PAGEMARGIN]]
         }
+
+        p {
+            [[if:PARAGRAPHSPACING]]--qd-paragraph-vertical-margin: [[PARAGRAPHSPACING]];[[endif:PARAGRAPHSPACING]]
+            [[if:PARAGRAPHINDENT]]--qd-paragraph-text-indent: [[PARAGRAPHINDENT]];[[endif:PARAGRAPHINDENT]]
+        }
     </style>
 </head>
 <body class="quarkdown quarkdown-[[DOCTYPE]]">

--- a/quarkdown-html/src/main/resources/render/theme/global.css
+++ b/quarkdown-html/src/main/resources/render/theme/global.css
@@ -440,6 +440,7 @@ body.quarkdown-paged:not(:has(.pagedjs_page)) {
     line-height: var(--qd-line-height);
     margin-top: 0;
     margin-bottom: 0;
+    text-indent: 2em;
 }
 
 /* Syllables-based word break */
@@ -458,6 +459,28 @@ p + .float + p:not(.stack > p):not(.page-margin-content > p),
 /* Spacing between the paragraph and its floating element sibling. */
 p + .float:has(+ p:not(.stack > p):not(.page-margin-content > p)) {
     margin-top: var(--qd-paragraph-vertical-margin) !important;
+}
+
+/* Paragraph indentation cancelling */
+p:first-child,
+h1 + p,
+h2 + p,
+h3 + p,
+h4 + p,
+h5 + p,
+h6 + p,
+hr + p,
+figure + p,
+table + p,
+details > summary + p,
+.float + p,
+figure p,
+.stack > p,
+.container[style*="text-align"] > p,
+.container[style*="justify-items"] > p,
+.mermaid p
+{
+    text-indent: 0 !important;
 }
 
 .float[style*="float: inline-start"] {

--- a/quarkdown-html/src/main/resources/render/theme/global.css
+++ b/quarkdown-html/src/main/resources/render/theme/global.css
@@ -31,6 +31,7 @@
 
     /* Text */
     --qd-line-height: 1.5;
+    --qd-paragraph-text-indent: none; /* Paragraph indentation (with LaTeX policies) */
     --qd-location-suffix: ". "; /* Suffix for element (e.g. headings) location numbering */
     --qd-caption-label-suffix: ": "; /* Suffix for labels (e.g. Figure 1.1: ...) in captions */
     --qd-slides-horizontal-alignment: center; /* Text alignment of slides documents */
@@ -440,7 +441,7 @@ body.quarkdown-paged:not(:has(.pagedjs_page)) {
     line-height: var(--qd-line-height);
     margin-top: 0;
     margin-bottom: 0;
-    text-indent: 2em;
+    text-indent: var(--qd-paragraph-text-indent);
 }
 
 /* Syllables-based word break */

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Document.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Document.kt
@@ -52,6 +52,7 @@ val Document: Module =
         ::theme,
         ::numbering,
         ::disableNumbering,
+        ::paragraphStyle,
         ::captionPosition,
         ::texMacro,
         ::pageFormat,
@@ -309,6 +310,27 @@ fun numbering(
 fun disableNumbering(
     @Injected context: Context,
 ) = numbering(context, emptyMap())
+
+/**
+ * Sets the global style of paragraphs in the document.
+ * If a value is `null`, the default value supplied by the underlying renderer is used.
+ * @param spacing whitespace between paragraphs, multiplied by the font size.
+ * @param indent whitespace at the start of each paragraph, multiplied by the font size.
+ *               LaTeX's policy is used: indenting the first line of paragraphs, except the first one and aligned ones.
+ * @wiki Paragraph style
+ */
+@Name("paragraphstyle")
+fun paragraphStyle(
+    @Injected context: Context,
+    spacing: Number? = null,
+    indent: Number? = null,
+): VoidValue {
+    with(context.documentInfo.layout.paragraphStyle) {
+        this.spacing = spacing?.toDouble() ?: this.spacing
+        this.indent = indent?.toDouble() ?: this.indent
+    }
+    return VoidValue
+}
 
 /**
  * Sets the position of captions, relative to the content they describe.

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Document.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Document.kt
@@ -313,7 +313,7 @@ fun disableNumbering(
 
 /**
  * Sets the global style of paragraphs in the document.
- * If a value is `null`, the default value supplied by the underlying renderer is used.
+ * If a value is unset, the default value supplied by the underlying renderer is used.
  * @param spacing whitespace between paragraphs, multiplied by the font size.
  * @param indent whitespace at the start of each paragraph, multiplied by the font size.
  *               LaTeX's policy is used: indenting the first line of paragraphs, except the first one and aligned ones.

--- a/quarkdown-test/src/test/kotlin/com/quarkdown/test/DocumentTest.kt
+++ b/quarkdown-test/src/test/kotlin/com/quarkdown/test/DocumentTest.kt
@@ -34,6 +34,8 @@ class DocumentTest {
             assertNull(documentInfo.name)
             assertEquals(0, documentInfo.authors.size)
             assertNull(documentInfo.locale)
+            assertNull(documentInfo.layout.pageFormat.pageWidth)
+            assertNull(documentInfo.layout.paragraphStyle.spacing)
         }
     }
 
@@ -52,6 +54,7 @@ class DocumentTest {
             .doclang {english}
             .theme {darko} layout:{minimal}
             .pageformat {A3} orientation:{landscape} margin:{3cm 2px} columns:{4} alignment:{end}
+            .paragraphstyle spacing:{1.5} indent:{2}
             .slides transition:{zoom} speed:{fast}
             .autopagebreak maxdepth:{3}
             """.trimIndent(),


### PR DESCRIPTION
This PR introduces the `.paragraphstyle` function, which gives access to customization of paragraph spacing and indentation. For instance, `.paragraphstyle spacing:{0} indent:{2}` gives the LaTeX classic look.