### PR TITLE
fix: escape dot (`.`) in range parsing

### DIFF
--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/function/value/factory/ValueFactory.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/function/value/factory/ValueFactory.kt
@@ -128,7 +128,7 @@ object ValueFactory {
         val rawString = raw.toString()
 
         // Matches 'x..y', where both x and y are optional integers.
-        val regex = "(\\d+)?..(\\d+)?".toRegex()
+        val regex = "(\\d+)?\\.\\.(\\d+)?".toRegex()
 
         // If the raw value does not represent a range, an error is thrown.
         if (!regex.matches(rawString)) {


### PR DESCRIPTION
This PR fixes the [range](https://github.com/iamgio/quarkdown/wiki/range)'s regex pattern in which the dots are incorrectly unescaped.