### PR TITLE
feat(cli): allow browser launcher selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,14 @@ If you would like to familiarize yourself with Quarkdown instead, `quarkdown rep
   - `html`
   - `html-pdf` (equivalent to `-r html --pdf`)
 
+- `-b <browser>` or `--browser <browser>`: sets the browser to launch the preview with. Defaults to `default`. Accepted values:
+  - `default`
+  - `none`
+  - `chrome`
+  - `chromium`
+  - `firefox`
+  - `edge` (Windows only)
+
 - `--server-port <port>`: optional customization of the local webserver's port. Defaults to `8089`.
 
 - `--pretty`: produces pretty output code. This is useful for debugging or to read the output code more easily,

--- a/quarkdown-cli/src/main/kotlin/com/quarkdown/cli/exec/CompileCommand.kt
+++ b/quarkdown-cli/src/main/kotlin/com/quarkdown/cli/exec/CompileCommand.kt
@@ -6,11 +6,12 @@ import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.types.file
 import com.quarkdown.cli.CliOptions
 import com.quarkdown.cli.exec.strategy.FileExecutionStrategy
+import com.quarkdown.cli.server.BrowserLaunchers.browserChoice
 import com.quarkdown.cli.server.WebServerOptions
 import com.quarkdown.core.log.Log
 import com.quarkdown.core.pipeline.PipelineOptions
 import com.quarkdown.interaction.Env
-import com.quarkdown.server.browser.DefaultBrowserLauncher
+import com.quarkdown.server.browser.BrowserLauncher
 import java.io.File
 
 /**
@@ -40,6 +41,15 @@ class CompileCommand : ExecuteCommand("compile") {
         help = "(Unsafe) Disable Chrome sandbox for PDF export",
         envvar = Env.NO_SANDBOX,
     ).flag()
+
+    /**
+     * Optional browser to open the served file in, if preview is enabled.
+     */
+    private val browser: BrowserLauncher? by option(
+        "-b",
+        "--browser",
+        help = "Browser to open the preview in",
+    ).browserChoice()
 
     override fun finalizeCliOptions(original: CliOptions) =
         original.copy(
@@ -74,7 +84,7 @@ class CompileCommand : ExecuteCommand("compile") {
             WebServerOptions(
                 port = super.serverPort,
                 targetFile = directory,
-                browserLauncher = DefaultBrowserLauncher(),
+                browserLauncher = browser,
             ),
         )
     }

--- a/quarkdown-cli/src/main/kotlin/com/quarkdown/cli/server/BrowserLaunchers.kt
+++ b/quarkdown-cli/src/main/kotlin/com/quarkdown/cli/server/BrowserLaunchers.kt
@@ -1,0 +1,46 @@
+package com.quarkdown.cli.server
+
+import com.github.ajalt.clikt.parameters.options.OptionWithValues
+import com.github.ajalt.clikt.parameters.options.default
+import com.github.ajalt.clikt.parameters.options.validate
+import com.github.ajalt.clikt.parameters.types.choice
+import com.quarkdown.server.browser.BrowserLauncher
+import com.quarkdown.server.browser.DefaultBrowserLauncher
+import com.quarkdown.server.browser.NoneBrowserLauncher
+import com.quarkdown.server.browser.SimpleEnvBrowserLauncher
+
+/**
+ * Utility to provide browser launchers for the CLI.
+ */
+internal object BrowserLaunchers {
+    object Chrome : SimpleEnvBrowserLauncher("chrome")
+
+    object Chromium : SimpleEnvBrowserLauncher("chromium")
+
+    object Edge : SimpleEnvBrowserLauncher("edge")
+
+    object Firefox : SimpleEnvBrowserLauncher("firefox")
+
+    private val choices: Map<String, BrowserLauncher> =
+        mapOf(
+            "default" to DefaultBrowserLauncher(),
+            "none" to NoneBrowserLauncher(),
+            "chrome" to Chrome,
+            "edge" to Edge,
+            "firefox" to Firefox,
+            "chromium" to Chromium,
+        )
+
+    /**
+     * Provides a validated choice of browser launchers for the CLI.
+     */
+    fun OptionWithValues<String?, String, String>.browserChoice(default: BrowserLauncher? = null) =
+        choice(choices, ignoreCase = true)
+            .apply { if (default != null) default(default) }
+            .validate {
+                require(it.isValid) {
+                    "The specified browser (${it::class.simpleName}) cannot be launched " +
+                        "because it is either not installed, not loaded in the environment (BROWSER_<NAME>), or unsupported."
+                }
+            }
+}

--- a/quarkdown-cli/src/main/kotlin/com/quarkdown/cli/server/StartWebServerCommand.kt
+++ b/quarkdown-cli/src/main/kotlin/com/quarkdown/cli/server/StartWebServerCommand.kt
@@ -2,12 +2,13 @@ package com.quarkdown.cli.server
 
 import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.parameters.options.default
-import com.github.ajalt.clikt.parameters.options.flag
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.required
 import com.github.ajalt.clikt.parameters.types.file
 import com.github.ajalt.clikt.parameters.types.int
+import com.quarkdown.cli.server.BrowserLaunchers.browserChoice
 import com.quarkdown.server.LocalFileWebServer
+import com.quarkdown.server.browser.BrowserLauncher
 import com.quarkdown.server.browser.DefaultBrowserLauncher
 import java.io.File
 
@@ -36,12 +37,16 @@ class StartWebServerCommand : CliktCommand(name = "start") {
         .default(DEFAULT_SERVER_PORT)
 
     /**
-     * Whether to open the served file in the default browser.
+     * Optional browser to open the served file in.
      */
-    private val open: Boolean by option("-o", "--open", help = "Open the served file in the default browser").flag()
+    private val browser: BrowserLauncher? by option(
+        "-b",
+        "--browser",
+        help = "Browser to open the served file in",
+    ).browserChoice(default = DefaultBrowserLauncher())
 
     override fun run() {
-        val options = WebServerOptions(port, targetFile, DefaultBrowserLauncher().takeIf { open })
+        val options = WebServerOptions(port, targetFile, browser)
         WebServerStarter.start(options)
     }
 }

--- a/quarkdown-server/src/main/kotlin/com/quarkdown/server/browser/BrowserLauncher.kt
+++ b/quarkdown-server/src/main/kotlin/com/quarkdown/server/browser/BrowserLauncher.kt
@@ -5,6 +5,11 @@ package com.quarkdown.server.browser
  */
 interface BrowserLauncher {
     /**
+     * Indicates whether the browser is valid and can be launched.
+     */
+    val isValid: Boolean
+
+    /**
      * Launches a URL in the specified browser.
      * @param url URL to launch
      */

--- a/quarkdown-server/src/main/kotlin/com/quarkdown/server/browser/DefaultBrowserLauncher.kt
+++ b/quarkdown-server/src/main/kotlin/com/quarkdown/server/browser/DefaultBrowserLauncher.kt
@@ -7,11 +7,10 @@ import java.net.URI
  * Launcher of a URL in the default browser.
  */
 class DefaultBrowserLauncher : BrowserLauncher {
+    override val isValid: Boolean
+        get() = Desktop.isDesktopSupported() && Desktop.getDesktop().isSupported(Desktop.Action.BROWSE)
+
     override fun launch(url: String) {
-        if (Desktop.isDesktopSupported() && Desktop.getDesktop().isSupported(Desktop.Action.BROWSE)) {
-            Desktop.getDesktop().browse(URI(url))
-            return
-        }
-        throw UnsupportedOperationException("Cannot open the default browser on this platform.")
+        Desktop.getDesktop().browse(URI(url))
     }
 }

--- a/quarkdown-server/src/main/kotlin/com/quarkdown/server/browser/EnvBrowserLauncher.kt
+++ b/quarkdown-server/src/main/kotlin/com/quarkdown/server/browser/EnvBrowserLauncher.kt
@@ -1,0 +1,40 @@
+package com.quarkdown.server.browser
+
+/**
+ * Prefix used to look up browser environment variables.
+ * Example: `BROWSER_CHROME`, `BROWSER_FIREFOX`, etc.
+ */
+private const val ENV_PREFIX = "BROWSER_"
+
+/**
+ * Launcher of browsers whose path is stored in environment variables (`BROWSER_<env>`).
+ *
+ * @property env the environment variable suffix (e.g., "chrome" for BROWSER_CHROME).
+ * @property envValue the resolved environment variable value if set.
+ */
+abstract class EnvBrowserLauncher(
+    private val env: String,
+) : BrowserLauncher {
+    /**
+     * The value of the environment variable for the browser, if set.
+     */
+    protected val envValue: String?
+        get() = System.getenv(ENV_PREFIX + env.uppercase())
+}
+
+/**
+ * Simple implementation of [EnvBrowserLauncher] that launches a browser if the environment variable is set,
+ * passing the URL as the first argument to the browser executable.
+ */
+open class SimpleEnvBrowserLauncher(
+    env: String,
+) : EnvBrowserLauncher(env) {
+    override val isValid: Boolean
+        get() = super.envValue != null && super.envValue!!.isNotBlank()
+
+    override fun launch(url: String) {
+        val browserPath = super.envValue!!
+        val command = arrayOf(browserPath, url)
+        Runtime.getRuntime().exec(command)
+    }
+}

--- a/quarkdown-server/src/main/kotlin/com/quarkdown/server/browser/NoneBrowserLauncher.kt
+++ b/quarkdown-server/src/main/kotlin/com/quarkdown/server/browser/NoneBrowserLauncher.kt
@@ -1,0 +1,12 @@
+package com.quarkdown.server.browser
+
+/**
+ * A fake browser launcher that does not perform any action.
+ * This is needed to allow `--browser none` option in the CLI.
+ */
+class NoneBrowserLauncher : BrowserLauncher {
+    override val isValid: Boolean
+        get() = true
+
+    override fun launch(url: String) {}
+}


### PR DESCRIPTION
This PR adds the `--browser` option to `c` and `start` commands, letting the user decide which browser, or even `none`, should open the document preview.

The option defaults to `default` in `c` and to `none` in `start`. 

The `--open` flag has been removed from `start`.
