### PR TITLE
chore(cli): make `c` alias for `compile`

### DIFF
--- a/quarkdown-cli/src/main/kotlin/com/quarkdown/cli/QuarkdownCli.kt
+++ b/quarkdown-cli/src/main/kotlin/com/quarkdown/cli/QuarkdownCli.kt
@@ -12,6 +12,8 @@ import com.quarkdown.cli.server.StartWebServerCommand
  * Main command of Quarkdown CLI, which delegates to subcommands.
  */
 class QuarkdownCommand : CliktCommand() {
+    override fun aliases() = mapOf("c" to listOf(CompileCommand().commandName))
+
     override fun run() {}
 }
 

--- a/quarkdown-cli/src/main/kotlin/com/quarkdown/cli/exec/CompileCommand.kt
+++ b/quarkdown-cli/src/main/kotlin/com/quarkdown/cli/exec/CompileCommand.kt
@@ -17,7 +17,7 @@ import java.io.File
  * Command to compile a Quarkdown file into an output.
  * @see FileExecutionStrategy
  */
-class CompileCommand : ExecuteCommand("c") {
+class CompileCommand : ExecuteCommand("compile") {
     /**
      * Quarkdown source file to process.
      */


### PR DESCRIPTION
This PR makes `compile` the base subcommand to compile source files. `c` is now an alias (still preferred).