### PR TITLE
fix: excessive justification

### DIFF
--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/quarkdown/block/Container.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/quarkdown/block/Container.kt
@@ -59,13 +59,25 @@ class Container(
 
     /**
      * Possible alignment types of a [Container].
+     * @param isLocal whether this alignment should be applied only to specific element types in the document,
+     *                rather than globally to the entire document
      */
-    enum class TextAlignment : RenderRepresentable {
+    enum class TextAlignment(
+        val isLocal: Boolean = false,
+    ) : RenderRepresentable {
         START,
         CENTER,
         END,
-        JUSTIFY,
+        JUSTIFY(isLocal = true),
         ;
+
+        /**
+         * Whether this alignment is applied globally to the document. This is complementary to [isLocal].
+         * If true, it will be applied to all elements in the document.
+         * If false, it will only be applied to specific elements that support this alignment.
+         */
+        val isGlobal: Boolean
+            get() = !isLocal
 
         override fun <T> accept(visitor: RenderRepresentableVisitor<T>): T = visitor.visit(this)
 

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/rendering/template/TemplatePlaceholders.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/rendering/template/TemplatePlaceholders.kt
@@ -99,8 +99,17 @@ object TemplatePlaceholders {
 
     /**
      * Horizontal content alignment of each page.
+     * This is applied globally to all elements in the document.
+     * For instance: start, center, end.
      */
-    const val HORIZONTAL_ALIGNMENT = "HALIGNMENT"
+    const val GLOBAL_HORIZONTAL_ALIGNMENT = "HALIGNMENT_GLOBAL"
+
+    /**
+     * Horizontal content alignment of each page.
+     * This is applied locally to selected elements in the document.
+     * For instance: justify.
+     */
+    const val LOCAL_HORIZONTAL_ALIGNMENT = "HALIGNMENT_LOCAL"
 
     /**
      * Line height of paragraphs.

--- a/quarkdown-html/src/main/kotlin/com/quarkdown/rendering/html/post/HtmlPostRenderer.kt
+++ b/quarkdown-html/src/main/kotlin/com/quarkdown/rendering/html/post/HtmlPostRenderer.kt
@@ -111,9 +111,14 @@ class HtmlPostRenderer(
                 TemplatePlaceholders.COLUMN_COUNT,
                 pageFormat.columnCount,
             )
+            // Alignment can be global or local. See TemplatePlaceholders.GLOBAL_HORIZONTAL_ALIGNMENT for details.
             optionalValue(
-                TemplatePlaceholders.HORIZONTAL_ALIGNMENT,
-                pageFormat.alignment?.asCSS,
+                TemplatePlaceholders.GLOBAL_HORIZONTAL_ALIGNMENT,
+                pageFormat.alignment?.takeIf { it.isGlobal }?.asCSS,
+            )
+            optionalValue(
+                TemplatePlaceholders.LOCAL_HORIZONTAL_ALIGNMENT,
+                pageFormat.alignment?.takeIf { it.isLocal }?.asCSS,
             )
             optionalValue(
                 TemplatePlaceholders.PARAGRAPH_SPACING,

--- a/quarkdown-html/src/main/resources/render/html-wrapper.html.template
+++ b/quarkdown-html/src/main/resources/render/html-wrapper.html.template
@@ -53,11 +53,14 @@
     <style>
         body {
             [[if:COLUMNCOUNT]]--property-column-count: [[COLUMNCOUNT]];[[endif:COLUMNCOUNT]]
-            [[if:HALIGNMENT]]
-            --qd-slides-horizontal-alignment: [[HALIGNMENT]];
-            --qd-paged-horizontal-alignment: [[HALIGNMENT]];
-            text-align: [[HALIGNMENT]];
-            [[endif:HALIGNMENT]]
+            [[if:HALIGNMENT_LOCAL]]
+            --qd-horizontal-alignment-local: [[HALIGNMENT_LOCAL]] !important;
+            --qd-horizontal-alignment-global: unset !important;
+            [[endif:HALIGNMENT_LOCAL]]
+            [[if:HALIGNMENT_GLOBAL]]
+            --qd-horizontal-alignment-global: [[HALIGNMENT_GLOBAL]] !important;
+            --qd-horizontal-alignment-local: unset !important;
+            [[endif:HALIGNMENT_GLOBAL]]
             [[if:PAGEBORDERWIDTH]]
             --qd-page-content-border-width: [[PAGEBORDERWIDTH]];
             --qd-page-content-border-style: solid;

--- a/quarkdown-html/src/main/resources/render/theme/components/_alignment.scss
+++ b/quarkdown-html/src/main/resources/render/theme/components/_alignment.scss
@@ -1,0 +1,20 @@
+.quarkdown {
+  text-align: var(--qd-horizontal-alignment-global);
+
+  // Local alignment (e.g. justification) is applied to specific elements instead of the whole document.
+  p, li, caption, figcaption {
+    text-align: var(--qd-horizontal-alignment-local);
+  }
+}
+
+.quarkdown-slides {
+  --qd-horizontal-alignment-global: center;
+
+  .reveal .slides > :is(section, .pdf-page) {
+    text-align: var(--qd-horizontal-alignment-global);
+  }
+}
+
+.quarkdown-plain, .quarkdown-paged {
+  --qd-horizontal-alignment-local: justify;
+}

--- a/quarkdown-html/src/main/resources/render/theme/components/_box.scss
+++ b/quarkdown-html/src/main/resources/render/theme/components/_box.scss
@@ -87,7 +87,7 @@
       display: flex;
       flex-direction: row;
       align-items: center; // Align icons
-      justify-content: var(--qd-horizontal-alignment);
+      justify-content: var(--qd-horizontal-alignment-global);
 
       &::before {
         content: $icon;

--- a/quarkdown-html/src/main/resources/render/theme/components/_viewport.scss
+++ b/quarkdown-html/src/main/resources/render/theme/components/_viewport.scss
@@ -9,7 +9,6 @@ body.quarkdown {
   color: var(--qd-main-color);
   font-family: var(--qd-main-font), serif;
   font-size: var(--qd-main-font-size);
-  text-align: var(--qd-horizontal-alignment);
 
   &:not(.quarkdown-paged), &.quarkdown-paged .pagedjs_page {
     background-color: var(--qd-background-color);
@@ -21,16 +20,11 @@ body.quarkdown {
   }
 
   // Slides viewport
-  &.quarkdown-slides {
-    --qd-horizontal-alignment: var(--qd-slides-horizontal-alignment);
+  &.quarkdown-slides .reveal .slides {
+    @include content-area-border;
 
-    .reveal .slides {
-      @include content-area-border;
-
-      > :is(section, .pdf-page) {
-        text-align: var(--qd-slides-horizontal-alignment);
-        column-count: var(--property-column-count);
-      }
+    > section, .pdf-page {
+      column-count: var(--property-column-count);
     }
   }
 
@@ -51,7 +45,6 @@ body.quarkdown {
     }
 
     .pagedjs_page {
-      text-align: var(--qd-paged-horizontal-alignment);
       box-shadow: 0 16px 48px rgba(0, 0, 0, 0.1);
     }
 

--- a/quarkdown-html/src/main/resources/render/theme/global.scss
+++ b/quarkdown-html/src/main/resources/render/theme/global.scss
@@ -1,4 +1,5 @@
 @use "components/viewport";
+@use "components/alignment";
 @use "components/block";
 @use "components/heading";
 @use "components/paragraph";
@@ -67,14 +68,13 @@
   --qd-paragraph-text-indent: none; // Paragraph indentation (with LaTeX policies)
   --qd-location-suffix: ". "; // Suffix for element (e.g. headings) location numbering
   --qd-caption-label-suffix: ": "; // Suffix for labels (e.g. Figure 1.1: ...) in captions
-  --qd-slides-horizontal-alignment: center; // Text alignment of slides documents
-  --qd-paged-horizontal-alignment: justify; // Text alignment of paged documents
-  /*
-  Global text alignment (should not be overridden externally).
-  It can equal to either --qd-pages-horizontal-alignment or --qd-slides-horizontal-alignment
-  according to the current document type.
-  */
-  --qd-horizontal-alignment: var(--qd-paged-horizontal-alignment);
+
+  // Global horizontal alignment of content.
+  // This is applied to all elements in the document.
+  --qd-horizontal-alignment-global: var(--qd-paged-horizontal-alignment-global);
+  // Local horizontal alignment of content.
+  // This is applied only to selected elements in the document (e.g. justification).
+  --qd-horizontal-alignment-local: var(--qd-paged-horizontal-alignment-local);
 
   // Code
   --qd-code-line-height: var(--qd-line-height); // Line height of code blocks

--- a/quarkdown-html/src/main/resources/render/theme/layout/beamer.scss
+++ b/quarkdown-html/src/main/resources/render/theme/layout/beamer.scss
@@ -17,7 +17,10 @@
   --qd-slides-code-block-font-size: 1.25em;
   --qd-block-margin: 32px;
   --qd-box-margin-multiplier: 1.2;
-  --qd-slides-horizontal-alignment: start;
+}
+
+.quarkdown-slides {
+  --qd-horizontal-alignment-global: start;
 }
 
 .quarkdown {

--- a/quarkdown-html/src/main/resources/render/theme/layout/latex.scss
+++ b/quarkdown-html/src/main/resources/render/theme/layout/latex.scss
@@ -18,11 +18,14 @@
   --qd-paragraph-vertical-margin: 1.5em;
   --qd-line-height: 1.5;
   --qd-location-suffix: " ";
-  --qd-slides-horizontal-alignment: start;
   --qd-table-default-cell-alignment: start;
   --qd-quote-type-label-suffix: ". ";
   --qd-box-icon-baseline: -0.1em;
   --qd-mermaid-node-filter: drop-shadow(1px 2px var(--qd-mermaid-node-border-color));
+}
+
+.quarkdown-slides {
+  --qd-horizontal-alignment-global: start;
 }
 
 @page {


### PR DESCRIPTION
This PR lets justification apply only to selected elements.

- Fixes extreme justification applied to lists that span over multiple `paged` pages.
- Multiline headings are no longer justified