### PR TITLE
[dev] refactor: make `DocumentInfo` and sub-properties immutable

### DIFF
--- a/quarkdown-core/build.gradle.kts
+++ b/quarkdown-core/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     kotlin("jvm")
-    id("com.quarkdown.automerge") version "1.1.0"
+    id("com.quarkdown.amber") version "2.1.2"
     `java-test-fixtures`
 }
 

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/context/MutableContext.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/context/MutableContext.kt
@@ -3,6 +3,7 @@ package com.quarkdown.core.context
 import com.quarkdown.core.ast.attributes.MutableAstAttributes
 import com.quarkdown.core.ast.base.block.LinkDefinition
 import com.quarkdown.core.ast.quarkdown.FunctionCallNode
+import com.quarkdown.core.document.DocumentInfo
 import com.quarkdown.core.document.sub.Subdocument
 import com.quarkdown.core.flavor.MarkdownFlavor
 import com.quarkdown.core.function.call.FunctionCall
@@ -27,6 +28,8 @@ open class MutableContext(
     override val options: MutableContextOptions = MutableContextOptions(),
 ) : BaseContext(attributes, flavor, libraries, subdocument) {
     override val libraries: MutableSet<Library> = super.libraries.toMutableSet()
+
+    override var documentInfo: DocumentInfo = super.documentInfo
 
     override val loadableLibraries: MutableSet<Library> = (super.loadableLibraries + loadableLibraries).toMutableSet()
 

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/context/ScopeContext.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/context/ScopeContext.kt
@@ -28,8 +28,11 @@ class ScopeContext(
     override val attachedPipeline: Pipeline?
         get() = super.attachedPipeline ?: parent.attachedPipeline
 
-    override val documentInfo: DocumentInfo
+    override var documentInfo: DocumentInfo
         get() = parent.documentInfo
+        set(value) {
+            (parent as? MutableContext)?.documentInfo = value
+        }
 
     override val options: MutableContextOptions
         get() = parent.options as? MutableContextOptions ?: MutableContextOptions()

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/document/DocumentInfo.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/document/DocumentInfo.kt
@@ -1,5 +1,6 @@
 package com.quarkdown.core.document
 
+import com.quarkdown.amber.annotations.NestedData
 import com.quarkdown.core.document.layout.DocumentLayoutInfo
 import com.quarkdown.core.document.numbering.DocumentNumbering
 import com.quarkdown.core.document.tex.TexInfo
@@ -16,6 +17,7 @@ import com.quarkdown.core.localization.Locale
  * @param numbering formats to apply to element numbering across the document
  * @param pageFormat format of the pages of the document
  */
+@NestedData
 data class DocumentInfo(
     val type: DocumentType = DocumentType.PLAIN,
     val name: String? = null,

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/document/DocumentInfo.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/document/DocumentInfo.kt
@@ -6,8 +6,8 @@ import com.quarkdown.core.document.tex.TexInfo
 import com.quarkdown.core.localization.Locale
 
 /**
- * Mutable information about the final artifact.
- * This data is mutated by library functions `.docname`, `.docauthor`, etc.
+ * Immutable information about the document.
+ * This data is updated by library functions `.docname`, `.docauthor`, etc., by overwriting [com.quarkdown.core.context.MutableContext.documentInfo].
  * @param type type of the document
  * @param name name of the document, if specified
  * @param authors authors of the document, if specified
@@ -17,12 +17,12 @@ import com.quarkdown.core.localization.Locale
  * @param pageFormat format of the pages of the document
  */
 data class DocumentInfo(
-    var type: DocumentType = DocumentType.PLAIN,
-    var name: String? = null,
-    val authors: MutableList<DocumentAuthor> = mutableListOf(),
-    var locale: Locale? = null,
-    var numbering: DocumentNumbering? = null,
-    var theme: DocumentTheme? = null,
+    val type: DocumentType = DocumentType.PLAIN,
+    val name: String? = null,
+    val authors: List<DocumentAuthor> = mutableListOf(),
+    val locale: Locale? = null,
+    val numbering: DocumentNumbering? = null,
+    val theme: DocumentTheme? = null,
     val tex: TexInfo = TexInfo(),
     val layout: DocumentLayoutInfo = DocumentLayoutInfo(),
 ) {

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/document/layout/caption/CaptionPositionInfo.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/document/layout/caption/CaptionPositionInfo.kt
@@ -1,6 +1,6 @@
 package com.quarkdown.core.document.layout.caption
 
-import com.quarkdown.automerge.annotations.Mergeable
+import com.quarkdown.amber.annotations.Mergeable
 
 /**
  * Immutable information about the position of captions of [com.quarkdown.core.ast.quarkdown.CaptionableNode] nodes in a document.

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/document/layout/caption/CaptionPositionInfo.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/document/layout/caption/CaptionPositionInfo.kt
@@ -1,15 +1,18 @@
 package com.quarkdown.core.document.layout.caption
 
+import com.quarkdown.automerge.annotations.Mergeable
+
 /**
- * Mutable information about the position of captions of [com.quarkdown.core.ast.quarkdown.CaptionableNode] nodes in a document.
+ * Immutable information about the position of captions of [com.quarkdown.core.ast.quarkdown.CaptionableNode] nodes in a document.
  * @param default default relative position of captions
  * @param figures position of captions for [com.quarkdown.core.ast.quarkdown.block.Figure], if different from the default
  * @param tables position of captions for [com.quarkdown.core.ast.base.block.Table], if different from the default
  */
+@Mergeable
 data class CaptionPositionInfo(
-    var default: CaptionPosition = CaptionPosition.BOTTOM,
-    var figures: CaptionPosition? = null,
-    var tables: CaptionPosition? = null,
+    val default: CaptionPosition = CaptionPosition.BOTTOM,
+    val figures: CaptionPosition? = null,
+    val tables: CaptionPosition? = null,
 ) {
     /**
      * @return the value of [property] if it is not `null`, otherwise the [default] value.

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/document/layout/font/FontInfo.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/document/layout/font/FontInfo.kt
@@ -1,19 +1,21 @@
 package com.quarkdown.core.document.layout.font
 
+import com.quarkdown.automerge.annotations.Mergeable
 import com.quarkdown.core.document.size.Size
 import com.quarkdown.core.misc.font.FontFamily
 
 /**
- * Mutable information about the global font configuration of a document.
+ * Immutable information about the global font configuration of a document.
  * When any of the fields is `null`, the default value supplied by the underlying renderer is used.
  * @param mainFamily font family of generic content
  * @param headingFamily font family of headings
  * @param codeFamily font family of code blocks and code spans
  * @param size font size of generic content. Other elements will scale accordingly
  */
+@Mergeable
 data class FontInfo(
-    var mainFamily: FontFamily? = null,
-    var headingFamily: FontFamily? = null,
-    var codeFamily: FontFamily? = null,
-    var size: Size? = null,
+    val mainFamily: FontFamily? = null,
+    val headingFamily: FontFamily? = null,
+    val codeFamily: FontFamily? = null,
+    val size: Size? = null,
 )

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/document/layout/font/FontInfo.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/document/layout/font/FontInfo.kt
@@ -1,6 +1,6 @@
 package com.quarkdown.core.document.layout.font
 
-import com.quarkdown.automerge.annotations.Mergeable
+import com.quarkdown.amber.annotations.Mergeable
 import com.quarkdown.core.document.size.Size
 import com.quarkdown.core.misc.font.FontFamily
 

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/document/layout/page/PageFormatInfo.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/document/layout/page/PageFormatInfo.kt
@@ -1,6 +1,6 @@
 package com.quarkdown.core.document.layout.page
 
-import com.quarkdown.automerge.annotations.Mergeable
+import com.quarkdown.amber.annotations.Mergeable
 import com.quarkdown.core.ast.quarkdown.block.Container
 import com.quarkdown.core.document.size.Size
 import com.quarkdown.core.document.size.Sizes

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/document/layout/page/PageFormatInfo.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/document/layout/page/PageFormatInfo.kt
@@ -1,5 +1,6 @@
 package com.quarkdown.core.document.layout.page
 
+import com.quarkdown.automerge.annotations.Mergeable
 import com.quarkdown.core.ast.quarkdown.block.Container
 import com.quarkdown.core.document.size.Size
 import com.quarkdown.core.document.size.Sizes
@@ -7,7 +8,7 @@ import com.quarkdown.core.misc.color.Color
 import com.quarkdown.core.util.Defaultable
 
 /**
- * Mutable information about the format of all pages of a document.
+ * Immutable information about the format of all pages of a document.
  * When any of the fields is `null`, the default value supplied by the underlying renderer is used.
  *
  * This class is marked as [Defaultable], since its default values can be supplied by the document type
@@ -21,12 +22,13 @@ import com.quarkdown.core.util.Defaultable
  * @param columnCount number of columns on each page. If set, the layout becomes multi-column
  * @param alignment text alignment of the content of each page
  */
+@Mergeable
 data class PageFormatInfo(
-    var pageWidth: Size? = null,
-    var pageHeight: Size? = null,
-    var margin: Sizes? = null,
-    var contentBorderWidth: Sizes? = null,
-    var contentBorderColor: Color? = null,
-    var columnCount: Int? = null,
-    var alignment: Container.TextAlignment? = null,
+    val pageWidth: Size? = null,
+    val pageHeight: Size? = null,
+    val margin: Sizes? = null,
+    val contentBorderWidth: Sizes? = null,
+    val contentBorderColor: Color? = null,
+    val columnCount: Int? = null,
+    val alignment: Container.TextAlignment? = null,
 ) : Defaultable

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/document/layout/paragraph/ParagraphStyleInfo.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/document/layout/paragraph/ParagraphStyleInfo.kt
@@ -1,16 +1,19 @@
 package com.quarkdown.core.document.layout.paragraph
 
+import com.quarkdown.automerge.annotations.Mergeable
+
 /**
- * Mutable information about the style of paragraphs in a document.
+ * Immutable information about the style of paragraphs in a document.
  * When any of the fields is `null`, the default value supplied by the underlying renderer is used.
  * @param lineHeight height of each line, multiplied by the font size
  * @param letterSpacing whitespace between letters, multiplied by the font size
  * @param spacing whitespace between paragraphs, multiplied by the font size
  * @param indent whitespace at the start of each paragraph, following LaTeX's policy, multiplied by the font size
  */
+@Mergeable
 data class ParagraphStyleInfo(
-    var lineHeight: Double? = null,
-    var letterSpacing: Double? = null,
-    var spacing: Double? = null,
-    var indent: Double? = null,
+    val lineHeight: Double? = null,
+    val letterSpacing: Double? = null,
+    val spacing: Double? = null,
+    val indent: Double? = null,
 )

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/document/layout/paragraph/ParagraphStyleInfo.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/document/layout/paragraph/ParagraphStyleInfo.kt
@@ -1,6 +1,6 @@
 package com.quarkdown.core.document.layout.paragraph
 
-import com.quarkdown.automerge.annotations.Mergeable
+import com.quarkdown.amber.annotations.Mergeable
 
 /**
  * Immutable information about the style of paragraphs in a document.

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/document/numbering/DocumentNumbering.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/document/numbering/DocumentNumbering.kt
@@ -1,6 +1,6 @@
 package com.quarkdown.core.document.numbering
 
-import com.quarkdown.automerge.annotations.Mergeable
+import com.quarkdown.amber.annotations.Mergeable
 import com.quarkdown.core.ast.Node
 import com.quarkdown.core.ast.base.block.FootnoteDefinition
 import com.quarkdown.core.ast.base.block.Heading

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/document/tex/TexInfo.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/document/tex/TexInfo.kt
@@ -5,5 +5,5 @@ package com.quarkdown.core.document.tex
  * @param macros custom user-defined macros to be used in math expressions
  */
 data class TexInfo(
-    val macros: Map<String, String> = mutableMapOf(),
+    val macros: Map<String, String> = emptyMap(),
 )

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/document/tex/TexInfo.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/document/tex/TexInfo.kt
@@ -1,9 +1,9 @@
 package com.quarkdown.core.document.tex
 
 /**
- * Mutable TeX configuration that affects math typesetting.
- * @param macros custom user-defined macros
+ * Immutable TeX configuration that affects math typesetting.
+ * @param macros custom user-defined macros to be used in math expressions
  */
 data class TexInfo(
-    val macros: MutableMap<String, String> = mutableMapOf(),
+    val macros: Map<String, String> = mutableMapOf(),
 )

--- a/quarkdown-core/src/test/kotlin/com/quarkdown/core/FunctionNodeExpansionTest.kt
+++ b/quarkdown-core/src/test/kotlin/com/quarkdown/core/FunctionNodeExpansionTest.kt
@@ -10,8 +10,8 @@ import com.quarkdown.core.ast.base.inline.Text
 import com.quarkdown.core.ast.quarkdown.FunctionCallNode
 import com.quarkdown.core.ast.quarkdown.block.Box
 import com.quarkdown.core.ast.quarkdown.block.Container
-import com.quarkdown.core.context.Context
 import com.quarkdown.core.context.MutableContext
+import com.quarkdown.core.document.DocumentInfo
 import com.quarkdown.core.document.DocumentType
 import com.quarkdown.core.flavor.quarkdown.QuarkdownFlavor
 import com.quarkdown.core.function.call.FunctionCallArgument
@@ -64,10 +64,10 @@ class FunctionNodeExpansionTest {
 
     @Suppress("MemberVisibilityCanBePrivate")
     fun setAndEchoDocumentName(
-        @Injected context: Context,
+        @Injected context: MutableContext,
         name: String,
     ): StringValue {
-        context.documentInfo.name = name
+        context.documentInfo = context.documentInfo.copy(name = name)
         return StringValue(context.documentInfo.name!!)
     }
 
@@ -376,7 +376,7 @@ class FunctionNodeExpansionTest {
 
     @Test
     fun `invalid document type`() {
-        context.documentInfo.type = DocumentType.SLIDES
+        context.documentInfo = DocumentInfo(type = DocumentType.SLIDES)
         val node =
             FunctionCallNode(
                 context,

--- a/quarkdown-core/src/test/kotlin/com/quarkdown/core/LocalizationTest.kt
+++ b/quarkdown-core/src/test/kotlin/com/quarkdown/core/LocalizationTest.kt
@@ -4,6 +4,7 @@ import com.quarkdown.core.context.Context
 import com.quarkdown.core.context.MutableContext
 import com.quarkdown.core.context.localization.localizeOrDefault
 import com.quarkdown.core.context.localization.localizeOrNull
+import com.quarkdown.core.document.DocumentInfo
 import com.quarkdown.core.flavor.quarkdown.QuarkdownFlavor
 import com.quarkdown.core.localization.Locale
 import com.quarkdown.core.localization.LocaleLoader
@@ -40,7 +41,7 @@ class LocalizationTest {
             )
 
         return MutableContext(QuarkdownFlavor).apply {
-            documentInfo.locale = locale
+            documentInfo = DocumentInfo(locale = locale)
             localizationTables["mytable"] = table
         }
     }

--- a/quarkdown-core/src/test/kotlin/com/quarkdown/core/StandaloneFunctionTest.kt
+++ b/quarkdown-core/src/test/kotlin/com/quarkdown/core/StandaloneFunctionTest.kt
@@ -1,7 +1,6 @@
 package com.quarkdown.core
 
 import com.quarkdown.core.ast.quarkdown.block.Container
-import com.quarkdown.core.context.Context
 import com.quarkdown.core.context.MutableContext
 import com.quarkdown.core.document.DocumentType
 import com.quarkdown.core.flavor.quarkdown.QuarkdownFlavor
@@ -641,10 +640,10 @@ class StandaloneFunctionTest {
 
     @Suppress("MemberVisibilityCanBePrivate")
     fun setDocumentName(
-        @Injected context: Context,
+        @Injected context: MutableContext,
         name: String,
     ): VoidValue {
-        context.documentInfo.name = name
+        context.documentInfo = context.documentInfo.copy(name = name)
         return VoidValue
     }
 
@@ -702,7 +701,7 @@ class StandaloneFunctionTest {
         documentType: DocumentType,
     ): FunctionCall<T> {
         val context = MutableContext(QuarkdownFlavor)
-        context.documentInfo.type = documentType
+        context.documentInfo = context.documentInfo.copy(type = documentType)
         val adapter = KFunctionAdapter(function)
         return FunctionCall(adapter, emptyList(), context)
     }

--- a/quarkdown-core/src/test/kotlin/com/quarkdown/core/TreeTraversalTest.kt
+++ b/quarkdown-core/src/test/kotlin/com/quarkdown/core/TreeTraversalTest.kt
@@ -19,6 +19,7 @@ import com.quarkdown.core.ast.quarkdown.block.Numbered
 import com.quarkdown.core.context.MutableContext
 import com.quarkdown.core.context.hooks.location.LocationAwareLabelStorerHook
 import com.quarkdown.core.context.hooks.location.LocationAwarenessHook
+import com.quarkdown.core.document.DocumentInfo
 import com.quarkdown.core.document.numbering.DocumentNumbering
 import com.quarkdown.core.document.numbering.NumberingFormat
 import com.quarkdown.core.flavor.quarkdown.QuarkdownFlavor
@@ -169,9 +170,12 @@ class TreeTraversalTest {
         fun getLabels(format: String): List<String> {
             val context = MutableContext(QuarkdownFlavor)
 
-            context.documentInfo.numbering =
-                DocumentNumbering(
-                    figures = NumberingFormat.fromString(format),
+            context.documentInfo =
+                DocumentInfo(
+                    numbering =
+                        DocumentNumbering(
+                            figures = NumberingFormat.fromString(format),
+                        ),
                 )
 
             ObservableAstIterator()
@@ -226,12 +230,15 @@ class TreeTraversalTest {
 
         val context = MutableContext(QuarkdownFlavor)
 
-        context.documentInfo.numbering =
-            DocumentNumbering(
-                extra =
-                    mapOf(
-                        "key1" to NumberingFormat.fromString("1.1"),
-                        "key2" to NumberingFormat.fromString("A"),
+        context.documentInfo =
+            context.documentInfo.copy(
+                numbering =
+                    DocumentNumbering(
+                        extra =
+                            mapOf(
+                                "key1" to NumberingFormat.fromString("1.1"),
+                                "key2" to NumberingFormat.fromString("A"),
+                            ),
                     ),
             )
 

--- a/quarkdown-html/src/test/kotlin/com/quarkdown/rendering/html/HtmlPostRendererTest.kt
+++ b/quarkdown-html/src/test/kotlin/com/quarkdown/rendering/html/HtmlPostRendererTest.kt
@@ -5,6 +5,7 @@ import com.quarkdown.core.context.MutableContext
 import com.quarkdown.core.document.DocumentInfo
 import com.quarkdown.core.document.DocumentTheme
 import com.quarkdown.core.document.DocumentType
+import com.quarkdown.core.document.deepCopy
 import com.quarkdown.core.document.layout.DocumentLayoutInfo
 import com.quarkdown.core.document.layout.font.FontInfo
 import com.quarkdown.core.document.layout.page.PageFormatInfo
@@ -45,10 +46,7 @@ class HtmlPostRendererTest {
         })
 
     private fun setFontInfo(fontInfo: FontInfo) {
-        context.documentInfo =
-            context.documentInfo.copy(
-                layout = context.documentInfo.layout.copy(font = fontInfo),
-            )
+        context.documentInfo = context.documentInfo.deepCopy(layoutFont = fontInfo)
     }
 
     @BeforeTest

--- a/quarkdown-html/src/test/kotlin/com/quarkdown/rendering/html/HtmlPostRendererTest.kt
+++ b/quarkdown-html/src/test/kotlin/com/quarkdown/rendering/html/HtmlPostRendererTest.kt
@@ -2,10 +2,15 @@ package com.quarkdown.rendering.html
 
 import com.quarkdown.core.ast.attributes.presence.markMathPresence
 import com.quarkdown.core.context.MutableContext
+import com.quarkdown.core.document.DocumentInfo
 import com.quarkdown.core.document.DocumentTheme
 import com.quarkdown.core.document.DocumentType
+import com.quarkdown.core.document.layout.DocumentLayoutInfo
+import com.quarkdown.core.document.layout.font.FontInfo
+import com.quarkdown.core.document.layout.page.PageFormatInfo
 import com.quarkdown.core.document.size.Sizes
 import com.quarkdown.core.document.size.inch
+import com.quarkdown.core.document.tex.TexInfo
 import com.quarkdown.core.flavor.quarkdown.QuarkdownFlavor
 import com.quarkdown.core.localization.LocaleLoader
 import com.quarkdown.core.media.ResolvableMedia
@@ -89,7 +94,7 @@ class HtmlPostRendererTest {
 
     @Test
     fun `with title`() {
-        context.documentInfo.name = "Doc title"
+        context.documentInfo = DocumentInfo(name = "Doc title")
         val postRenderer =
             postRenderer("<head><title>[[TITLE]]</title></head><body>[[CONTENT]]</body>") {
                 content("<strong>Hello, world!</strong>")
@@ -135,7 +140,7 @@ class HtmlPostRendererTest {
 
     @Test
     fun `slides conditional`() {
-        context.documentInfo.type = DocumentType.PLAIN
+        context.documentInfo = DocumentInfo(type = DocumentType.PLAIN)
         val postRenderer =
             postRenderer(
                 """
@@ -176,7 +181,10 @@ class HtmlPostRendererTest {
         )
 
     private fun fontFamilyProcessorResult() =
-        HtmlPostRenderer(context, baseTemplateProcessor = { fontFamilyProcessor }).createTemplateProcessor().process().trim()
+        HtmlPostRenderer(context, baseTemplateProcessor = { fontFamilyProcessor })
+            .createTemplateProcessor()
+            .process()
+            .trim()
 
     @Test
     fun `system font`() {
@@ -306,10 +314,13 @@ class HtmlPostRendererTest {
 
     @Test
     fun `semi-real`() {
-        context.documentInfo.name = "Quarkdown"
-        context.documentInfo.locale = LocaleLoader.SYSTEM.fromName("english")
-        context.documentInfo.type = DocumentType.SLIDES
-        context.documentInfo.layout.font.mainFamily = FontFamily.System("Arial")
+        context.documentInfo =
+            DocumentInfo(
+                name = "Quarkdown",
+                locale = LocaleLoader.SYSTEM.fromName("english"),
+                type = DocumentType.SLIDES,
+                layout = DocumentLayoutInfo(font = FontInfo(mainFamily = FontFamily.System("Arial"))),
+            )
         context.attributes.markMathPresence()
 
         val postRenderer =
@@ -392,16 +403,18 @@ class HtmlPostRendererTest {
 
     @Test
     fun real() {
-        with(context.documentInfo) {
-            name = "Quarkdown"
-            locale = LocaleLoader.SYSTEM.fromName("english")
-            type = DocumentType.SLIDES
-            layout.font.mainFamily = FontFamily.System("Arial")
-            layout.pageFormat.pageWidth = 8.5.inch
-            layout.pageFormat.margin = Sizes(1.0.inch)
-            tex.macros["\\R"] = "\\mathbb{R}"
-            tex.macros["\\Z"] = "\\mathbb{Z}"
-        }
+        context.documentInfo =
+            DocumentInfo(
+                name = "Quarkdown",
+                locale = LocaleLoader.SYSTEM.fromName("english"),
+                type = DocumentType.SLIDES,
+                layout =
+                    DocumentLayoutInfo(
+                        font = FontInfo(mainFamily = FontFamily.System("Arial")),
+                        pageFormat = PageFormatInfo(pageWidth = 8.5.inch, margin = Sizes(1.0.inch)),
+                    ),
+                tex = TexInfo(macros = mutableMapOf("\\R" to "\\mathbb{R}", "\\Z" to "\\mathbb{Z}")),
+            )
         context.attributes.markMathPresence()
 
         val postRenderer =
@@ -442,8 +455,11 @@ class HtmlPostRendererTest {
     private val plainHtml = "<html><head></head><body></body></html>"
 
     private fun `resource generation`(block: (Set<OutputResource>) -> Unit) {
-        context.documentInfo.type = DocumentType.SLIDES
-        context.documentInfo.theme = DocumentTheme(color = "darko", layout = "minimal")
+        context.documentInfo =
+            DocumentInfo(
+                type = DocumentType.SLIDES,
+                theme = DocumentTheme(color = "darko", layout = "minimal"),
+            )
         context.attributes.markMathPresence()
 
         val postRenderer = HtmlPostRenderer(context)
@@ -504,7 +520,7 @@ class HtmlPostRendererTest {
     @Test
     fun `resource generation, with specific localized theme`() {
         val context = MutableContext(QuarkdownFlavor)
-        context.documentInfo.locale = LocaleLoader.SYSTEM.find("zh-CN")
+        context.documentInfo = DocumentInfo(locale = LocaleLoader.SYSTEM.find("zh-CN"))
 
         val postRenderer = HtmlPostRenderer(context)
         val resources = postRenderer.generateResources(plainHtml)
@@ -519,7 +535,7 @@ class HtmlPostRendererTest {
     @Test
     fun `resource generation, with missing localized theme`() {
         val context = MutableContext(QuarkdownFlavor)
-        context.documentInfo.locale = LocaleLoader.SYSTEM.find("akan")
+        context.documentInfo = DocumentInfo(locale = LocaleLoader.SYSTEM.find("akan"))
 
         val postRenderer = HtmlPostRenderer(context)
         val resources = postRenderer.generateResources(plainHtml)

--- a/quarkdown-html/src/test/kotlin/com/quarkdown/rendering/html/HtmlPostRendererTest.kt
+++ b/quarkdown-html/src/test/kotlin/com/quarkdown/rendering/html/HtmlPostRendererTest.kt
@@ -44,6 +44,13 @@ class HtmlPostRendererTest {
             TemplateProcessor(template).block()
         })
 
+    private fun setFontInfo(fontInfo: FontInfo) {
+        context.documentInfo =
+            context.documentInfo.copy(
+                layout = context.documentInfo.layout.copy(font = fontInfo),
+            )
+    }
+
     @BeforeTest
     fun setup() {
         context = MutableContext(QuarkdownFlavor)
@@ -188,7 +195,8 @@ class HtmlPostRendererTest {
 
     @Test
     fun `system font`() {
-        context.documentInfo.layout.font.mainFamily = FontFamily.System("Arial")
+        setFontInfo(FontInfo(mainFamily = FontFamily.System("Arial")))
+
         assertEquals(
             """
             @font-face { font-family: '63529059'; src: local('Arial'); }
@@ -206,7 +214,9 @@ class HtmlPostRendererTest {
         val workingDirectory = File("src/test/resources")
         val path = "media/NotoSans-Regular.ttf"
         val media = ResolvableMedia(path, workingDirectory)
-        context.documentInfo.layout.font.mainFamily = FontFamily.Media(media, path)
+
+        setFontInfo(FontInfo(mainFamily = FontFamily.Media(media, path)))
+
         assertEquals(
             """
             @font-face { font-family: '${path.hashCode()}'; src: url('${File(workingDirectory, path).absolutePath}'); }
@@ -225,9 +235,12 @@ class HtmlPostRendererTest {
         val path = "media/NotoSans-Regular.ttf"
         val file = File(workingDirectory, path)
         val media = ResolvableMedia(path, workingDirectory)
-        context.documentInfo.layout.font.mainFamily = FontFamily.Media(media, path)
+
+        setFontInfo(FontInfo(mainFamily = FontFamily.Media(media, path)))
+
         context.options.enableLocalMediaStorage = true
         context.mediaStorage.register(path, media)
+
         assertEquals(
             """
             @font-face { font-family: '${path.hashCode()}'; src: url('media/NotoSans-Regular@${file.hashCode()}.ttf'); }
@@ -245,7 +258,9 @@ class HtmlPostRendererTest {
         val url =
             "https://fonts.gstatic.com/s/notosans/v39/o-0mIpQlx3QUlC5A4PNB6Ryti20_6n1iPHjcz6L1SoM-jCpoiyD9A-9U6VTYyWtZ3rKW9w.woff"
         val media = ResolvableMedia(url)
-        context.documentInfo.layout.font.mainFamily = FontFamily.Media(media, url)
+
+        setFontInfo(FontInfo(mainFamily = FontFamily.Media(media, url)))
+
         assertEquals(
             """
             @font-face { font-family: '${url.hashCode()}'; src: url('$url'); }
@@ -263,9 +278,12 @@ class HtmlPostRendererTest {
         val url =
             "https://fonts.gstatic.com/s/notosans/v39/o-0mIpQlx3QUlC5A4PNB6Ryti20_6n1iPHjcz6L1SoM-jCpoiyD9A-9U6VTYyWtZ3rKW9w.woff"
         val media = ResolvableMedia(url)
-        context.documentInfo.layout.font.mainFamily = FontFamily.Media(media, url)
+
+        setFontInfo(FontInfo(mainFamily = FontFamily.Media(media, url)))
+
         context.options.enableRemoteMediaStorage = true
         context.mediaStorage.register(url, media)
+
         assertEquals(
             """
             @font-face { font-family: '${url.hashCode()}'; src: url('media/https-fonts.gstatic.com-s-notosans-v39-o-0mIpQlx3QUlC5A4PNB6Ryti20_6n1iPHjcz6L1SoM-jCpoiyD9A-9U6VTYyWtZ3rKW9w.woff'); }
@@ -281,7 +299,9 @@ class HtmlPostRendererTest {
     @Test
     fun `google font`() {
         val name = "Karla"
-        context.documentInfo.layout.font.mainFamily = FontFamily.GoogleFont(name)
+
+        setFontInfo(FontInfo(mainFamily = FontFamily.GoogleFont(name)))
+
         assertEquals(
             """
             @import url('https://fonts.googleapis.com/css2?family=$name&display=swap');
@@ -296,8 +316,13 @@ class HtmlPostRendererTest {
 
     @Test
     fun `main and heading fonts`() {
-        context.documentInfo.layout.font.mainFamily = FontFamily.System("Arial")
-        context.documentInfo.layout.font.headingFamily = FontFamily.GoogleFont("Roboto")
+        setFontInfo(
+            FontInfo(
+                mainFamily = FontFamily.System("Arial"),
+                headingFamily = FontFamily.GoogleFont("Roboto"),
+            ),
+        )
+
         assertEquals(
             """
             @font-face { font-family: '63529059'; src: local('Arial'); }

--- a/quarkdown-html/src/test/kotlin/com/quarkdown/rendering/html/HtmlSecurityTest.kt
+++ b/quarkdown-html/src/test/kotlin/com/quarkdown/rendering/html/HtmlSecurityTest.kt
@@ -1,6 +1,7 @@
 package com.quarkdown.rendering.html
 
 import com.quarkdown.core.context.MutableContext
+import com.quarkdown.core.document.deepCopy
 import com.quarkdown.core.flavor.quarkdown.QuarkdownFlavor
 import com.quarkdown.core.template.TemplateProcessor
 import com.quarkdown.rendering.html.post.HtmlPostRenderer
@@ -27,8 +28,7 @@ class HtmlSecurityTest {
     ) {
         val context = MutableContext(QuarkdownFlavor)
 
-        context.documentInfo =
-            context.documentInfo.copy(tex = context.documentInfo.tex.copy(macros = mapOf(name to content)))
+        context.documentInfo = context.documentInfo.deepCopy(texMacros = mapOf(name to content))
 
         val postRenderer = HtmlPostRenderer(context, ::texMacrosTemplateProcessor)
 

--- a/quarkdown-html/src/test/kotlin/com/quarkdown/rendering/html/HtmlSecurityTest.kt
+++ b/quarkdown-html/src/test/kotlin/com/quarkdown/rendering/html/HtmlSecurityTest.kt
@@ -26,7 +26,10 @@ class HtmlSecurityTest {
         expectedResult: String,
     ) {
         val context = MutableContext(QuarkdownFlavor)
-        context.documentInfo.tex.macros[name] = content
+
+        context.documentInfo =
+            context.documentInfo.copy(tex = context.documentInfo.tex.copy(macros = mapOf(name to content)))
+
         val postRenderer = HtmlPostRenderer(context, ::texMacrosTemplateProcessor)
 
         assertEquals(

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Document.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Document.kt
@@ -15,6 +15,8 @@ import com.quarkdown.core.document.DocumentInfo
 import com.quarkdown.core.document.DocumentTheme
 import com.quarkdown.core.document.DocumentType
 import com.quarkdown.core.document.layout.caption.CaptionPosition
+import com.quarkdown.core.document.layout.caption.CaptionPositionInfo
+import com.quarkdown.core.document.layout.caption.merge
 import com.quarkdown.core.document.layout.font.FontInfo
 import com.quarkdown.core.document.layout.font.merge
 import com.quarkdown.core.document.layout.page.PageFormatInfo
@@ -527,16 +529,25 @@ fun paragraphStyle(
  */
 @Name("captionposition")
 fun captionPosition(
-    @Injected context: Context,
+    @Injected context: MutableContext,
     @LikelyNamed default: CaptionPosition? = null,
     @LikelyNamed figures: CaptionPosition? = null,
     @LikelyNamed tables: CaptionPosition? = null,
 ): VoidValue {
-    with(context.documentInfo.layout.captionPosition) {
-        this.default = default ?: this.default
-        this.figures = figures ?: this.figures
-        this.tables = tables ?: this.tables
-    }
+    val currentPosition = context.documentInfo.layout.captionPosition
+    val position =
+        CaptionPositionInfo(
+            default = default ?: currentPosition.default,
+            figures = figures,
+            tables = tables,
+        )
+
+    // Update global caption position.
+    context.documentInfo =
+        context.documentInfo.copy(
+            layout = context.documentInfo.layout.copy(captionPosition = position.merge(currentPosition)),
+        )
+
     return VoidValue
 }
 

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Document.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Document.kt
@@ -14,6 +14,7 @@ import com.quarkdown.core.document.DocumentAuthor
 import com.quarkdown.core.document.DocumentInfo
 import com.quarkdown.core.document.DocumentTheme
 import com.quarkdown.core.document.DocumentType
+import com.quarkdown.core.document.deepCopy
 import com.quarkdown.core.document.layout.caption.CaptionPosition
 import com.quarkdown.core.document.layout.caption.CaptionPositionInfo
 import com.quarkdown.core.document.layout.caption.merge
@@ -470,10 +471,7 @@ fun font(
         )
 
     // Update global font info.
-    context.documentInfo =
-        context.documentInfo.copy(
-            layout = context.documentInfo.layout.copy(font = fontInfo.merge(context.documentInfo.layout.font)),
-        )
+    context.documentInfo = context.documentInfo.deepCopy(layoutFont = fontInfo.merge(context.documentInfo.layout.font))
 
     return VoidValue
 }
@@ -512,10 +510,7 @@ fun paragraphStyle(
         )
 
     // Update global paragraph style.
-    context.documentInfo =
-        context.documentInfo.copy(
-            layout = context.documentInfo.layout.copy(paragraphStyle = style.merge(currentStyle)),
-        )
+    context.documentInfo = context.documentInfo.deepCopy(layoutParagraphStyle = style.merge(currentStyle))
 
     return VoidValue
 }
@@ -543,10 +538,7 @@ fun captionPosition(
         )
 
     // Update global caption position.
-    context.documentInfo =
-        context.documentInfo.copy(
-            layout = context.documentInfo.layout.copy(captionPosition = position.merge(currentPosition)),
-        )
+    context.documentInfo = context.documentInfo.deepCopy(layoutCaptionPosition = position.merge(currentPosition))
 
     return VoidValue
 }
@@ -655,10 +647,7 @@ fun pageFormat(
         )
 
     // Update global page format.
-    context.documentInfo =
-        context.documentInfo.copy(
-            layout = context.documentInfo.layout.copy(pageFormat = format.merge(currentFormat)),
-        )
+    context.documentInfo = context.documentInfo.deepCopy(layoutPageFormat = format.merge(currentFormat))
 
     return VoidValue
 }

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Document.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Document.kt
@@ -14,8 +14,9 @@ import com.quarkdown.core.document.DocumentAuthor
 import com.quarkdown.core.document.DocumentInfo
 import com.quarkdown.core.document.DocumentTheme
 import com.quarkdown.core.document.DocumentType
-import com.quarkdown.core.document.layout.DocumentLayoutInfo
 import com.quarkdown.core.document.layout.caption.CaptionPosition
+import com.quarkdown.core.document.layout.font.FontInfo
+import com.quarkdown.core.document.layout.font.merge
 import com.quarkdown.core.document.layout.page.PageFormatInfo
 import com.quarkdown.core.document.layout.page.PageMarginPosition
 import com.quarkdown.core.document.layout.page.PageOrientation
@@ -455,12 +456,19 @@ fun font(
 ): VoidValue {
     fun fontFamily(name: String?): FontFamily? = name?.let { loadFontFamily(it, context) }
 
-    with(context.documentInfo.layout.font) {
-        this.mainFamily = fontFamily(main) ?: this.mainFamily
-        this.headingFamily = fontFamily(heading) ?: this.headingFamily
-        this.codeFamily = fontFamily(code) ?: this.codeFamily
-        this.size = size ?: this.size
-    }
+    val fontInfo =
+        FontInfo(
+            mainFamily = fontFamily(main),
+            headingFamily = fontFamily(heading),
+            codeFamily = fontFamily(code),
+            size = size,
+        )
+
+    // Update global font info.
+    context.documentInfo =
+        context.documentInfo.copy(
+            layout = context.documentInfo.layout.copy(font = fontInfo.merge(context.documentInfo.layout.font)),
+        )
 
     return VoidValue
 }
@@ -614,8 +622,11 @@ fun pageFormat(
             contentBorderColor = borderColor,
         )
 
-    val layout: DocumentLayoutInfo = context.documentInfo.layout.copy(pageFormat = format.merge(currentFormat))
-    context.documentInfo = context.documentInfo.copy(layout = layout)
+    // Update global page format.
+    context.documentInfo =
+        context.documentInfo.copy(
+            layout = context.documentInfo.layout.copy(pageFormat = format.merge(currentFormat)),
+        )
 
     return VoidValue
 }

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Document.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Document.kt
@@ -29,6 +29,7 @@ import com.quarkdown.core.document.numbering.NumberingFormat
 import com.quarkdown.core.document.numbering.merge
 import com.quarkdown.core.document.size.Size
 import com.quarkdown.core.document.size.Sizes
+import com.quarkdown.core.document.tex.TexInfo
 import com.quarkdown.core.function.library.loader.Module
 import com.quarkdown.core.function.library.loader.moduleOf
 import com.quarkdown.core.function.reflect.annotation.Injected
@@ -553,10 +554,18 @@ fun captionPosition(
  */
 @Name("texmacro")
 fun texMacro(
-    @Injected context: Context,
+    @Injected context: MutableContext,
     name: String,
     @LikelyBody macro: String,
-) = VoidValue.also { context.documentInfo.tex.macros[name] = macro }
+) = VoidValue.also {
+    val texInfo: TexInfo =
+        context.documentInfo.tex.copy(
+            macros =
+                context.documentInfo.tex.macros + (name to macro),
+        )
+
+    context.documentInfo = context.documentInfo.copy(tex = texInfo)
+}
 
 /**
  * Sets the page layout format of the document.

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Document.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Document.kt
@@ -22,6 +22,8 @@ import com.quarkdown.core.document.layout.page.PageMarginPosition
 import com.quarkdown.core.document.layout.page.PageOrientation
 import com.quarkdown.core.document.layout.page.PageSizeFormat
 import com.quarkdown.core.document.layout.page.merge
+import com.quarkdown.core.document.layout.paragraph.ParagraphStyleInfo
+import com.quarkdown.core.document.layout.paragraph.merge
 import com.quarkdown.core.document.numbering.DocumentNumbering
 import com.quarkdown.core.document.numbering.NumberingFormat
 import com.quarkdown.core.document.numbering.merge
@@ -490,18 +492,28 @@ fun font(
  */
 @Name("paragraphstyle")
 fun paragraphStyle(
-    @Injected context: Context,
+    @Injected context: MutableContext,
     @Name("lineheight") lineHeight: Number? = null,
     @Name("letterspacing") letterSpacing: Number? = null,
     @LikelyNamed spacing: Number? = null,
     @LikelyNamed indent: Number? = null,
 ): VoidValue {
-    with(context.documentInfo.layout.paragraphStyle) {
-        this.lineHeight = lineHeight?.toDouble() ?: this.lineHeight
-        this.letterSpacing = letterSpacing?.toDouble() ?: this.letterSpacing
-        this.spacing = spacing?.toDouble() ?: this.spacing
-        this.indent = indent?.toDouble() ?: this.indent
-    }
+    val currentStyle = context.documentInfo.layout.paragraphStyle
+
+    val style =
+        ParagraphStyleInfo(
+            lineHeight = lineHeight?.toDouble(),
+            letterSpacing = letterSpacing?.toDouble(),
+            spacing = spacing?.toDouble(),
+            indent = indent?.toDouble(),
+        )
+
+    // Update global paragraph style.
+    context.documentInfo =
+        context.documentInfo.copy(
+            layout = context.documentInfo.layout.copy(paragraphStyle = style.merge(currentStyle)),
+        )
+
     return VoidValue
 }
 


### PR DESCRIPTION
This PR makes `DocumentInfo` immutable, along with its data properties (`PageFormatInfo`, `ParagraphStyleInfo`, `DocumentNumbering`, `CaptionPositionInfo`, `FontInfo`, `TexInfo`).

This is powered by the [amber](https://github.com/quarkdown-labs/amber.kt) library, made ad-hoc for this specific use case.

The entry point to mutate the document info and metadata is now by overwriting `MutableContext#documentInfo`. 