### PR TITLE
fix: don't constrain ToC height in slides PDF

### DIFF
--- a/quarkdown-html/src/main/resources/render/theme/components/_toc.scss
+++ b/quarkdown-html/src/main/resources/render/theme/components/_toc.scss
@@ -24,11 +24,11 @@
       content: target-counter(attr(href), page);
       float: right;
     }
-
-    // ToC is scrollable in slides
-    @at-root .quarkdown-slides#{&} {
-      overflow-y: scroll;
-      max-height: 50vh;
-    }
   }
+}
+
+// ToC is scrollable in slides (not in PDF view)
+.quarkdown-slides nav:not(.pdf-page nav) {
+  overflow-y: scroll;
+  max-height: 50vh;
 }


### PR DESCRIPTION
This PR prevents constraints to the height of table of contents when slides are exported to PDF.