### PR TITLE
fix(wrapper): Output variable name instead of value

### DIFF
--- a/quarkdown-interaction/src/main/kotlin/com/quarkdown/interaction/Env.kt
+++ b/quarkdown-interaction/src/main/kotlin/com/quarkdown/interaction/Env.kt
@@ -4,7 +4,7 @@ package com.quarkdown.interaction
  * Environment variables that may affect the `interaction` module.
  */
 object Env {
-    private const val QUARKDOWN_NPM_PREFIX = "QD_NPM_PREFIX"
+    const val QUARKDOWN_NPM_PREFIX = "QD_NPM_PREFIX"
     private const val NODE_PATH = "NODE_PATH"
 
     private operator fun get(key: String): String? = System.getenv(key)

--- a/quarkdown-interaction/src/main/kotlin/com/quarkdown/interaction/executable/NodeModule.kt
+++ b/quarkdown-interaction/src/main/kotlin/com/quarkdown/interaction/executable/NodeModule.kt
@@ -20,7 +20,8 @@ class NodeModuleNotInstalledException(
         """
         Module '${module.name}' is not installed. Please install it via `npm install ${module.name} --prefix $${Env.QUARKDOWN_NPM_PREFIX}` and retry.
         Make sure ${Env.QUARKDOWN_NPM_PREFIX} is an environment variable pointing to Quarkdown's `lib` directory or any other installation directory,
-        and it must be available at Quarkdown's launch.
+        and it must be available at Quarkdown's launch. The current value is '${Env.npmPrefix}'. Note that '/node_modules' is automatically appended
+        to this path, so if your system has modules installed in '/usr/lib/node_modules', use '/usr/lib'.
         
         For more information, see: https://github.com/iamgio/quarkdown/wiki/pdf-export
         

--- a/quarkdown-interaction/src/main/kotlin/com/quarkdown/interaction/executable/NodeModule.kt
+++ b/quarkdown-interaction/src/main/kotlin/com/quarkdown/interaction/executable/NodeModule.kt
@@ -18,8 +18,8 @@ class NodeModuleNotInstalledException(
     module: NodeModule,
 ) : IllegalStateException(
         """
-        Module '${module.name}' is not installed. Please install it via `npm install ${module.name} --prefix $${Env.npmPrefix}` and retry.
-        Make sure ${Env.npmPrefix} is an environment variable pointing to Quarkdown's `lib` directory or any other installation directory,
+        Module '${module.name}' is not installed. Please install it via `npm install ${module.name} --prefix $${Env.QUARKDOWN_NPM_PREFIX}` and retry.
+        Make sure ${Env.QUARKDOWN_NPM_PREFIX} is an environment variable pointing to Quarkdown's `lib` directory or any other installation directory,
         and it must be available at Quarkdown's launch.
         
         For more information, see: https://github.com/iamgio/quarkdown/wiki/pdf-export


### PR DESCRIPTION
Trying to work out AUR packaging, the first thing I hit was this error:

> Make sure null is an environment variable pointing to Quarkdown's `lib` directory or any other installation directory,

Obiviously the *value* of the variable (which in my case was not set) was used where you meant the variable name. Obviously untested.

I don't actually know if this is the right way to *fix* this problem, I just made something up that sounded plausable. Please do feel free to edit this PR to actually fix the problem properly. Draft made is because this is not tested.
