### PR TITLE
fix: allow setting only one dimension (width/height) of the page size

### DIFF
--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/document/DocumentType.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/document/DocumentType.kt
@@ -1,16 +1,20 @@
 package com.quarkdown.core.document
 
+import com.quarkdown.core.document.layout.page.PageFormatInfo
 import com.quarkdown.core.document.layout.page.PageOrientation
+import com.quarkdown.core.document.layout.page.PageSizeFormat
 import com.quarkdown.core.document.numbering.DocumentNumbering
 import com.quarkdown.core.document.numbering.NumberingFormat
 
 /**
  * Type of produced document, which affects its post-rendering stage.
  * @param preferredOrientation the preferred orientation of the document, to apply if not overridden by the user
+ * @param defaultPageFormat the default page format to apply, if not overridden by the user
  * @param defaultNumbering the default numbering formats to apply, if not overridden by the user
  */
 enum class DocumentType(
     val preferredOrientation: PageOrientation,
+    val defaultPageFormat: PageFormatInfo? = null,
     val defaultNumbering: DocumentNumbering? = null,
 ) {
     /**
@@ -24,11 +28,19 @@ enum class DocumentType(
      */
     PAGED(
         PageOrientation.PORTRAIT,
-        DocumentNumbering(
-            headings = NumberingFormat.fromString("1.1.1"),
-            figures = NumberingFormat.fromString("1.1"),
-            tables = NumberingFormat.fromString("1.1"),
-        ),
+        defaultPageFormat =
+            with(PageSizeFormat.A4.getBounds(PageOrientation.PORTRAIT)) {
+                PageFormatInfo(
+                    pageWidth = width,
+                    pageHeight = height,
+                )
+            },
+        defaultNumbering =
+            DocumentNumbering(
+                headings = NumberingFormat.fromString("1.1.1"),
+                figures = NumberingFormat.fromString("1.1"),
+                tables = NumberingFormat.fromString("1.1"),
+            ),
     ),
 
     /**

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/document/layout/page/PageFormatInfo.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/document/layout/page/PageFormatInfo.kt
@@ -4,10 +4,15 @@ import com.quarkdown.core.ast.quarkdown.block.Container
 import com.quarkdown.core.document.size.Size
 import com.quarkdown.core.document.size.Sizes
 import com.quarkdown.core.misc.color.Color
+import com.quarkdown.core.util.Defaultable
 
 /**
  * Mutable information about the format of all pages of a document.
  * When any of the fields is `null`, the default value supplied by the underlying renderer is used.
+ *
+ * This class is marked as [Defaultable], since its default values can be supplied by the document type
+ * via [com.quarkdown.core.document.DocumentType.defaultPageFormat].
+ *
  * @param pageWidth width of each page
  * @param pageHeight height of each page
  * @param margin blank space around the content of each page
@@ -24,10 +29,4 @@ data class PageFormatInfo(
     var contentBorderColor: Color? = null,
     var columnCount: Int? = null,
     var alignment: Container.TextAlignment? = null,
-) {
-    /**
-     * Whether the document has a fixed size.
-     */
-    val hasSize: Boolean
-        get() = pageWidth != null && pageHeight != null
-}
+) : Defaultable

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/rendering/template/TemplatePlaceholders.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/rendering/template/TemplatePlaceholders.kt
@@ -58,11 +58,6 @@ object TemplatePlaceholders {
     const val IS_SLIDES = "SLIDES"
 
     /**
-     * Whether the document has a fixed size.
-     */
-    const val HAS_PAGE_SIZE = "PAGESIZE"
-
-    /**
      * Width of the document.
      */
     const val PAGE_WIDTH = "PAGEWIDTH"

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/util/Defaultable.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/util/Defaultable.kt
@@ -1,0 +1,31 @@
+package com.quarkdown.core.util
+
+/**
+ * Marker interface for types that support default values.
+ */
+interface Defaultable
+
+/**
+ * Holds a value and an optional default value of type [T].
+ * @param value the primary value
+ * @param default the default value, if any
+ */
+data class Defaulted<T : Defaultable>(
+    val value: T,
+    val default: T? = null,
+)
+
+/**
+ * Wraps a value with an optional default.
+ * @param default the default value to associate
+ * @return a [Defaulted] instance containing the value and default
+ */
+fun <T : Defaultable> T.withDefault(default: T?): Defaulted<T> = Defaulted(this, default)
+
+/**
+ * Retrieves a value using [valueProvider] from the primary value,
+ * or from the default if the primary value is `null`.
+ * @param valueProvider function to extract a value from [T]
+ * @return the provided value, or the default if not present. `null` if neither is present
+ */
+operator fun <T : Defaultable, V> Defaulted<T>.get(valueProvider: T.() -> V?): V? = valueProvider(value) ?: default?.valueProvider()

--- a/quarkdown-html/src/main/kotlin/com/quarkdown/rendering/html/post/HtmlPostRendererTemplate.kt
+++ b/quarkdown-html/src/main/kotlin/com/quarkdown/rendering/html/post/HtmlPostRendererTemplate.kt
@@ -8,6 +8,8 @@ import com.quarkdown.core.document.DocumentType
 import com.quarkdown.core.rendering.template.TemplatePlaceholders
 import com.quarkdown.core.template.TemplateProcessor
 import com.quarkdown.core.util.Escape
+import com.quarkdown.core.util.get
+import com.quarkdown.core.util.withDefault
 import com.quarkdown.rendering.html.css.asCSS
 
 /**
@@ -87,41 +89,40 @@ class HtmlPostRendererTemplate(
      * @see com.quarkdown.core.document.layout.page.PageFormatInfo
      */
     private fun TemplateProcessor.pageFormat() {
-        val pageFormat = document.layout.pageFormat
+        val pageFormat = document.layout.pageFormat.withDefault(document.type.defaultPageFormat)
 
-        conditional(TemplatePlaceholders.HAS_PAGE_SIZE, pageFormat.hasSize)
         optionalValue(
             TemplatePlaceholders.PAGE_WIDTH,
-            pageFormat.pageWidth?.asCSS,
+            pageFormat[{ pageWidth }]?.asCSS,
         )
         optionalValue(
             TemplatePlaceholders.PAGE_HEIGHT,
-            pageFormat.pageHeight?.asCSS,
+            pageFormat[{ pageHeight }]?.asCSS,
         )
         optionalValue(
             TemplatePlaceholders.PAGE_MARGIN,
-            pageFormat.margin?.asCSS,
+            pageFormat[{ margin }]?.asCSS,
         )
         optionalValue(
             TemplatePlaceholders.PAGE_CONTENT_BORDER_WIDTH,
-            pageFormat.contentBorderWidth?.asCSS,
+            pageFormat[{ contentBorderWidth }]?.asCSS,
         )
         optionalValue(
             TemplatePlaceholders.PAGE_CONTENT_BORDER_COLOR,
-            pageFormat.contentBorderColor?.asCSS,
+            pageFormat[{ contentBorderColor }]?.asCSS,
         )
         optionalValue(
             TemplatePlaceholders.COLUMN_COUNT,
-            pageFormat.columnCount,
+            pageFormat[{ columnCount }],
         )
         // Alignment can be global or local. See TemplatePlaceholders.GLOBAL_HORIZONTAL_ALIGNMENT for details.
         optionalValue(
             TemplatePlaceholders.GLOBAL_HORIZONTAL_ALIGNMENT,
-            pageFormat.alignment?.takeIf { it.isGlobal }?.asCSS,
+            pageFormat[{ alignment }]?.takeIf { it.isGlobal }?.asCSS,
         )
         optionalValue(
             TemplatePlaceholders.LOCAL_HORIZONTAL_ALIGNMENT,
-            pageFormat.alignment?.takeIf { it.isLocal }?.asCSS,
+            pageFormat[{ alignment }]?.takeIf { it.isLocal }?.asCSS,
         )
     }
 

--- a/quarkdown-html/src/main/resources/render/html-wrapper.html.template
+++ b/quarkdown-html/src/main/resources/render/html-wrapper.html.template
@@ -106,14 +106,12 @@
         }
 
         body.quarkdown-slides .reveal {
-            [[if:PAGESIZE]]
-            width: [[PAGEWIDTH]];
-            height: [[PAGEHEIGHT]];
-            [[endif:PAGESIZE]]
+            [[if:PAGEWIDTH]]width: [[PAGEWIDTH]];[[endif:PAGEWIDTH]]
+            [[if:PAGEHEIGHT]]height: [[PAGEHEIGHT]];[[endif:PAGEHEIGHT]]
         }
 
         @page {
-            [[if:PAGESIZE]]size: [[PAGEWIDTH]] [[PAGEHEIGHT]];[[endif:PAGESIZE]]
+            size: [[if:PAGEWIDTH]][[PAGEWIDTH]][[endif:PAGEWIDTH]][[if:!PAGEWIDTH]]auto[[endif:!PAGEWIDTH]] [[if:PAGEHEIGHT]][[PAGEHEIGHT]][[endif:PAGEHEIGHT]][[if:!PAGEHEIGHT]]auto[[endif:!PAGEHEIGHT]];
             [[if:PAGEMARGIN]]margin: [[PAGEMARGIN]];[[endif:PAGEMARGIN]]
             [[if:PLAIN]][[if:!PAGEMARGIN]]margin: 0;[[endif:!PAGEMARGIN]][[endif:PLAIN]]
         }


### PR DESCRIPTION
This PR fixes an issue that would make it unable to override only one dimension of the page size of *paged* and *slides* documents, via `.pageformat`'s `width` or `height`.