### PR TITLE
feat: let preview stick to the end of the document

### DIFF
--- a/quarkdown-html/src/main/resources/render/script/script.js
+++ b/quarkdown-html/src/main/resources/render/script/script.js
@@ -274,24 +274,40 @@ function hashCode(str) {
 //
 // Scroll position restoration.
 
+// The last scroll position.
 const scrollYStorageKey = "scrollY";
 const storedScrollY = +sessionStorage.getItem(scrollYStorageKey);
+
+// Whether the last session was scrolled to the end.
+// If so, the new document will be scrolled to the end as well, ignoring the actual scroll position.
+const stickyToEndStorageKey = "stickyToEnd";
+const stickyToEnd = sessionStorage.getItem(stickyToEndStorageKey) === "true";
+
+// Whether the scroll position has already been restored.
 let scrollRestored = false;
+
+// The maximum scroll position that can be restored.
+function getScrollHeight() {
+    return document.documentElement.scrollHeight - window.innerHeight;
+}
 
 // Saves scroll position.
 function saveScrollPosition() {
     history.scrollRestoration = "manual";
     sessionStorage.setItem(scrollYStorageKey, window.scrollY.toString());
+    sessionStorage.setItem(stickyToEndStorageKey, (window.scrollY >= getScrollHeight()).toString());
 }
 
 // Restores scroll position. Even if called multiple times, it will only restore the first time.
+// If the last session was scrolled to the end, it will scroll to the end of the new document ignoring the actual coordinates.
 function restoreScrollPosition() {
     if (scrollRestored || !storedScrollY) return;
 
-    console.log("Restoring scroll position to", storedScrollY);
+    const y = stickyToEnd ? getScrollHeight() : storedScrollY;
+    console.log("Restoring scroll position to", y, "sticky to end = ", stickyToEnd);
     scrollRestored = true;
     requestAnimationFrame(() => {
-        window.scrollTo({top: storedScrollY, behavior: "auto"});
+        window.scrollTo({top: y, behavior: "auto"});
     });
 }
 

--- a/quarkdown-html/src/main/resources/render/script/script.js
+++ b/quarkdown-html/src/main/resources/render/script/script.js
@@ -291,11 +291,21 @@ function getScrollHeight() {
     return document.documentElement.scrollHeight - window.innerHeight;
 }
 
+// Whether the document is scrolled to the bottom (returns true also if the content fits in the viewport).
+function isScrolledToBottom() {
+    const scrollableHeight = document.documentElement.scrollHeight;
+    const viewportHeight = window.innerHeight;
+    const scrollY = window.scrollY;
+
+    // If content fits in viewport or scrolled to bottom.
+    return scrollableHeight <= viewportHeight || scrollY >= getScrollHeight();
+}
+
 // Saves scroll position.
 function saveScrollPosition() {
     history.scrollRestoration = "manual";
     sessionStorage.setItem(scrollYStorageKey, window.scrollY.toString());
-    sessionStorage.setItem(stickyToEndStorageKey, (window.scrollY >= getScrollHeight()).toString());
+    sessionStorage.setItem(stickyToEndStorageKey, isScrolledToBottom().toString());
 }
 
 // Restores scroll position. Even if called multiple times, it will only restore the first time.

--- a/quarkdown-html/src/main/resources/render/script/script.js
+++ b/quarkdown-html/src/main/resources/render/script/script.js
@@ -311,10 +311,10 @@ function saveScrollPosition() {
 // Restores scroll position. Even if called multiple times, it will only restore the first time.
 // If the last session was scrolled to the end, it will scroll to the end of the new document ignoring the actual coordinates.
 function restoreScrollPosition() {
-    if (scrollRestored || !storedScrollY) return;
+    if (scrollRestored || !(storedScrollY || stickyToEnd)) return;
 
     const y = stickyToEnd ? getScrollHeight() : storedScrollY;
-    console.log("Restoring scroll position to", y, "sticky to end = ", stickyToEnd);
+    console.log("Restoring scroll position to", y, "sticky to end =", stickyToEnd);
     scrollRestored = true;
     requestAnimationFrame(() => {
         window.scrollTo({top: y, behavior: "auto"});


### PR DESCRIPTION
This PR introduces sticky scroll restoration.

The preview (`-p`) now checks whether the current document is scrolled to bottom. If so, the next preview's scroll will be restored to the end of the updated document as well, making live preview much more natural.