### PR TITLE
docs: add links to other language versions of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,19 @@
   &nbsp; | &nbsp;
   <strong><a href="https://github.com/iamgio/quarkdown/releases/latest">Stable</a></strong>&nbsp;
   <br>
+  <br>
+  <strong>Translated</strong>
+  <br>
+  <!-- Keep these links. Translations will automatically update with the README. -->
+  <a href="https://www.readme-i18n.com/iamgio/quarkdown?lang=de">Deutsch</a> | 
+  <a href="https://www.readme-i18n.com/iamgio/quarkdown?lang=es">Español</a> | 
+  <a href="https://www.readme-i18n.com/iamgio/quarkdown?lang=fr">français</a> | 
+  <a href="https://www.readme-i18n.com/iamgio/quarkdown?lang=ja">日本語</a> | 
+  <a href="https://www.readme-i18n.com/iamgio/quarkdown?lang=ko">한국어</a> | 
+  <a href="https://www.readme-i18n.com/iamgio/quarkdown?lang=pt">Português</a> | 
+  <a href="https://www.readme-i18n.com/iamgio/quarkdown?lang=ru">Русский</a> | 
+  <a href="https://www.readme-i18n.com/iamgio/quarkdown?lang=zh">中文</a>
+  <br>
   <hr>
 </p>
 


### PR DESCRIPTION
Added language selection links to the README for easier access to translated versions: German, Spanish, French, Japanese, Korean, Portuguese, Russian, and Chinese.

The updated can be previewed in my forked repository: https://github.com/dowithless/quarkdown/tree/patch-1