### PR TITLE
fix(lexer): fix multiple inline math that could be tokenized as a single block

### DIFF
--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/lexer/patterns/PatternHelpers.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/lexer/patterns/PatternHelpers.kt
@@ -15,7 +15,22 @@ internal object PatternHelpers {
      */
     const val DELIMITED_TITLE = """"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|\((?:\\.|[^)\\])*\)"""
 
-    /** Comments */
+    /**
+     * Pattern of one-line fenced content between two dollar signs,
+     * which is used for [com.quarkdown.core.lexer.tokens.OnelineMathToken] and [com.quarkdown.core.lexer.tokens.InlineMathToken]
+     * The spacing between the dollar signs and the inner content must be of one unit.
+     *
+     * Inner dollar signs are included in the content as long as they are not adjacent to whitespace or non-word characters.
+     */
+    const val ONELINE_MATH =
+        // Starting delimiter.
+        "\\$[ \\t]" +
+            // Ungreedy content: stop at the first delimiter wrapped by whitespace.
+            "((?:[^$\\n]|[^\\s]\\$|\\$[^\\s])+?)" +
+            // Ending delimiter.
+            "(?<![ \\t])[ \\t]\\$"
+
+    /** Comments. */
     val COMMENT = "<!--(-?>|[\\s\\S]*?-->)".toRegex()
 
     /**

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/lexer/patterns/QuarkdownBlockTokenRegexPatterns.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/lexer/patterns/QuarkdownBlockTokenRegexPatterns.kt
@@ -62,7 +62,7 @@ class QuarkdownBlockTokenRegexPatterns : BaseMarkdownBlockTokenRegexPatterns() {
             wrap = ::OnelineMathToken,
             regex =
                 RegexBuilder("^ {0,3}math[ \\t]*customid?[ \\t]*$")
-                    .withReference("math", ONELINE_MATH_HELPER)
+                    .withReference("math", PatternHelpers.ONELINE_MATH)
                     .withReference("customid", PatternHelpers.customId("onelinemath"))
                     .build(),
             groupNames = listOf("onelinemathcustomid"),
@@ -78,9 +78,3 @@ class QuarkdownBlockTokenRegexPatterns : BaseMarkdownBlockTokenRegexPatterns() {
         FunctionCallPatterns().blockFunctionCall
     }
 }
-
-/**
- * Pattern of one-line fenced content between two dollar signs.
- * The spacing between the dollar signs and the inner content must be of one unit.
- */
-const val ONELINE_MATH_HELPER = "\\\$[ \\t](.+?)(?<![ \\t])[ \\t]\\\$"

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/lexer/patterns/QuarkdownInlineTokenRegexPatterns.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/lexer/patterns/QuarkdownInlineTokenRegexPatterns.kt
@@ -24,8 +24,8 @@ class QuarkdownInlineTokenRegexPatterns : BaseMarkdownInlineTokenRegexPatterns()
             name = "InlineMath",
             wrap = ::InlineMathToken,
             regex =
-                RegexBuilder("(?<=^|\\s|\\W)math(?=\$|\\s|\\W)")
-                    .withReference("math", ONELINE_MATH_HELPER)
+                RegexBuilder("(?<=^|\\s|\\W)math(?=$|\\s|\\W)")
+                    .withReference("math", PatternHelpers.ONELINE_MATH)
                     .build(),
         )
     }

--- a/quarkdown-core/src/test/kotlin/com/quarkdown/core/BlockParserTest.kt
+++ b/quarkdown-core/src/test/kotlin/com/quarkdown/core/BlockParserTest.kt
@@ -276,6 +276,9 @@ class BlockParserTest {
             assertEquals("Math expression", nodes.next().expression)
         }
 
+        assertEquals($$"Math $expression", nodes.next().expression)
+        assertEquals("Math expression$", nodes.next().expression)
+
         with(nodes.next()) {
             assertEquals("Math expression", expression)
             assertEquals("custom-id", referenceId)

--- a/quarkdown-core/src/test/kotlin/com/quarkdown/core/InlineParserTest.kt
+++ b/quarkdown-core/src/test/kotlin/com/quarkdown/core/InlineParserTest.kt
@@ -522,6 +522,9 @@ class InlineParserTest {
         repeat(7) {
             assertEquals("Math expression", nodes.next().expression)
         }
-        assertEquals("Math \$expression", nodes.next().expression)
+        assertEquals($$"Math $expression", nodes.next().expression)
+        assertEquals("Math", nodes.next().expression)
+        assertEquals("expression", nodes.next().expression)
+        assertFalse(nodes.hasNext())
     }
 }

--- a/quarkdown-core/src/test/resources/parsing/inline/mathspan.md
+++ b/quarkdown-core/src/test/resources/parsing/inline/mathspan.md
@@ -15,3 +15,5 @@ Text,$ Math expression $
 Text$ Not math expression $ text
 
 $ Math $expression $ text
+
+$ Math $ abc $ expression $

--- a/quarkdown-core/src/test/resources/parsing/math_oneline.md
+++ b/quarkdown-core/src/test/resources/parsing/math_oneline.md
@@ -1,5 +1,11 @@
 $ Math expression $
 
+$Not math $
+
+$ Not math$
+
+$Not math $
+
 A paragraph
 $ Not math: this is inline math $
 
@@ -10,5 +16,11 @@ $ Not math: this is inline math $
 $ Not math  $
 
 $ Not math $ some text
+
+$ Not math $ abc $ Not math $
+
+$ Math $expression $
+
+$ Math expression$ $
 
 $ Math expression $ {#custom-id}

--- a/quarkdown-test/src/test/kotlin/com/quarkdown/test/MathTest.kt
+++ b/quarkdown-test/src/test/kotlin/com/quarkdown/test/MathTest.kt
@@ -5,9 +5,9 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 
 /**
- * Tests for TeX integration.
+ * Tests for math nodes and TeX integration.
  */
-class TexTest {
+class MathTest {
     @Test
     fun `inline math`() {
         execute("Hello $ \\frac {x} {2} $") {
@@ -19,10 +19,31 @@ class TexTest {
     }
 
     @Test
+    fun `multiple inline math in the same paragraph`() {
+        execute("$ \\frac {x} {2} $ and $ \\sqrt {x + 1} $") {
+            assertEquals(
+                "<p><formula>\\frac {x} {2}</formula> and <formula>\\sqrt {x + 1}</formula></p>",
+                it,
+            )
+        }
+    }
+
+    @Test
     fun `one-line block math`() {
         execute("$ \\frac {x} {2} $") {
             assertEquals(
                 "<formula data-block=\"\">\\frac {x} {2}</formula>",
+                it,
+            )
+            assertEquals(0, documentInfo.tex.macros.size)
+        }
+    }
+
+    @Test
+    fun `one-line block math with inner dollar sign`() {
+        execute("$ \\frac {x} {2}$ $") {
+            assertEquals(
+                "<formula data-block=\"\">\\frac {x} {2}$</formula>",
                 it,
             )
             assertEquals(0, documentInfo.tex.macros.size)


### PR DESCRIPTION
This PR fixes an issue that would cause multiple math spans in the same line to be tokenized as a single math block, if the line started with a math span and ended with another (e.g. `$ first $ some text $ second $`)  