### PR TITLE
fix(live-preview): fix live preview refreshing to the wrong slide in slides documents

### DIFF
--- a/quarkdown-server/src/main/resources/live-preview/wrapper.html.template
+++ b/quarkdown-server/src/main/resources/live-preview/wrapper.html.template
@@ -227,6 +227,12 @@
         newFrame.contentWindow.onscroll = null;
         newFrame.onload = null;
 
+        // (#199) If the URL has changed (e.g. different slide, subdocument, etc.), update the hidden frame's URL to match.
+        const activeUrl = currentFrame.contentWindow.location.href;
+        if (newFrame.src !== activeUrl) {
+            newFrame.src = activeUrl;
+        }
+
         // Swap frame visibility.
         setFrameVisibility(newFrame, true);
         setFrameVisibility(currentFrame, false);


### PR DESCRIPTION
This PR fixes an issue that would display a different slide when live-reloading slides documents. That's due to frame buffers not syncing their URL. 