### PR TITLE
feat(postrenderer): add document description metadata

### DIFF
--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/document/DocumentInfo.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/document/DocumentInfo.kt
@@ -10,8 +10,9 @@ import com.quarkdown.core.localization.Locale
  * Immutable information about the document.
  * This data is updated by library functions `.docname`, `.docauthor`, etc., by overwriting [com.quarkdown.core.context.MutableContext.documentInfo].
  * @param type type of the document
- * @param name name of the document, if specified
  * @param authors authors of the document, if specified
+ * @param name name of the document, if specified
+ * @param description description of the document, if specified
  * @param theme theme of the document, if specified
  * @param locale language of the document
  * @param numbering formats to apply to element numbering across the document
@@ -21,6 +22,7 @@ import com.quarkdown.core.localization.Locale
 data class DocumentInfo(
     val type: DocumentType = DocumentType.PLAIN,
     val name: String? = null,
+    val description: String? = null,
     val authors: List<DocumentAuthor> = emptyList(),
     val locale: Locale? = null,
     val numbering: DocumentNumbering? = null,

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/rendering/template/TemplatePlaceholders.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/rendering/template/TemplatePlaceholders.kt
@@ -23,6 +23,11 @@ object TemplatePlaceholders {
     const val AUTHORS = "AUTHORS"
 
     /**
+     * Description of the document.
+     */
+    const val DESCRIPTION = "DESCRIPTION"
+
+    /**
      * Language of the document.
      */
     const val LANGUAGE = "LANG"

--- a/quarkdown-html/src/main/kotlin/com/quarkdown/rendering/html/post/HtmlPostRendererTemplate.kt
+++ b/quarkdown-html/src/main/kotlin/com/quarkdown/rendering/html/post/HtmlPostRendererTemplate.kt
@@ -51,10 +51,15 @@ class HtmlPostRendererTemplate(
     private fun TemplateProcessor.documentMetadata() {
         value(TemplatePlaceholders.TITLE, document.name ?: "Quarkdown")
         optionalValue(
+            TemplatePlaceholders.DESCRIPTION,
+            document.description?.let(Escape.Html::escape),
+        )
+        optionalValue(
             TemplatePlaceholders.AUTHORS,
-            Escape.Html
-                .escape(document.authors.joinToString { it.name })
-                .takeIf { it.isNotEmpty() },
+            document.authors
+                .takeIf { it.isNotEmpty() }
+                ?.joinToString { it.name }
+                ?.let(Escape.Html::escape),
         )
         optionalValue(TemplatePlaceholders.LANGUAGE, document.locale?.tag)
         value(

--- a/quarkdown-html/src/main/resources/render/html-wrapper.html.template
+++ b/quarkdown-html/src/main/resources/render/html-wrapper.html.template
@@ -4,6 +4,9 @@
 <head>
     <meta name="generator" content="Quarkdown">
     <meta charset="UTF-8">
+    [[if:DESCRIPTION]]
+    <meta name="description" content="[[DESCRIPTION]]">
+    [[endif:DESCRIPTION]]
     [[if:AUTHORS]]
     <meta name="author" content="[[AUTHORS]]">
     [[endif:AUTHORS]]

--- a/quarkdown-html/src/test/kotlin/com/quarkdown/rendering/html/HtmlPostRendererTest.kt
+++ b/quarkdown-html/src/test/kotlin/com/quarkdown/rendering/html/HtmlPostRendererTest.kt
@@ -403,6 +403,7 @@ class HtmlPostRendererTest {
         context.documentInfo =
             DocumentInfo(
                 name = "Quarkdown",
+                description = "The Quarkdown typesetting system",
                 locale = LocaleLoader.SYSTEM.fromName("english"),
                 type = DocumentType.SLIDES,
                 layout =
@@ -420,6 +421,9 @@ class HtmlPostRendererTest {
                 """
                 <html[[if:LANG]] lang="[[LANG]]"[[endif:LANG]]>
                 <head>
+                    [[if:DESCRIPTION]]
+                    <meta name="description" content="[[DESCRIPTION]]">
+                    [[endif:DESCRIPTION]]
                     [[if:AUTHORS]]
                     <meta name="author" content="[[AUTHORS]]"></meta>
                     [[endif:AUTHORS]]
@@ -470,6 +474,7 @@ class HtmlPostRendererTest {
             """
             <html lang="en">
             <head>
+                <meta name="description" content="The Quarkdown typesetting system">
                 <link rel="stylesheet" href="...css"></link>
                 <script src="...js"></script>
                 <script src="...js"></script>

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Document.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Document.kt
@@ -63,6 +63,7 @@ val Document: QuarkdownModule =
     moduleOf(
         ::docType,
         ::docName,
+        ::docDescription,
         ::docAuthor,
         ::docAuthors,
         ::docLanguage,
@@ -167,6 +168,36 @@ fun docName(
         name,
         get = { (this.name ?: "").wrappedAsValue() },
         modify = { copy(name = it) },
+    )
+
+/**
+ * If [description] is specified, sets the document description to that value.
+ *
+ * In HTML, descriptions are exported to SEO-friendly meta tags.
+ *
+ * ```
+ * .docdescription {This is a sample document}
+ * ```
+ *
+ * If it's unset, the current description of the document is returned.
+ *
+ * ```
+ * The current document description is .docdescription
+ * ```
+ *
+ * @param description optional description to assign to the document
+ * @return the current document description if [description] is unset, nothing otherwise
+ * @wiki Document metadata
+ */
+@Name("docdescription")
+fun docDescription(
+    @Injected context: MutableContext,
+    description: String? = null,
+): OutputValue<*> =
+    context.modifyOrEchoDocumentInfo(
+        description,
+        get = { (this.description ?: "").wrappedAsValue() },
+        modify = { copy(description = it) },
     )
 
 /**

--- a/quarkdown-test/src/test/kotlin/com/quarkdown/test/DocumentTest.kt
+++ b/quarkdown-test/src/test/kotlin/com/quarkdown/test/DocumentTest.kt
@@ -34,6 +34,7 @@ class DocumentTest {
             assertEquals(DocumentType.PLAIN, documentInfo.type)
             assertNull(documentInfo.name)
             assertEquals(0, documentInfo.authors.size)
+            assertNull(documentInfo.description)
             assertNull(documentInfo.locale)
             assertNull(documentInfo.layout.pageFormat.pageWidth)
             assertNull(documentInfo.layout.pageFormat.margin)
@@ -48,6 +49,7 @@ class DocumentTest {
         execute(
             """
             .docname {My Quarkdown document}
+            .docdescription {A comprehensive guide to Quarkdown}
             .docauthors
               - iamgio
                 - website: https://iamgio.eu
@@ -64,6 +66,7 @@ class DocumentTest {
             """.trimIndent(),
         ) {
             assertEquals("My Quarkdown document", documentInfo.name)
+            assertEquals("A comprehensive guide to Quarkdown", documentInfo.description)
             assertEquals(
                 listOf(
                     DocumentAuthor("iamgio", mapOf("website" to "https://iamgio.eu")),
@@ -112,20 +115,26 @@ class DocumentTest {
             .doctype {slides}
             .doclang {english}
             
+            .docdescription
+                A comprehensive guide to Quarkdown
+
             .docname .text {.docname} size:{tiny}.
-            
+
+            .docdescription
+
             .docauthors
-            
+
             #! .docauthor
-            
+
             .doctype
-            
+
             .doclang
             """.trimIndent(),
         ) {
             assertEquals(
                 "<p>My Quarkdown document " +
                     "<span class=\"size-tiny\">My Quarkdown document</span>.</p>" +
+                    "<p>A comprehensive guide to Quarkdown</p>" +
                     "<table>" +
                     "<thead><tr><th>Key</th><th>Value</th></tr></thead>" +
                     "<tbody>" +


### PR DESCRIPTION
This PR adds the `.docdescription` metadata function.

When exporting to HTML, this metadata is directly exported to a `<meta name="description">` tag, which directly affects SEO.