### PR TITLE
feat: override default paragraph style for Chinese locale

### DIFF
--- a/mock/localization.qd
+++ b/mock/localization.qd
@@ -1,0 +1,14 @@
+# Ad-hoc locale adaptation
+
+Quarkdown can dynamically adapt to different locales.  
+Try changing the document language to *Chinese* in `setup.qd` and see this page magically morph!
+
+---
+
+在這個快速變化的時代，生活節奏越來越快，人們開始重新思考什麼才是真正重要的。無論是城市的喧囂還是鄉間的寧靜，內心的平衡才是追求的目標。
+
+陽光穿過窗戶，灑在舊書的頁面上，時間彷彿靜止了一刻。記憶中的味道、聲音與畫面交織成過去與現在的橋樑。每一次呼吸，都像是與世界重新連結的契機。
+
+當科技不斷前進，我們是否還記得最初的感動？在無數的選擇之中，找到屬於自己的節奏，才能真正走出屬於自己的路。
+
+語言，是連結思想的工具；而文字，則是記錄靈魂的方式。願每一段文字，都是一場靜靜綻放的旅程。

--- a/mock/main.qd
+++ b/mock/main.qd
@@ -23,3 +23,4 @@
     - alignment.qd
     - stacks.qd
     - bibliography.qd
+    - localization.qd

--- a/quarkdown-html/src/main/resources/render/theme/components/_paragraph.scss
+++ b/quarkdown-html/src/main/resources/render/theme/components/_paragraph.scss
@@ -29,7 +29,16 @@ p {
   }
 }
 
-// Paragraph indentation cancelling
+// Paragraphs that don't expect indentation.
+figure p,
+.stack > p,
+.container[style*="text-align"] > p,
+.container[style*="justify-items"] > p,
+.mermaid p {
+  text-indent: 0 !important;
+}
+
+// First paragraphs may not expect indentation, depending on the locale or theme.
 p:first-child,
 h1 + p,
 h2 + p,
@@ -41,11 +50,6 @@ hr + p,
 figure + p,
 table + p,
 details > summary + p,
-.float + p,
-figure p,
-.stack > p,
-.container[style*="text-align"] > p,
-.container[style*="justify-items"] > p,
-.mermaid p {
-  text-indent: 0 !important;
+.float + p {
+  text-indent: var(--qd-first-paragraph-text-indent, 0) !important;
 }

--- a/quarkdown-html/src/main/resources/render/theme/locale/zh.css
+++ b/quarkdown-html/src/main/resources/render/theme/locale/zh.css
@@ -1,3 +1,10 @@
+:root {
+  --qd-localized-font: "Noto Serif SC";
+  --qd-paragraph-text-indent: 2em;
+  --qd-first-paragraph-text-indent: var(--qd-paragraph-text-indent);
+  --qd-paragraph-vertical-margin: 0;
+}
+
 /*
 This is the Noto Serif Simplified Chinese font face.
 Source: https://fonts.googleapis.com/css2?family=Noto+Serif+SC:wght@200..900&display=swap
@@ -898,7 +905,4 @@ Latin characters have been removed to reduce conflicts with the default font.
           U+70B9, U+7684,    /* 点, 的 */
           U+7F51,            /* 网 */
           U+FF0C, U+FF0E, U+FF1A; /* ，．： */
-}
-:root {
-  --qd-localized-font: "Noto Serif SC";
 }

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Document.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Document.kt
@@ -317,6 +317,10 @@ fun disableNumbering(
 /**
  * Sets the global style of paragraphs in the document.
  * If a value is unset, the default value supplied by the underlying renderer is used.
+ *
+ * The default value may also be affected by the current document locale, set via [docLanguage].
+ * For instance, the Chinese `zh` locale prefers a 2em indentation and no vertical spacing.
+ *
  * @param lineHeight height of each line, multiplied by the font size
  * @param letterSpacing whitespace between letters, multiplied by the font size
  * @param spacing whitespace between paragraphs, multiplied by the font size


### PR DESCRIPTION
This PR adds paragraph indentation and removes vertical spacing when the document locale is set to Chinese. 