### PR TITLE
feat(slides): add speaker notes

### DIFF
--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/quarkdown/block/SlidesSpeakerNote.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/quarkdown/block/SlidesSpeakerNote.kt
@@ -1,0 +1,15 @@
+package com.quarkdown.core.ast.quarkdown.block
+
+import com.quarkdown.core.ast.NestableNode
+import com.quarkdown.core.ast.Node
+import com.quarkdown.core.visitor.node.NodeVisitor
+
+/**
+ * A node that, when rendered in a `Slides` environment in speaker view,
+ * contains speaker notes for the current slide.
+ */
+class SlidesSpeakerNote(
+    override val children: List<Node>,
+) : NestableNode {
+    override fun <T> accept(visitor: NodeVisitor<T>): T = visitor.visit(this)
+}

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/quarkdown/invisible/SlidesConfigurationInitializer.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/quarkdown/invisible/SlidesConfigurationInitializer.kt
@@ -6,13 +6,16 @@ import com.quarkdown.core.visitor.node.NodeVisitor
 
 /**
  * A non-visible node that injects properties that affect the global configuration for slides documents.
+ * If not specified, the default values of the underlying renderer are used.
  * @param centerVertically whether slides should be centered vertically
  * @param showControls whether navigation controls should be shown
+ * @param showNotes whether speaker notes should be shown when not in speaker view
  * @param transition global transition between slides
  */
 class SlidesConfigurationInitializer(
     val centerVertically: Boolean?,
     val showControls: Boolean?,
+    val showNotes: Boolean?,
     val transition: Transition?,
 ) : Node {
     override fun <T> accept(visitor: NodeVisitor<T>) = visitor.visit(this)

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/visitor/node/NodeVisitor.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/visitor/node/NodeVisitor.kt
@@ -44,6 +44,7 @@ import com.quarkdown.core.ast.quarkdown.block.MermaidDiagram
 import com.quarkdown.core.ast.quarkdown.block.Numbered
 import com.quarkdown.core.ast.quarkdown.block.PageBreak
 import com.quarkdown.core.ast.quarkdown.block.SlidesFragment
+import com.quarkdown.core.ast.quarkdown.block.SlidesSpeakerNote
 import com.quarkdown.core.ast.quarkdown.block.Stacked
 import com.quarkdown.core.ast.quarkdown.block.toc.TableOfContentsView
 import com.quarkdown.core.ast.quarkdown.inline.InlineCollapse
@@ -170,9 +171,11 @@ interface NodeVisitor<T> {
 
     fun visit(node: PageCounter): T
 
+    fun visit(node: BibliographyCitation): T
+
     fun visit(node: SlidesFragment): T
 
-    fun visit(node: BibliographyCitation): T
+    fun visit(node: SlidesSpeakerNote): T
 
     // Quarkdown invisible nodes
 

--- a/quarkdown-html/src/main/kotlin/com/quarkdown/rendering/html/node/BaseHtmlNodeRenderer.kt
+++ b/quarkdown-html/src/main/kotlin/com/quarkdown/rendering/html/node/BaseHtmlNodeRenderer.kt
@@ -50,6 +50,7 @@ import com.quarkdown.core.ast.quarkdown.block.MermaidDiagram
 import com.quarkdown.core.ast.quarkdown.block.Numbered
 import com.quarkdown.core.ast.quarkdown.block.PageBreak
 import com.quarkdown.core.ast.quarkdown.block.SlidesFragment
+import com.quarkdown.core.ast.quarkdown.block.SlidesSpeakerNote
 import com.quarkdown.core.ast.quarkdown.block.Stacked
 import com.quarkdown.core.ast.quarkdown.block.list.FocusListItemVariant
 import com.quarkdown.core.ast.quarkdown.block.list.LocationTargetListItemVariant
@@ -360,9 +361,11 @@ open class BaseHtmlNodeRenderer(
 
     override fun visit(node: InlineCollapse): CharSequence = throw UnsupportedRenderException(node)
 
+    override fun visit(node: BibliographyCitation): CharSequence = throw UnsupportedRenderException(node)
+
     override fun visit(node: SlidesFragment): CharSequence = throw UnsupportedRenderException(node)
 
-    override fun visit(node: BibliographyCitation): CharSequence = throw UnsupportedRenderException(node)
+    override fun visit(node: SlidesSpeakerNote): CharSequence = throw UnsupportedRenderException(node)
 
     override fun visit(variant: FocusListItemVariant): HtmlTagBuilder.() -> Unit = throw UnsupportedRenderException(variant::class)
 

--- a/quarkdown-html/src/main/kotlin/com/quarkdown/rendering/html/node/QuarkdownHtmlNodeRenderer.kt
+++ b/quarkdown-html/src/main/kotlin/com/quarkdown/rendering/html/node/QuarkdownHtmlNodeRenderer.kt
@@ -449,6 +449,9 @@ class QuarkdownHtmlNodeRenderer(
                 node.showControls?.let {
                     append("const slides_showControls = $it;")
                 }
+                node.showNotes?.let {
+                    append("const slides_showNotes = $it;")
+                }
                 node.transition?.let {
                     append("const slides_transitionStyle = '${it.style.asCSS}';")
                     append("const slides_transitionSpeed = '${it.speed.asCSS}';")

--- a/quarkdown-html/src/main/kotlin/com/quarkdown/rendering/html/node/QuarkdownHtmlNodeRenderer.kt
+++ b/quarkdown-html/src/main/kotlin/com/quarkdown/rendering/html/node/QuarkdownHtmlNodeRenderer.kt
@@ -28,6 +28,7 @@ import com.quarkdown.core.ast.quarkdown.block.MermaidDiagram
 import com.quarkdown.core.ast.quarkdown.block.Numbered
 import com.quarkdown.core.ast.quarkdown.block.PageBreak
 import com.quarkdown.core.ast.quarkdown.block.SlidesFragment
+import com.quarkdown.core.ast.quarkdown.block.SlidesSpeakerNote
 import com.quarkdown.core.ast.quarkdown.block.Stacked
 import com.quarkdown.core.ast.quarkdown.block.list.FocusListItemVariant
 import com.quarkdown.core.ast.quarkdown.block.list.LocationTargetListItemVariant
@@ -367,11 +368,6 @@ class QuarkdownHtmlNodeRenderer(
 
     override fun visit(node: MathSpan) = buildTag("formula", node.expression)
 
-    override fun visit(node: SlidesFragment) =
-        tagBuilder("div", node.children)
-            .classNames("fragment", node.behavior.asCSS)
-            .build()
-
     override fun visit(node: BibliographyCitation): CharSequence {
         val (entry: BibliographyEntry, view: BibliographyView) =
             node.getDefinition(context) ?: return Text("[???]").accept(this)
@@ -380,6 +376,18 @@ class QuarkdownHtmlNodeRenderer(
         val label = view.style.labelProvider.getLabel(entry, index)
         return Text(label).accept(this)
     }
+
+    override fun visit(node: SlidesFragment) =
+        tagBuilder("div", node.children)
+            .classNames("fragment", node.behavior.asCSS)
+            .build()
+
+    override fun visit(node: SlidesSpeakerNote) =
+        buildTag("aside") {
+            className("notes")
+            hidden()
+            +node.children
+        }
 
     /**
      * Applies the text transformation of [data] into [this] CSS builder.

--- a/quarkdown-html/src/main/resources/render/html-wrapper.html.template
+++ b/quarkdown-html/src/main/resources/render/html-wrapper.html.template
@@ -17,6 +17,7 @@
     <script src="script/slides.js"></script>
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
     <script src="https://cdnjs.cloudflare.com/ajax/libs/reveal.js/5.2.1/reveal.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/reveal.js/5.2.1/plugin/notes/notes.js"></script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/reveal.js/5.2.1/reset.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/reveal.js/5.2.1/reveal.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/reveal.js/5.2.1/theme/white.css">

--- a/quarkdown-html/src/main/resources/render/script/slides.js
+++ b/quarkdown-html/src/main/resources/render/script/slides.js
@@ -79,6 +79,7 @@ class SlidesDocument extends QuarkdownDocument {
             transition: typeof slides_transitionStyle !== undef ? slides_transitionStyle : 'slide',
             transitionSpeed: typeof slides_transitionSpeed !== undef ? slides_transitionSpeed : 'default',
             hash: true,
+            plugins: [RevealNotes],
         });
     }
 

--- a/quarkdown-html/src/main/resources/render/script/slides.js
+++ b/quarkdown-html/src/main/resources/render/script/slides.js
@@ -76,6 +76,7 @@ class SlidesDocument extends QuarkdownDocument {
             // If the center property is not explicitly set, it defaults to true unless the `--reveal-center-vertically` CSS variable of `:root` is set to `false`.
             center: typeof slides_center !== undef ? slides_center : getComputedStyle(document.documentElement).getPropertyValue('--reveal-center-vertically') !== 'false',
             controls: typeof slides_showControls !== undef ? slides_showControls : true,
+            showNotes: typeof slides_showNotes !== undef ? slides_showNotes : false,
             transition: typeof slides_transitionStyle !== undef ? slides_transitionStyle : 'slide',
             transitionSpeed: typeof slides_transitionSpeed !== undef ? slides_transitionSpeed : 'default',
             hash: true,

--- a/quarkdown-html/src/main/resources/render/theme/components/_alignment.scss
+++ b/quarkdown-html/src/main/resources/render/theme/components/_alignment.scss
@@ -20,6 +20,11 @@
   .reveal .slides > :is(section, .pdf-page) {
     text-align: var(--qd-horizontal-alignment-global);
   }
+
+  .speaker-notes {
+    --qd-horizontal-alignment-global: start;
+    --qd-horizontal-alignment-local: start;
+  }
 }
 
 .quarkdown-plain, .quarkdown-paged {

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Slides.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Slides.kt
@@ -2,6 +2,7 @@ package com.quarkdown.stdlib
 
 import com.quarkdown.core.ast.MarkdownContent
 import com.quarkdown.core.ast.quarkdown.block.SlidesFragment
+import com.quarkdown.core.ast.quarkdown.block.SlidesSpeakerNote
 import com.quarkdown.core.ast.quarkdown.invisible.SlidesConfigurationInitializer
 import com.quarkdown.core.document.DocumentType
 import com.quarkdown.core.document.slides.Transition
@@ -22,6 +23,7 @@ val Slides: Module =
     moduleOf(
         ::setSlidesConfiguration,
         ::fragment,
+        ::speakerNote,
     )
 
 /**
@@ -61,3 +63,18 @@ fun fragment(
     behavior: SlidesFragment.Behavior = SlidesFragment.Behavior.SHOW,
     @LikelyBody content: MarkdownContent,
 ) = SlidesFragment(behavior, content.children).wrappedAsValue()
+
+/**
+ * Creates a speaker note for a `slides` document.
+ *
+ * Speaker notes are visible only to the presenter and not to the audience during a presentation.
+ * In Reveal.js, speaker notes are shown in the speaker view (enabled by pressing `S`).
+ * @param content the content of the note
+ * @return a new [SlidesSpeakerNote] node
+ * @wiki Slides speaker note
+ */
+@OnlyForDocumentType(DocumentType.SLIDES)
+@Name("speakernote")
+fun speakerNote(
+    @LikelyBody content: MarkdownContent,
+): NodeValue = SlidesSpeakerNote(content.children).wrappedAsValue()

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Slides.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Slides.kt
@@ -30,6 +30,7 @@ val Slides: Module =
  * Sets global properties that affect the behavior of a 'slides' document.
  * @param center whether slides should be centered vertically
  * @param showControls whether navigation controls should be shown
+ * @param showNotes whether speaker notes should be shown when not in speaker view
  * @param transitionStyle global transition style between slides
  * @param transitionSpeed global transition speed between slides
  * @return a new [SlidesConfigurationInitializer] node
@@ -40,12 +41,14 @@ val Slides: Module =
 fun setSlidesConfiguration(
     @LikelyNamed center: Boolean? = null,
     @Name("controls") showControls: Boolean? = null,
+    @Name("speakernotes") showNotes: Boolean? = null,
     @Name("transition") transitionStyle: Transition.Style? = null,
     @Name("speed") transitionSpeed: Transition.Speed = Transition.Speed.DEFAULT,
 ): NodeValue =
     SlidesConfigurationInitializer(
         center,
         showControls,
+        showNotes,
         transitionStyle?.let { Transition(it, transitionSpeed) },
     ).wrappedAsValue()
 


### PR DESCRIPTION
This PR introduces speaker notes to Reveal.js slides via `.speakernote`.

Speaker notes are shown when in speaker view (press `S` while viewing the HTML output).  
Setting `.slides speakernotes:{yes}` will show the notes also when not in speaker view, including PDFs.