### PR TITLE
feat(project-creator): add document description

### DIFF
--- a/quarkdown-cli/src/main/kotlin/com/quarkdown/cli/creator/command/CreateProjectCommand.kt
+++ b/quarkdown-cli/src/main/kotlin/com/quarkdown/cli/creator/command/CreateProjectCommand.kt
@@ -63,6 +63,9 @@ class CreateProjectCommand : CliktCommand("create") {
             default = DocumentType.PLAIN,
         )
 
+    private val description: String by option("--description", help = "Document description")
+        .prompt("Document description (optional)")
+
     private fun findLocale(language: String): Locale? = LocaleLoader.SYSTEM.find(language)
 
     private val languageRaw: String? by option("--lang", help = "Document language")
@@ -88,6 +91,7 @@ class CreateProjectCommand : CliktCommand("create") {
     private fun createDocumentInfo() =
         DocumentInfo(
             name = name?.takeUnless { it.isBlank() } ?: directory.name,
+            description = description.takeUnless { it.isBlank() },
             authors = authors.toMutableList(),
             type = type,
             locale = language,

--- a/quarkdown-cli/src/main/kotlin/com/quarkdown/cli/creator/template/DefaultProjectCreatorTemplateProcessorFactory.kt
+++ b/quarkdown-cli/src/main/kotlin/com/quarkdown/cli/creator/template/DefaultProjectCreatorTemplateProcessorFactory.kt
@@ -21,6 +21,7 @@ class DefaultProjectCreatorTemplateProcessorFactory(
         with(ProjectCreatorTemplatePlaceholders) {
             TemplateProcessor.fromResourceName(TEMPLATE).apply {
                 optionalValue(NAME, info.name)
+                optionalValue(DESCRIPTION, info.description)
                 conditional(AUTHORS, info.authors.isNotEmpty())
                 iterable(AUTHORS, info.authors.map { it.name })
                 optionalValue(TYPE, info.type.quarkdownName)

--- a/quarkdown-cli/src/main/kotlin/com/quarkdown/cli/creator/template/ProjectCreatorTemplatePlaceholders.kt
+++ b/quarkdown-cli/src/main/kotlin/com/quarkdown/cli/creator/template/ProjectCreatorTemplatePlaceholders.kt
@@ -5,6 +5,7 @@ package com.quarkdown.cli.creator.template
  */
 object ProjectCreatorTemplatePlaceholders {
     const val NAME = "NAME"
+    const val DESCRIPTION = "DESCRIPTION"
     const val AUTHORS = "AUTHORS"
     const val TYPE = "TYPE"
     const val LANGUAGE = "LANG"

--- a/quarkdown-cli/src/main/resources/creator/main.qd.template
+++ b/quarkdown-cli/src/main/resources/creator/main.qd.template
@@ -1,4 +1,5 @@
 [[if:NAME]].docname {[[NAME]]}[[endif:NAME]]
+[[if:DESCRIPTION]].docdescription {[[DESCRIPTION]]}[[endif:DESCRIPTION]]
 [[if:TYPE]].doctype {[[TYPE]]}[[endif:TYPE]]
 [[if:LANG]].doclang {[[LANG]]}[[endif:LANG]]
 [[if:THEME]]

--- a/quarkdown-cli/src/test/kotlin/com/quarkdown/cli/ProjectCreatorTest.kt
+++ b/quarkdown-cli/src/test/kotlin/com/quarkdown/cli/ProjectCreatorTest.kt
@@ -54,6 +54,22 @@ class ProjectCreatorTest {
         assertEquals(".docname {Test}\n.doctype {plain}", resources.first().textContent)
     }
 
+    @Test
+    fun `only description`() {
+        val creator = projectCreator(DocumentInfo(description = "A sample document"))
+        val resources = creator.createResources()
+        assertEquals(1, resources.size)
+        assertEquals(".docdescription {A sample document}\n.doctype {plain}", resources.first().textContent)
+    }
+
+    @Test
+    fun `name and description`() {
+        val creator = projectCreator(DocumentInfo(name = "Test", description = "A test document"))
+        val resources = creator.createResources()
+        assertEquals(1, resources.size)
+        assertEquals(".docname {Test}\n.docdescription {A test document}\n.doctype {plain}", resources.first().textContent)
+    }
+
     private val singleAuthor: MutableList<DocumentAuthor>
         get() = mutableListOf(DocumentAuthor("Giorgio"))
 
@@ -71,6 +87,14 @@ class ProjectCreatorTest {
         val resources = creator.createResources()
         assertEquals(1, resources.size)
         assertEquals(".docname {Document}\n.doctype {plain}\n\n.docauthors\n  - Giorgio", resources.first().textContent)
+    }
+
+    @Test
+    fun `description and author`() {
+        val creator = projectCreator(DocumentInfo(description = "Test description", authors = singleAuthor))
+        val resources = creator.createResources()
+        assertEquals(1, resources.size)
+        assertEquals(".docdescription {Test description}\n.doctype {plain}\n\n.docauthors\n  - Giorgio", resources.first().textContent)
     }
 
     @Test
@@ -153,7 +177,36 @@ class ProjectCreatorTest {
             .doctype {plain}
             .doclang {English}
             .theme {dark} layout:{minimal}
-            
+
+            .docauthors
+              - Giorgio
+            """.trimIndent(),
+            resources.first().textContent,
+        )
+    }
+
+    @Test
+    fun `name, description, locale, theme and author`() {
+        val creator =
+            projectCreator(
+                DocumentInfo(
+                    name = "Comprehensive Test",
+                    description = "A comprehensive test document",
+                    locale = LocaleLoader.SYSTEM.find("en")!!,
+                    theme = DocumentTheme(color = "dark", layout = "minimal"),
+                    authors = singleAuthor,
+                ),
+            )
+        val resources = creator.createResources()
+        assertEquals(1, resources.size)
+        assertEquals(
+            """
+            .docname {Comprehensive Test}
+            .docdescription {A comprehensive test document}
+            .doctype {plain}
+            .doclang {English}
+            .theme {dark} layout:{minimal}
+
             .docauthors
               - Giorgio
             """.trimIndent(),


### PR DESCRIPTION
This PR adds document description (introduced in #250) to the project creator wizard (`quarkdown create`).