### PR TITLE
feat!: number all tables, no longer require caption

### DIFF
--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/context/hooks/location/LocationAwareLabelStorerHook.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/context/hooks/location/LocationAwareLabelStorerHook.kt
@@ -52,7 +52,7 @@ class LocationAwareLabelStorerHook(
 
         updateHeadingLabels(iterator)
         updateLabels<Figure<*>>(DocumentNumbering::figures, iterator, filter = { it.caption != null })
-        updateLabels<Table>(DocumentNumbering::tables, iterator, filter = { it.caption != null })
+        updateLabels<Table>(DocumentNumbering::tables, iterator)
         updateLabels<Code>(DocumentNumbering::codeBlocks, iterator)
 
         // Updates the labels of Numbered nodes, which are grouped by their key.

--- a/quarkdown-test/src/test/kotlin/com/quarkdown/test/CrossReferenceTest.kt
+++ b/quarkdown-test/src/test/kotlin/com/quarkdown/test/CrossReferenceTest.kt
@@ -287,7 +287,7 @@ class CrossReferenceTest {
             | Header 1 | Header 2 |
             |----------|----------|
             | Cell 1   | Cell 2   |
-            "" {#my-table}
+            {#my-table}
             
             | Header 1 | Header 2 |
             |----------|----------|

--- a/quarkdown-test/src/test/kotlin/com/quarkdown/test/NumberingTest.kt
+++ b/quarkdown-test/src/test/kotlin/com/quarkdown/test/NumberingTest.kt
@@ -368,8 +368,11 @@ class NumberingTest {
                 it,
             )
         }
+    }
 
-        // Non-captioned elements are not counted.
+    @Test
+    fun `non-captioned figures are not numbered`() {
+        // Non-captioned tables are numbered since v1.10.
         execute(
             """
             .noautopagebreak
@@ -397,14 +400,15 @@ class NumberingTest {
             assertEquals(
                 "<h1>A</h1>" +
                     "<figure><img src=\"img.png\" alt=\"\" /></figure>" +
-                    "<table><thead><tr><th>A</th><th>B</th><th>C</th></tr></thead>" +
-                    "<tbody><tr><td>D</td><td>E</td><td>F</td></tr></tbody></table>" +
+                    "<table id=\"table-1.1\"><thead><tr><th>A</th><th>B</th><th>C</th></tr></thead>" +
+                    "<tbody><tr><td>D</td><td>E</td><td>F</td></tr></tbody>" +
+                    "<caption class=\"caption-bottom\" data-location=\"1.1\"></caption></table>" +
                     "<figure id=\"figure-1.1\"><img src=\"img.png\" alt=\"\" title=\"Caption\" />" +
                     "<figcaption class=\"caption-bottom\" data-location=\"1.1\">Caption</figcaption>" +
                     "</figure>" +
-                    "<table id=\"table-1.1\"><thead><tr><th>A</th><th>B</th><th>C</th></tr></thead>" +
+                    "<table id=\"table-1.2\"><thead><tr><th>A</th><th>B</th><th>C</th></tr></thead>" +
                     "<tbody><tr><td>D</td><td>E</td><td>F</td></tr></tbody>" +
-                    "<caption class=\"caption-bottom\" data-location=\"1.1\">Caption</caption></table>",
+                    "<caption class=\"caption-bottom\" data-location=\"1.2\">Caption</caption></table>",
                 it,
             )
         }


### PR DESCRIPTION
As long as there is a table numbering format, all tables will be numbered.

Until now, a caption, even empty, was needed in order to number a table. This constraint is going to be kept for figures. 