### PR TITLE
feat(postrenderer): let lists inherit margins and spacing from paragraph spacing

### DIFF
--- a/quarkdown-html/src/main/resources/render/html-wrapper.html.template
+++ b/quarkdown-html/src/main/resources/render/html-wrapper.html.template
@@ -75,6 +75,7 @@
             [[endif:PAGEBORDERCOLOR]]
             [[if:PARAGRAPHLINEHEIGHT]]--qd-line-height: [[PARAGRAPHLINEHEIGHT]];[[endif:PARAGRAPHLINEHEIGHT]]
             [[if:PARAGRAPHLETTERSPACING]]--qd-letter-spacing: [[PARAGRAPHLETTERSPACING]];[[endif:PARAGRAPHLETTERSPACING]]
+            [[if:PARAGRAPHSPACING]]--qd-paragraph-vertical-margin: [[PARAGRAPHSPACING]];[[endif:PARAGRAPHSPACING]]
         }
 
         .page-break {
@@ -104,7 +105,6 @@
         }
 
         p {
-            [[if:PARAGRAPHSPACING]]--qd-paragraph-vertical-margin: [[PARAGRAPHSPACING]];[[endif:PARAGRAPHSPACING]]
             [[if:PARAGRAPHINDENT]]--qd-paragraph-text-indent: [[PARAGRAPHINDENT]];[[endif:PARAGRAPHINDENT]]
         }
     </style>

--- a/quarkdown-html/src/main/resources/render/theme/components/_block.scss
+++ b/quarkdown-html/src/main/resources/render/theme/components/_block.scss
@@ -11,6 +11,12 @@
     margin-bottom: var(--qd-block-margin);
   }
 
+  .box {
+    $margin: calc(var(--qd-block-margin) * var(--qd-box-margin-multiplier));
+    margin-top: $margin;
+    margin-bottom: $margin;
+  }
+
   // Resets the margin of the first element in a page
   .pagedjs_page_content > div > *:first-child,
   .pagedjs_page_content > div > *[data-hidden]:first-child ~ *:nth-child(2) {

--- a/quarkdown-html/src/main/resources/render/theme/components/_box.scss
+++ b/quarkdown-html/src/main/resources/render/theme/components/_box.scss
@@ -3,8 +3,6 @@
 .quarkdown .box {
   width: 100%;
   border-radius: var(--qd-box-border-radius);
-  margin-top: calc(var(--qd-box-margin-multiplier) * var(--qd-block-margin));
-  margin-bottom: calc(var(--qd-box-margin-multiplier) * var(--qd-block-margin));
   --box-background-color: transparent;
   --box-content-foreground-color: var(--qd-main-color);
   --box-header-foreground-color: var(--qd-main-color);

--- a/quarkdown-html/src/main/resources/render/theme/components/_list.scss
+++ b/quarkdown-html/src/main/resources/render/theme/components/_list.scss
@@ -1,5 +1,8 @@
 .quarkdown {
   ul, ol {
+    $margin: calc(var(--qd-paragraph-vertical-margin) / var(--qd-list-margin-divider));
+    margin-top: $margin;
+    margin-bottom: $margin;
     padding-left: 20px;
 
     &:has(> .task-list-item) {
@@ -8,14 +11,15 @@
   }
 
   li {
-    // Not loose
-    margin-top: 0.5em;
-    margin-bottom: 0.5em;
+    // Tight
+    --qd-list-item-margin-divider: 1.4;
+    $margin: calc(var(--qd-paragraph-vertical-margin) / (var(--qd-list-margin-divider) * var(--qd-list-item-margin-divider)));
+    margin-top: $margin;
+    margin-bottom: $margin;
 
     &:has(p) {
       // Loose
-      margin-top: 1em;
-      margin-bottom: 1em;
+      --qd-list-item-margin-divider: 0.7;
     }
 
     // If a list item has a custom bullet element, the actual content is wrapped in a container

--- a/quarkdown-html/src/main/resources/render/theme/components/_list.scss
+++ b/quarkdown-html/src/main/resources/render/theme/components/_list.scss
@@ -1,6 +1,6 @@
 .quarkdown {
   ul, ol {
-    $margin: calc(var(--qd-paragraph-vertical-margin) / var(--qd-list-margin-divider));
+    $margin: calc(var(--qd-paragraph-vertical-margin) * var(--qd-list-margin-multiplier));
     margin-top: $margin;
     margin-bottom: $margin;
     padding-left: 20px;
@@ -12,14 +12,14 @@
 
   li {
     // Tight
-    --qd-list-item-margin-divider: 1.4;
-    $margin: calc(var(--qd-paragraph-vertical-margin) / (var(--qd-list-margin-divider) * var(--qd-list-item-margin-divider)));
+    --qd-list-item-margin-multiplier: 0.75;
+    $margin: calc(var(--qd-paragraph-vertical-margin) * var(--qd-list-margin-multiplier) * var(--qd-list-item-margin-multiplier));
     margin-top: $margin;
     margin-bottom: $margin;
 
     &:has(p) {
       // Loose
-      --qd-list-item-margin-divider: 0.7;
+      --qd-list-item-margin-multiplier: 1.5;
     }
 
     // If a list item has a custom bullet element, the actual content is wrapped in a container

--- a/quarkdown-html/src/main/resources/render/theme/global.scss
+++ b/quarkdown-html/src/main/resources/render/theme/global.scss
@@ -52,10 +52,11 @@
   --qd-localized-font: ""; // Font for specific locales, e.g. Chinese (see locale/zh.scss)
 
   // Margins
-  --qd-block-margin: 32px; // Margin of block elements
+  --qd-block-margin: 2em; // Margin of block elements
   --qd-paragraph-vertical-margin: var(--qd-block-margin); // Vertical margin of paragraphs preceded by a paragraph
   --qd-heading-margin: 40px 0 20px 0; // Margin of headings
   --qd-task-checkbox-margin-right: 0.9em; // Right margin of checkboxes in GFM task list items
+  --qd-list-margin-divider: 2.5; // --qd-paragraph-vertical-margin / this = list vertical margin
   --qd-box-margin-multiplier: 1.5; // --qd-block-margin * this = box vertical margin
 
   // Border

--- a/quarkdown-html/src/main/resources/render/theme/global.scss
+++ b/quarkdown-html/src/main/resources/render/theme/global.scss
@@ -56,7 +56,7 @@
   --qd-paragraph-vertical-margin: var(--qd-block-margin); // Vertical margin of paragraphs preceded by a paragraph
   --qd-heading-margin: 40px 0 20px 0; // Margin of headings
   --qd-task-checkbox-margin-right: 0.9em; // Right margin of checkboxes in GFM task list items
-  --qd-list-margin-divider: 2.5; // --qd-paragraph-vertical-margin / this = list vertical margin
+  --qd-list-margin-multiplier: 0.4; // --qd-paragraph-vertical-margin * this = list vertical margin
   --qd-box-margin-multiplier: 1.5; // --qd-block-margin * this = box vertical margin
 
   // Border

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Document.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Document.kt
@@ -323,7 +323,8 @@ fun disableNumbering(
  *
  * @param lineHeight height of each line, multiplied by the font size
  * @param letterSpacing whitespace between letters, multiplied by the font size
- * @param spacing whitespace between paragraphs, multiplied by the font size
+ * @param spacing whitespace between paragraphs, multiplied by the font size.
+ *                This also minorly affects whitespace around lists and between list items
  * @param indent whitespace at the start of each paragraph, multiplied by the font size.
  *               LaTeX's policy is used: indenting the first line of paragraphs, except the first one and aligned ones
  * @wiki Paragraph style


### PR DESCRIPTION
This PR lets these elements be slightly affected by the inter-paragraph spacing (`.paragraphstyle spacing:{x}`) instead of adopting a fixed value:
- Space around lists (`spacing * 0.4`)
- Space between list items (`spacing * 0.4 * x`), where `x` is 0.75 for tight lists and 1.5 for loose ones.

As a result spacing is zero, as expected, in Chinese documents. 