### PR TITLE
[dev] refactor: improve robustness of module management

### DIFF
--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/function/library/loader/MultiFunctionLibraryLoader.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/function/library/loader/MultiFunctionLibraryLoader.kt
@@ -1,25 +1,22 @@
 package com.quarkdown.core.function.library.loader
 
 import com.quarkdown.core.function.library.Library
+import com.quarkdown.core.function.library.module.QuarkdownModule
 
 /**
- * A subsection of Quarkdown functions that can be exported via a [MultiFunctionLibraryLoader].
- */
-typealias Module = Set<ExportableFunction>
-
-/**
- * Creates a [Module] from a set of Kotlin functions.
- * @param functions the functions to export in the module
- */
-fun moduleOf(vararg functions: ExportableFunction): Module = setOf(*functions)
-
-/**
- * Creates a library from a set of Kotlin functions.
+ * Creates a library from a set of Kotlin functions exported in a [QuarkdownModule].
  * @param name name to assign to the library
  * @see FunctionLibraryLoader
  */
 class MultiFunctionLibraryLoader(
     private val name: String,
-) : LibraryLoader<Module> {
-    override fun load(source: Module): Library = MultiLibraryLoader(this.name, FunctionLibraryLoader()).load(source)
+) : LibraryLoader<QuarkdownModule> {
+    override fun load(source: QuarkdownModule): Library =
+        MultiLibraryLoader(this.name, FunctionLibraryLoader())
+            .load(source)
+
+    /**
+     * Creates a library from a set of Kotlin functions exported in multiple [QuarkdownModule]s.
+     */
+    fun load(vararg sources: QuarkdownModule): Library = load(QuarkdownModule(*sources))
 }

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/function/library/module/QuarkdownModule.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/function/library/module/QuarkdownModule.kt
@@ -1,0 +1,33 @@
+package com.quarkdown.core.function.library.module
+
+import com.quarkdown.core.function.library.loader.ExportableFunction
+import com.quarkdown.core.function.library.loader.MultiFunctionLibraryLoader
+
+/**
+ * A subsection of Quarkdown functions that can be exported via a [MultiFunctionLibraryLoader].
+ *
+ * While this class might seem redundant in place of a typealias,
+ * having an actual class makes it easier and more robust on Quarkdoc[^1]'s side to identify modules.
+ *
+ * [^1]: Quarkdoc is Quarkdown's documentation generator, based on Dokka. See the `quarkdown-quarkdoc` module.
+ *
+ * @param functions the functions to export in the module
+ */
+class QuarkdownModule(
+    functions: Set<ExportableFunction>,
+) : HashSet<ExportableFunction>(functions) {
+    /**
+     * Creates a [QuarkdownModule] that wraps multiple [QuarkdownModule]s, joining their functions into a single module.
+     * The identity of the submodules is lost in the process.
+     * @param modules the modules to include
+     */
+    constructor(vararg modules: QuarkdownModule) : this(modules.flatMap { it.asSequence() }.toSet())
+
+    operator fun plus(other: QuarkdownModule): QuarkdownModule = QuarkdownModule(this + other)
+}
+
+/**
+ * Creates a [QuarkdownModule] from a set of Kotlin functions.
+ * @param functions the functions to export in the module
+ */
+fun moduleOf(vararg functions: ExportableFunction): QuarkdownModule = setOf(*functions).let(::QuarkdownModule)

--- a/quarkdown-core/src/test/kotlin/com/quarkdown/core/FunctionNodeExpansionTest.kt
+++ b/quarkdown-core/src/test/kotlin/com/quarkdown/core/FunctionNodeExpansionTest.kt
@@ -18,6 +18,7 @@ import com.quarkdown.core.function.call.FunctionCallArgument
 import com.quarkdown.core.function.call.FunctionCallNodeExpander
 import com.quarkdown.core.function.library.LibraryRegistrant
 import com.quarkdown.core.function.library.loader.MultiFunctionLibraryLoader
+import com.quarkdown.core.function.library.module.moduleOf
 import com.quarkdown.core.function.reflect.annotation.Injected
 import com.quarkdown.core.function.reflect.annotation.Name
 import com.quarkdown.core.function.reflect.annotation.NotForDocumentType
@@ -87,7 +88,7 @@ class FunctionNodeExpansionTest {
 
         val library =
             MultiFunctionLibraryLoader("lib").load(
-                setOf(
+                moduleOf(
                     ::sum,
                     ::myFunction,
                     ::echoBoolean,

--- a/quarkdown-core/src/test/kotlin/com/quarkdown/core/StandaloneFunctionTest.kt
+++ b/quarkdown-core/src/test/kotlin/com/quarkdown/core/StandaloneFunctionTest.kt
@@ -19,6 +19,7 @@ import com.quarkdown.core.function.error.UnnamedArgumentAfterNamedException
 import com.quarkdown.core.function.error.UnresolvedParameterException
 import com.quarkdown.core.function.expression.ComposedExpression
 import com.quarkdown.core.function.library.loader.MultiFunctionLibraryLoader
+import com.quarkdown.core.function.library.module.moduleOf
 import com.quarkdown.core.function.reflect.KFunctionAdapter
 import com.quarkdown.core.function.reflect.annotation.Injected
 import com.quarkdown.core.function.reflect.annotation.NotForDocumentType
@@ -740,7 +741,7 @@ class StandaloneFunctionTest {
 
     @Test
     fun `library loader`() {
-        val library = MultiFunctionLibraryLoader("MyLib").load(setOf(::greetWithArgs, ::greetNoArgs, ::sum))
+        val library = MultiFunctionLibraryLoader("MyLib").load(moduleOf(::greetWithArgs, ::greetNoArgs, ::sum))
 
         assertEquals("MyLib", library.name)
         assertEquals(3, library.functions.size)

--- a/quarkdown-quarkdoc/src/main/kotlin/com/quarkdown/quarkdoc/dokka/transformers/module/ModulesStorer.kt
+++ b/quarkdown-quarkdoc/src/main/kotlin/com/quarkdown/quarkdoc/dokka/transformers/module/ModulesStorer.kt
@@ -1,17 +1,12 @@
 package com.quarkdown.quarkdoc.dokka.transformers.module
 
-import com.quarkdown.core.function.library.loader.MultiFunctionLibraryLoader
+import com.quarkdown.core.function.library.module.QuarkdownModule
 import com.quarkdown.quarkdoc.dokka.transformers.QuarkdocDocumentableReplacerTransformer
 import com.quarkdown.quarkdoc.dokka.util.isOfType
 import com.quarkdown.quarkdoc.dokka.util.sourcePaths
 import org.jetbrains.dokka.model.DProperty
 import org.jetbrains.dokka.model.GenericTypeConstructor
-import org.jetbrains.dokka.model.TypeAliased
 import org.jetbrains.dokka.plugability.DokkaContext
-
-// Cannot retrieve Module's class as it's typealiased.
-private const val MODULE_CLASS_NAME = "Module"
-private val MODULE_PACKAGE_NAME = MultiFunctionLibraryLoader::class.java.`package`.name
 
 /**
  * Transformer that, instead of performing transformations,
@@ -22,9 +17,8 @@ class ModulesStorer(
     context: DokkaContext,
 ) : QuarkdocDocumentableReplacerTransformer(context) {
     private fun isModuleDefinition(property: DProperty): Boolean {
-        val typeAlias = property.type as? TypeAliased ?: return false
-        val type = typeAlias.typeAlias as? GenericTypeConstructor ?: return false
-        return type.dri.isOfType(MODULE_PACKAGE_NAME, MODULE_CLASS_NAME)
+        val type = property.type as? GenericTypeConstructor ?: return false
+        return type.dri.isOfType<QuarkdownModule>()
     }
 
     override fun transformProperty(property: DProperty): AnyWithChanges<DProperty> {

--- a/quarkdown-quarkdoc/src/test/kotlin/com/quarkdown/quarkdoc/dokka/ModuleTransformerTest.kt
+++ b/quarkdown-quarkdoc/src/test/kotlin/com/quarkdown/quarkdoc/dokka/ModuleTransformerTest.kt
@@ -1,6 +1,6 @@
 package com.quarkdown.quarkdoc.dokka
 
-import com.quarkdown.core.function.library.loader.MultiFunctionLibraryLoader
+import com.quarkdown.core.function.library.module.QuarkdownModule
 import com.quarkdown.core.function.value.VoidValue
 import com.quarkdown.quarkdoc.dokka.transformers.module.QuarkdownModulesStorage
 import kotlin.test.Test
@@ -12,8 +12,8 @@ import kotlin.test.assertEquals
  */
 class ModuleTransformerTest :
     QuarkdocDokkaTest(
-        imports = listOf(MultiFunctionLibraryLoader::class, VoidValue::class),
-        stringImports = listOf("${MultiFunctionLibraryLoader::class.java.`package`.name}.Module"),
+        imports = listOf(QuarkdownModule::class, VoidValue::class),
+        stringImports = listOf(QuarkdownModule::class.java.packageName + ".*"),
     ) {
     @Test
     fun `two modules`() {
@@ -21,12 +21,12 @@ class ModuleTransformerTest :
             mapOf(
                 "M1.kt" to
                     """
-                    val Module1: Module = moduleOf(::aFunction)
+                    val Module1: QuarkdownModule = moduleOf(::aFunction)
                     fun aFunction() = VoidValue
                     """.trimIndent(),
                 "M2.kt" to
                     """
-                    val Module2: Module = moduleOf(::bFunction)
+                    val Module2: QuarkdownModule = moduleOf(::bFunction)
                     fun bFunction() = VoidValue
                     """.trimIndent(),
             )
@@ -47,12 +47,12 @@ class ModuleTransformerTest :
             mapOf(
                 "M1.kt" to
                     """
-                    val Module1: Module = moduleOf(::aFunction)
+                    val Module1: QuarkdownModule = moduleOf(::aFunction)
                     fun aFunction() = VoidValue
                     """.trimIndent(),
                 "M2.kt" to
                     """
-                    val Module2: Module = moduleOf(::bFunction)
+                    val Module2: QuarkdownModule = moduleOf(::bFunction)
                     fun bFunction() = VoidValue
                     """.trimIndent(),
                 "leftover.kt" to "object leftover {}",
@@ -73,7 +73,7 @@ class ModuleTransformerTest :
             (1..moduleCount).associate {
                 "M$it.kt" to
                     """
-                    val Module$it: Module = moduleOf(::someFunction$it)
+                    val Module$it: QuarkdownModule = moduleOf(::someFunction$it)
                     fun someFunction$it() = VoidValue
                     """.trimIndent()
             }

--- a/quarkdown-quarkdoc/src/test/kotlin/com/quarkdown/quarkdoc/dokka/QuarkdownSignatureTest.kt
+++ b/quarkdown-quarkdoc/src/test/kotlin/com/quarkdown/quarkdoc/dokka/QuarkdownSignatureTest.kt
@@ -1,6 +1,6 @@
 package com.quarkdown.quarkdoc.dokka
 
-import com.quarkdown.core.function.library.loader.MultiFunctionLibraryLoader
+import com.quarkdown.core.function.library.module.QuarkdownModule
 import com.quarkdown.core.function.value.DynamicValue
 import com.quarkdown.core.function.value.VoidValue
 import kotlin.test.Test
@@ -11,8 +11,8 @@ import kotlin.test.assertEquals
  */
 class QuarkdownSignatureTest :
     QuarkdocDokkaTest(
-        imports = listOf(MultiFunctionLibraryLoader::class, VoidValue::class, DynamicValue::class),
-        stringImports = listOf("${MultiFunctionLibraryLoader::class.java.`package`.name}.Module"),
+        imports = listOf(QuarkdownModule::class, VoidValue::class, DynamicValue::class),
+        stringImports = listOf(QuarkdownModule::class.java.packageName + ".*"),
     ) {
     /**
      * @param functionCode the code of the function to test. Its name must be equal to [functionName]
@@ -28,7 +28,7 @@ class QuarkdownSignatureTest :
             mapOf(
                 "TestModule.kt" to
                     """
-                    val TestModule: Module = moduleOf(::$functionName)
+                    val TestModule: QuarkdownModule = moduleOf(::$functionName)
                     $functionCode
                     """.trimIndent(),
             )

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Bibliography.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Bibliography.kt
@@ -5,8 +5,8 @@ import com.quarkdown.core.ast.quarkdown.bibliography.BibliographyCitation
 import com.quarkdown.core.ast.quarkdown.bibliography.BibliographyView
 import com.quarkdown.core.bibliography.bibtex.BibTeXBibliographyParser
 import com.quarkdown.core.context.MutableContext
-import com.quarkdown.core.function.library.loader.Module
-import com.quarkdown.core.function.library.loader.moduleOf
+import com.quarkdown.core.function.library.module.QuarkdownModule
+import com.quarkdown.core.function.library.module.moduleOf
 import com.quarkdown.core.function.reflect.annotation.Injected
 import com.quarkdown.core.function.reflect.annotation.LikelyNamed
 import com.quarkdown.core.function.reflect.annotation.Name
@@ -19,7 +19,7 @@ import com.quarkdown.core.bibliography.style.BibliographyStyle as CoreBibliograp
  * This module handles bibliographies and citations.
  * @see com.quarkdown.core.bibliography.Bibliography
  */
-val Bibliography: Module =
+val Bibliography: QuarkdownModule =
     moduleOf(
         ::bibliography,
         ::cite,

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Collection.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Collection.kt
@@ -1,7 +1,7 @@
 package com.quarkdown.stdlib
 
-import com.quarkdown.core.function.library.loader.Module
-import com.quarkdown.core.function.library.loader.moduleOf
+import com.quarkdown.core.function.library.module.QuarkdownModule
+import com.quarkdown.core.function.library.module.moduleOf
 import com.quarkdown.core.function.reflect.annotation.LikelyChained
 import com.quarkdown.core.function.reflect.annotation.Name
 import com.quarkdown.core.function.value.DynamicValue
@@ -24,7 +24,7 @@ internal const val INDEX_STARTS_AT = 1
  * `Collection` stdlib module exporter.
  * This module handles iterable collections.
  */
-val Collection: Module =
+val Collection: QuarkdownModule =
     moduleOf(
         ::collectionGet,
         ::collectionFirst,

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Data.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Data.kt
@@ -4,8 +4,8 @@ import com.github.doyaaaaaken.kotlincsv.dsl.csvReader
 import com.quarkdown.core.ast.base.block.Table
 import com.quarkdown.core.ast.base.inline.Text
 import com.quarkdown.core.context.Context
-import com.quarkdown.core.function.library.loader.Module
-import com.quarkdown.core.function.library.loader.moduleOf
+import com.quarkdown.core.function.library.module.QuarkdownModule
+import com.quarkdown.core.function.library.module.moduleOf
 import com.quarkdown.core.function.reflect.annotation.Injected
 import com.quarkdown.core.function.reflect.annotation.LikelyNamed
 import com.quarkdown.core.function.reflect.annotation.Name
@@ -21,7 +21,7 @@ import java.io.File
  * `Data` stdlib module exporter.
  * This module handles content fetched from external resources.
  */
-val Data: Module =
+val Data: QuarkdownModule =
     moduleOf(
         ::read,
         ::csv,

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Dictionary.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Dictionary.kt
@@ -1,7 +1,7 @@
 package com.quarkdown.stdlib
 
-import com.quarkdown.core.function.library.loader.Module
-import com.quarkdown.core.function.library.loader.moduleOf
+import com.quarkdown.core.function.library.module.QuarkdownModule
+import com.quarkdown.core.function.library.module.moduleOf
 import com.quarkdown.core.function.reflect.annotation.LikelyBody
 import com.quarkdown.core.function.reflect.annotation.LikelyChained
 import com.quarkdown.core.function.reflect.annotation.Name
@@ -13,7 +13,7 @@ import com.quarkdown.core.function.value.OutputValue
  * `Dictionary` stdlib module exporter.
  * This module handles map-like dictionaries.
  */
-val Dictionary: Module =
+val Dictionary: QuarkdownModule =
     moduleOf(
         ::dictionary,
         ::dictionaryGet,

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Document.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Document.kt
@@ -33,8 +33,8 @@ import com.quarkdown.core.document.numbering.merge
 import com.quarkdown.core.document.size.Size
 import com.quarkdown.core.document.size.Sizes
 import com.quarkdown.core.document.tex.TexInfo
-import com.quarkdown.core.function.library.loader.Module
-import com.quarkdown.core.function.library.loader.moduleOf
+import com.quarkdown.core.function.library.module.QuarkdownModule
+import com.quarkdown.core.function.library.module.moduleOf
 import com.quarkdown.core.function.reflect.annotation.Injected
 import com.quarkdown.core.function.reflect.annotation.LikelyBody
 import com.quarkdown.core.function.reflect.annotation.LikelyNamed
@@ -58,7 +58,7 @@ import com.quarkdown.stdlib.internal.loadFontFamily
  * This module handles document information and details.
  * @see com.quarkdown.core.document.DocumentInfo
  */
-val Document: Module =
+val Document: QuarkdownModule =
     moduleOf(
         ::docType,
         ::docName,

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Ecosystem.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Ecosystem.kt
@@ -2,8 +2,8 @@ package com.quarkdown.stdlib
 
 import com.quarkdown.core.context.Context
 import com.quarkdown.core.context.MutableContext
-import com.quarkdown.core.function.library.loader.Module
-import com.quarkdown.core.function.library.loader.moduleOf
+import com.quarkdown.core.function.library.module.QuarkdownModule
+import com.quarkdown.core.function.library.module.moduleOf
 import com.quarkdown.core.function.reflect.annotation.Injected
 import com.quarkdown.core.function.reflect.annotation.LikelyBody
 import com.quarkdown.core.function.reflect.annotation.Name
@@ -21,7 +21,7 @@ import java.io.Reader
  * `Ecosystem` stdlib module exporter.
  * This module handles interaction between Quarkdown sources.
  */
-val Ecosystem: Module =
+val Ecosystem: QuarkdownModule =
     moduleOf(
         ::include,
         ::includeAll,

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Flow.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Flow.kt
@@ -6,8 +6,8 @@ import com.quarkdown.core.context.ScopeContext
 import com.quarkdown.core.function.FunctionParameter
 import com.quarkdown.core.function.SimpleFunction
 import com.quarkdown.core.function.library.Library
-import com.quarkdown.core.function.library.loader.Module
-import com.quarkdown.core.function.library.loader.moduleOf
+import com.quarkdown.core.function.library.module.QuarkdownModule
+import com.quarkdown.core.function.library.module.moduleOf
 import com.quarkdown.core.function.reflect.annotation.Injected
 import com.quarkdown.core.function.reflect.annotation.LikelyBody
 import com.quarkdown.core.function.reflect.annotation.Name
@@ -29,7 +29,7 @@ import com.quarkdown.core.function.value.wrappedAsValue
  * `Flow` stdlib module exporter.
  * This module handles the control flow and other statements.
  */
-val Flow: Module =
+val Flow: QuarkdownModule =
     moduleOf(
         ::`if`,
         ::ifNot,

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Injection.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Injection.kt
@@ -1,8 +1,8 @@
 package com.quarkdown.stdlib
 
 import com.quarkdown.core.ast.base.block.Html
-import com.quarkdown.core.function.library.loader.Module
-import com.quarkdown.core.function.library.loader.moduleOf
+import com.quarkdown.core.function.library.module.QuarkdownModule
+import com.quarkdown.core.function.library.module.moduleOf
 import com.quarkdown.core.function.reflect.annotation.LikelyBody
 import com.quarkdown.core.function.reflect.annotation.Name
 import com.quarkdown.core.function.value.Value
@@ -12,7 +12,7 @@ import com.quarkdown.core.function.value.wrappedAsValue
  * `Injection` stdlib module exporter.
  * This module handles code injection of different languages.
  */
-val Injection: Module =
+val Injection: QuarkdownModule =
     moduleOf(
         ::html,
         ::css,

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Layout.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Layout.kt
@@ -22,8 +22,8 @@ import com.quarkdown.core.context.localization.localizeOrDefault
 import com.quarkdown.core.context.localization.localizeOrNull
 import com.quarkdown.core.document.size.Size
 import com.quarkdown.core.document.size.Sizes
-import com.quarkdown.core.function.library.loader.Module
-import com.quarkdown.core.function.library.loader.moduleOf
+import com.quarkdown.core.function.library.module.QuarkdownModule
+import com.quarkdown.core.function.library.module.moduleOf
 import com.quarkdown.core.function.reflect.annotation.Injected
 import com.quarkdown.core.function.reflect.annotation.LikelyBody
 import com.quarkdown.core.function.reflect.annotation.LikelyNamed
@@ -42,7 +42,7 @@ import com.quarkdown.core.util.toPlainText
  * `Layout` stdlib module exporter.
  * This module handles position and shape of an element.
  */
-val Layout: Module =
+val Layout: QuarkdownModule =
     moduleOf(
         ::container,
         ::align,

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Library.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Library.kt
@@ -2,8 +2,8 @@ package com.quarkdown.stdlib
 
 import com.quarkdown.core.context.Context
 import com.quarkdown.core.function.library.Library
-import com.quarkdown.core.function.library.loader.Module
-import com.quarkdown.core.function.library.loader.moduleOf
+import com.quarkdown.core.function.library.module.QuarkdownModule
+import com.quarkdown.core.function.library.module.moduleOf
 import com.quarkdown.core.function.reflect.annotation.Injected
 import com.quarkdown.core.function.reflect.annotation.Name
 import com.quarkdown.core.function.value.BooleanValue
@@ -14,7 +14,7 @@ import com.quarkdown.core.function.value.wrappedAsValue
  * `Library` stdlib module exporter.
  * This module handles loaded libraries and their functions.
  */
-val Library: Module =
+val Library: QuarkdownModule =
     moduleOf(
         ::libraryExists,
         ::functionExists,

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Localization.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Localization.kt
@@ -2,8 +2,8 @@ package com.quarkdown.stdlib
 
 import com.quarkdown.core.context.Context
 import com.quarkdown.core.context.MutableContext
-import com.quarkdown.core.function.library.loader.Module
-import com.quarkdown.core.function.library.loader.moduleOf
+import com.quarkdown.core.function.library.module.QuarkdownModule
+import com.quarkdown.core.function.library.module.moduleOf
 import com.quarkdown.core.function.reflect.annotation.Injected
 import com.quarkdown.core.function.reflect.annotation.LikelyBody
 import com.quarkdown.core.function.reflect.annotation.LikelyNamed
@@ -22,7 +22,7 @@ import com.quarkdown.core.localization.LocalizationTable
  * `Localization` stdlib module exporter.
  * This module handles localization-related features.
  */
-val Localization: Module =
+val Localization: QuarkdownModule =
     moduleOf(
         ::localization,
         ::localize,

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Logger.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Logger.kt
@@ -1,7 +1,7 @@
 package com.quarkdown.stdlib
 
-import com.quarkdown.core.function.library.loader.Module
-import com.quarkdown.core.function.library.loader.moduleOf
+import com.quarkdown.core.function.library.module.QuarkdownModule
+import com.quarkdown.core.function.library.module.moduleOf
 import com.quarkdown.core.function.value.VoidValue
 import com.quarkdown.core.log.Log
 
@@ -9,7 +9,7 @@ import com.quarkdown.core.log.Log
  * `Logger` stdlib module exporter.
  * This module contains logging utility.
  */
-val Logger: Module =
+val Logger: QuarkdownModule =
     moduleOf(
         ::log,
         ::debug,

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Logical.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Logical.kt
@@ -1,7 +1,7 @@
 package com.quarkdown.stdlib
 
-import com.quarkdown.core.function.library.loader.Module
-import com.quarkdown.core.function.library.loader.moduleOf
+import com.quarkdown.core.function.library.module.QuarkdownModule
+import com.quarkdown.core.function.library.module.moduleOf
 import com.quarkdown.core.function.reflect.annotation.LikelyChained
 import com.quarkdown.core.function.reflect.annotation.Name
 import com.quarkdown.core.function.value.BooleanValue
@@ -10,7 +10,7 @@ import com.quarkdown.core.function.value.DynamicValue
 /**
  * `Logical` stdlib module exporter.
  */
-val Logical: Module =
+val Logical: QuarkdownModule =
     moduleOf(
         ::isLower,
         ::isGreater,

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Math.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Math.kt
@@ -1,7 +1,7 @@
 package com.quarkdown.stdlib
 
-import com.quarkdown.core.function.library.loader.Module
-import com.quarkdown.core.function.library.loader.moduleOf
+import com.quarkdown.core.function.library.module.QuarkdownModule
+import com.quarkdown.core.function.library.module.moduleOf
 import com.quarkdown.core.function.reflect.annotation.LikelyChained
 import com.quarkdown.core.function.reflect.annotation.LikelyNamed
 import com.quarkdown.core.function.reflect.annotation.Name
@@ -15,7 +15,7 @@ import kotlin.math.pow
 /**
  * `Math` stdlib module exporter.
  */
-val Math: Module =
+val Math: QuarkdownModule =
     moduleOf(
         ::sum,
         ::subtract,

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Mermaid.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Mermaid.kt
@@ -3,8 +3,8 @@ package com.quarkdown.stdlib
 import com.quarkdown.core.ast.quarkdown.block.MermaidDiagram
 import com.quarkdown.core.ast.quarkdown.block.MermaidDiagramFigure
 import com.quarkdown.core.ast.quarkdown.block.SubdocumentGraph
-import com.quarkdown.core.function.library.loader.Module
-import com.quarkdown.core.function.library.loader.moduleOf
+import com.quarkdown.core.function.library.module.QuarkdownModule
+import com.quarkdown.core.function.library.module.moduleOf
 import com.quarkdown.core.function.reflect.annotation.LikelyBody
 import com.quarkdown.core.function.reflect.annotation.LikelyNamed
 import com.quarkdown.core.function.reflect.annotation.Name
@@ -22,7 +22,7 @@ import com.quarkdown.stdlib.internal.asDouble
  * `Mermaid` stdlib module exporter.
  * This module handles generation of Mermaid diagrams.
  */
-val Mermaid: Module =
+val Mermaid: QuarkdownModule =
     moduleOf(
         ::mermaid,
         ::xyChart,

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Optionality.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Optionality.kt
@@ -1,7 +1,7 @@
 package com.quarkdown.stdlib
 
-import com.quarkdown.core.function.library.loader.Module
-import com.quarkdown.core.function.library.loader.moduleOf
+import com.quarkdown.core.function.library.module.QuarkdownModule
+import com.quarkdown.core.function.library.module.moduleOf
 import com.quarkdown.core.function.reflect.annotation.LikelyChained
 import com.quarkdown.core.function.reflect.annotation.LikelyNamed
 import com.quarkdown.core.function.reflect.annotation.Name
@@ -17,7 +17,7 @@ import com.quarkdown.core.function.value.wrappedAsValue
  * `Optionality` stdlib module exporter.
  * This module handles `None` values to express optional values.
  */
-val Optionality: Module =
+val Optionality: QuarkdownModule =
     moduleOf(
         ::none,
         ::isNone,

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Reference.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Reference.kt
@@ -1,8 +1,8 @@
 package com.quarkdown.stdlib
 
 import com.quarkdown.core.ast.quarkdown.reference.CrossReference
-import com.quarkdown.core.function.library.loader.Module
-import com.quarkdown.core.function.library.loader.moduleOf
+import com.quarkdown.core.function.library.module.QuarkdownModule
+import com.quarkdown.core.function.library.module.moduleOf
 import com.quarkdown.core.function.reflect.annotation.Name
 import com.quarkdown.core.function.value.wrappedAsValue
 
@@ -11,7 +11,7 @@ import com.quarkdown.core.function.value.wrappedAsValue
  * This module handles cross-references.
  * @see com.quarkdown.core.ast.quarkdown.reference
  */
-val Reference: Module =
+val Reference: QuarkdownModule =
     moduleOf(
         ::reference,
     )

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Slides.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Slides.kt
@@ -6,8 +6,8 @@ import com.quarkdown.core.ast.quarkdown.block.SlidesSpeakerNote
 import com.quarkdown.core.ast.quarkdown.invisible.SlidesConfigurationInitializer
 import com.quarkdown.core.document.DocumentType
 import com.quarkdown.core.document.slides.Transition
-import com.quarkdown.core.function.library.loader.Module
-import com.quarkdown.core.function.library.loader.moduleOf
+import com.quarkdown.core.function.library.module.QuarkdownModule
+import com.quarkdown.core.function.library.module.moduleOf
 import com.quarkdown.core.function.reflect.annotation.LikelyBody
 import com.quarkdown.core.function.reflect.annotation.LikelyNamed
 import com.quarkdown.core.function.reflect.annotation.Name
@@ -19,7 +19,7 @@ import com.quarkdown.core.function.value.wrappedAsValue
  * `Slides` stdlib module exporter.
  * This module handles slides properties.
  */
-val Slides: Module =
+val Slides: QuarkdownModule =
     moduleOf(
         ::setSlidesConfiguration,
         ::fragment,

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Stdlib.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Stdlib.kt
@@ -21,27 +21,27 @@ object Stdlib : LibraryExporter {
         get() =
             MultiFunctionLibraryLoader(name = "stdlib")
                 .load(
-                    Document +
-                        Layout +
-                        Text +
-                        Math +
-                        Logical +
-                        String +
-                        Collection +
-                        Dictionary +
-                        Optionality +
-                        Logger +
-                        Flow +
-                        TableComputation +
-                        Data +
-                        Localization +
-                        Library +
-                        Slides +
-                        Ecosystem +
-                        Injection +
-                        Mermaid +
-                        Reference +
-                        Bibliography,
+                    Document,
+                    Layout,
+                    Text,
+                    Math,
+                    Logical,
+                    String,
+                    Collection,
+                    Dictionary,
+                    Optionality,
+                    Logger,
+                    Flow,
+                    TableComputation,
+                    Data,
+                    Localization,
+                    Library,
+                    Slides,
+                    Ecosystem,
+                    Injection,
+                    Mermaid,
+                    Reference,
+                    Bibliography,
                 ).withHooks(
                     PipelineHooks(
                         // Localization data is loaded before any function is called.

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/String.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/String.kt
@@ -1,7 +1,7 @@
 package com.quarkdown.stdlib
 
-import com.quarkdown.core.function.library.loader.Module
-import com.quarkdown.core.function.library.loader.moduleOf
+import com.quarkdown.core.function.library.module.QuarkdownModule
+import com.quarkdown.core.function.library.module.moduleOf
 import com.quarkdown.core.function.reflect.annotation.LikelyChained
 import com.quarkdown.core.function.reflect.annotation.Name
 import com.quarkdown.core.function.value.StringValue
@@ -14,7 +14,7 @@ import com.quarkdown.core.util.trimDelimiters
  * `String` stdlib module exporter.
  * This module handles string manipulation.
  */
-val String: Module =
+val String: QuarkdownModule =
     moduleOf(
         ::string,
         ::concatenate,

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/TableComputation.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/TableComputation.kt
@@ -4,8 +4,8 @@ import com.quarkdown.core.ast.MarkdownContent
 import com.quarkdown.core.ast.NestableNode
 import com.quarkdown.core.ast.base.block.Table
 import com.quarkdown.core.ast.dsl.buildInline
-import com.quarkdown.core.function.library.loader.Module
-import com.quarkdown.core.function.library.loader.moduleOf
+import com.quarkdown.core.function.library.module.QuarkdownModule
+import com.quarkdown.core.function.library.module.moduleOf
 import com.quarkdown.core.function.reflect.annotation.LikelyBody
 import com.quarkdown.core.function.reflect.annotation.Name
 import com.quarkdown.core.function.value.BooleanValue
@@ -24,7 +24,7 @@ import com.quarkdown.core.util.toPlainText
  * beyond basic data representation.
  * It adds dynamic operations like sorting, filtering, calculations.
  */
-val TableComputation: Module =
+val TableComputation: QuarkdownModule =
     moduleOf(
         ::tableSort,
         ::tableFilter,

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Text.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Text.kt
@@ -6,8 +6,8 @@ import com.quarkdown.core.ast.base.inline.LineBreak
 import com.quarkdown.core.ast.base.inline.Link
 import com.quarkdown.core.ast.quarkdown.inline.TextTransform
 import com.quarkdown.core.ast.quarkdown.inline.TextTransformData
-import com.quarkdown.core.function.library.loader.Module
-import com.quarkdown.core.function.library.loader.moduleOf
+import com.quarkdown.core.function.library.module.QuarkdownModule
+import com.quarkdown.core.function.library.module.moduleOf
 import com.quarkdown.core.function.reflect.annotation.LikelyBody
 import com.quarkdown.core.function.reflect.annotation.LikelyNamed
 import com.quarkdown.core.function.reflect.annotation.Name
@@ -22,7 +22,7 @@ import com.quarkdown.core.util.toPlainText
  * `Text` stdlib module exporter.
  * This module handles text formatting.
  */
-val Text: Module =
+val Text: QuarkdownModule =
     moduleOf(
         ::text,
         ::lineBreak,


### PR DESCRIPTION
This PR makes native library load functions more robustely, moving from a `Module` typealias to a `QuarkdownModule` actual class. This also fixes an issue with Quarkdoc failing at identifying modules since upgrading to Kotlin 2.2.