### PR TITLE
fix(code): fix line numbers and first-line indentation of code blocks spanning across different pages

### DIFF
--- a/quarkdown-html/src/test/resources/issues/split-code-block.qd
+++ b/quarkdown-html/src/test/resources/issues/split-code-block.qd
@@ -1,0 +1,19 @@
+.docname {Split code blocks should keep indentation and line numbers}
+.doctype {paged}
+.include {template/template.qd}
+
+.bulletin issue:{194} pr:{196} nextrelease:{1.9.1} relatedto:{paged.js not transferring indentation}
+
+<<<
+
+.repeat {5}
+    .loremipsum
+
+```javascript
+function a() {
+    const x = 0;
+    const y = 0;
+    const z = 0;
+    return x + y + z;
+}
+```


### PR DESCRIPTION
Before:

<img width="408" height="330" alt="Before" src="https://github.com/user-attachments/assets/04d3abe6-895a-4bbd-90b1-7f0f8a7b4249" />

After:

<img width="408" height="330" alt="After" src="https://github.com/user-attachments/assets/f29356ac-be8f-4658-860e-e98689e5f9ff" />
