### PR TITLE
fix: add ParameterAlreadyBoundException (closes #56)

### DIFF
--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/function/call/FunctionCallArgument.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/function/call/FunctionCallArgument.kt
@@ -28,6 +28,11 @@ data class FunctionCallArgument(
 }
 
 /**
- * @return a string representation of a sequence of arguments
+ * @return a string representation of [this] argument's value
  */
-fun List<FunctionCallArgument>.asString() = "(" + joinToString { it.value.unwrappedValue.toString() } + ")"
+fun FunctionCallArgument.asString() = value.unwrappedValue.toString()
+
+/**
+ * @return a string representation of [this] sequence of arguments
+ */
+fun List<FunctionCallArgument>.asString() = "(" + joinToString { it.asString() } + ")"

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/function/error/ParameterAlreadyBoundException.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/function/error/ParameterAlreadyBoundException.kt
@@ -1,0 +1,21 @@
+package com.quarkdown.core.function.error
+
+import com.quarkdown.core.function.FunctionParameter
+import com.quarkdown.core.function.call.FunctionCall
+import com.quarkdown.core.function.call.FunctionCallArgument
+import com.quarkdown.core.function.call.asString
+
+/**
+ * An exception thrown if a function parameter is bound more than once in a function call.
+ * @param call the invalid call
+ * @param parameter the parameter that was attempted to be bound again
+ * @param overriddingArgument the argument that was attempted to be bound to the already bound parameter
+ */
+class ParameterAlreadyBoundException(
+    call: FunctionCall<*>,
+    parameter: FunctionParameter<*>,
+    overriddingArgument: FunctionCallArgument,
+) : InvalidFunctionCallException(
+        call,
+        reason = "parameter '${parameter.name}' is already bound, but was attempted to be bound again to ${overriddingArgument.asString()}",
+    )

--- a/quarkdown-core/src/test/kotlin/com/quarkdown/core/StandaloneFunctionTest.kt
+++ b/quarkdown-core/src/test/kotlin/com/quarkdown/core/StandaloneFunctionTest.kt
@@ -15,6 +15,7 @@ import com.quarkdown.core.function.call.validate.FunctionCallValidator
 import com.quarkdown.core.function.error.InvalidArgumentCountException
 import com.quarkdown.core.function.error.InvalidFunctionCallException
 import com.quarkdown.core.function.error.NoSuchElementException
+import com.quarkdown.core.function.error.ParameterAlreadyBoundException
 import com.quarkdown.core.function.error.UnnamedArgumentAfterNamedException
 import com.quarkdown.core.function.error.UnresolvedParameterException
 import com.quarkdown.core.function.expression.ComposedExpression
@@ -454,6 +455,25 @@ class StandaloneFunctionTest {
             )
 
         assertEquals(6, call3.execute().unwrappedValue)
+    }
+
+    @Test
+    fun `KFunction parameter bound twice`() {
+        val function = KFunctionAdapter(::sum)
+
+        val call1 =
+            FunctionCall(
+                function,
+                arguments =
+                    listOf(
+                        FunctionCallArgument(DynamicValue("5")),
+                        FunctionCallArgument(DynamicValue("2"), name = "a"),
+                    ),
+            )
+
+        assertFailsWith<ParameterAlreadyBoundException> {
+            call1.execute()
+        }
     }
 
     @Test

--- a/quarkdown-test/src/test/kotlin/com/quarkdown/test/FunctionCallTest.kt
+++ b/quarkdown-test/src/test/kotlin/com/quarkdown/test/FunctionCallTest.kt
@@ -4,6 +4,7 @@ import com.quarkdown.core.ast.attributes.presence.hasCode
 import com.quarkdown.core.ast.attributes.presence.hasMath
 import com.quarkdown.core.function.error.InvalidArgumentCountException
 import com.quarkdown.core.function.error.InvalidFunctionCallException
+import com.quarkdown.core.function.error.ParameterAlreadyBoundException
 import com.quarkdown.core.function.error.UnresolvedReferenceException
 import com.quarkdown.core.pipeline.error.BasePipelineErrorHandler
 import com.quarkdown.test.util.execute
@@ -76,6 +77,20 @@ class FunctionCallTest {
 
         assertFailsWith<InvalidArgumentCountException> {
             execute(".sum {2} {5} {9}") {}
+        }
+    }
+
+    @Test
+    fun `error positional parameter already bound`() {
+        assertFailsWith<ParameterAlreadyBoundException> {
+            execute(".sum {2} a:{3}") {}
+        }
+    }
+
+    @Test
+    fun `error named parameter already bound`() {
+        assertFailsWith<ParameterAlreadyBoundException> {
+            execute(".sum a:{2} a:{3}") {}
         }
     }
 


### PR DESCRIPTION
This PR adds a new error that is thrown when a function parameter is bound to more than one argument in a call.

For instance, a function `f(a, b)` can cause this error when it's called via `.f {x} a:{y}` or `.f a:{x} a:{y}`.