### PR TITLE
feat: add .dockeywords metadata function

### DIFF
--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/document/DocumentInfo.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/document/DocumentInfo.kt
@@ -10,12 +10,13 @@ import com.quarkdown.core.localization.Locale
  * Immutable information about the document.
  * This data is updated by library functions `.docname`, `.docauthor`, etc., by overwriting [com.quarkdown.core.context.MutableContext.documentInfo].
  * @param type type of the document
- * @param authors authors of the document, if specified
  * @param name name of the document, if specified
  * @param description description of the document, if specified
- * @param theme theme of the document, if specified
+ * @param authors authors of the document, if specified
+ * @param keywords keywords of the document, if specified
  * @param locale language of the document
  * @param numbering formats to apply to element numbering across the document
+ * @param theme theme of the document, if specified
  * @param pageFormat format of the pages of the document
  */
 @NestedData
@@ -24,6 +25,7 @@ data class DocumentInfo(
     val name: String? = null,
     val description: String? = null,
     val authors: List<DocumentAuthor> = emptyList(),
+    val keywords: List<String> = emptyList(),
     val locale: Locale? = null,
     val numbering: DocumentNumbering? = null,
     val theme: DocumentTheme? = null,

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/rendering/template/TemplatePlaceholders.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/rendering/template/TemplatePlaceholders.kt
@@ -28,6 +28,11 @@ object TemplatePlaceholders {
     const val DESCRIPTION = "DESCRIPTION"
 
     /**
+     * Keywords of the document.
+     */
+    const val KEYWORDS = "KEYWORDS"
+
+    /**
      * Language of the document.
      */
     const val LANGUAGE = "LANG"

--- a/quarkdown-html/src/main/kotlin/com/quarkdown/rendering/html/post/HtmlPostRendererTemplate.kt
+++ b/quarkdown-html/src/main/kotlin/com/quarkdown/rendering/html/post/HtmlPostRendererTemplate.kt
@@ -49,10 +49,21 @@ class HtmlPostRendererTemplate(
      * @see com.quarkdown.core.document.DocumentInfo
      */
     private fun TemplateProcessor.documentMetadata() {
-        value(TemplatePlaceholders.TITLE, document.name ?: "Quarkdown")
+        value(
+            TemplatePlaceholders.TITLE,
+            document.name?.let(Escape.Html::escape)
+                ?: "Quarkdown",
+        )
         optionalValue(
             TemplatePlaceholders.DESCRIPTION,
             document.description?.let(Escape.Html::escape),
+        )
+        optionalValue(
+            TemplatePlaceholders.KEYWORDS,
+            document.keywords
+                .takeIf { it.isNotEmpty() }
+                ?.joinToString()
+                ?.let(Escape.Html::escape),
         )
         optionalValue(
             TemplatePlaceholders.AUTHORS,

--- a/quarkdown-html/src/main/resources/render/html-wrapper.html.template
+++ b/quarkdown-html/src/main/resources/render/html-wrapper.html.template
@@ -7,6 +7,9 @@
     [[if:DESCRIPTION]]
     <meta name="description" content="[[DESCRIPTION]]">
     [[endif:DESCRIPTION]]
+    [[if:KEYWORDS]]
+    <meta name="keywords" content="[[KEYWORDS]]">
+    [[endif:KEYWORDS]]
     [[if:AUTHORS]]
     <meta name="author" content="[[AUTHORS]]">
     [[endif:AUTHORS]]

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Document.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Document.kt
@@ -41,6 +41,7 @@ import com.quarkdown.core.function.reflect.annotation.LikelyNamed
 import com.quarkdown.core.function.reflect.annotation.Name
 import com.quarkdown.core.function.reflect.annotation.NotForDocumentType
 import com.quarkdown.core.function.value.DictionaryValue
+import com.quarkdown.core.function.value.DynamicValue
 import com.quarkdown.core.function.value.NodeValue
 import com.quarkdown.core.function.value.OutputValue
 import com.quarkdown.core.function.value.StringValue
@@ -66,6 +67,7 @@ val Document: QuarkdownModule =
         ::docDescription,
         ::docAuthor,
         ::docAuthors,
+        ::docKeywords,
         ::docLanguage,
         ::theme,
         ::numbering,
@@ -296,6 +298,42 @@ fun docAuthors(
                         )
                     }
             copy(authors = authors)
+        },
+    )
+
+/**
+ * If [keywords] is specified, sets the document keywords to those values.
+ * In HTML, keywords are exported to SEO-friendly meta tags.
+ *
+ * ```
+ * .dockeywords
+ *   - quarkdown
+ *   - markdown
+ *   - documentation
+ * ```
+ *
+ * If it's unset, the current keywords of the document are returned as a list.
+ *
+ * ```
+ * .foreach {.dockeywords}
+ *     keyword:
+ *     .keyword
+ * ```
+ *
+ * @param keywordsString optional space-separated keywords to assign to the document
+ * @return the current document keywords if [keywordsString] is unset, nothing otherwise
+ * @wiki Document metadata
+ */
+@Name("dockeywords")
+fun docKeywords(
+    @Injected context: MutableContext,
+    keywords: Iterable<DynamicValue>? = null,
+): OutputValue<*> =
+    context.modifyOrEchoDocumentInfo(
+        keywords,
+        get = { this.keywords.map(::StringValue).wrappedAsValue() },
+        modify = {
+            copy(keywords = it.map { value -> value.unwrappedValue.toString() }.toList())
         },
     )
 

--- a/quarkdown-test/src/test/kotlin/com/quarkdown/test/DocumentTest.kt
+++ b/quarkdown-test/src/test/kotlin/com/quarkdown/test/DocumentTest.kt
@@ -35,6 +35,7 @@ class DocumentTest {
             assertNull(documentInfo.name)
             assertEquals(0, documentInfo.authors.size)
             assertNull(documentInfo.description)
+            assertTrue(documentInfo.keywords.isEmpty())
             assertNull(documentInfo.locale)
             assertNull(documentInfo.layout.pageFormat.pageWidth)
             assertNull(documentInfo.layout.pageFormat.margin)
@@ -50,6 +51,12 @@ class DocumentTest {
             """
             .docname {My Quarkdown document}
             .docdescription {A comprehensive guide to Quarkdown}
+            
+            .dockeywords
+              - documentation
+              - markdown
+              - typesetting
+            
             .docauthors
               - iamgio
                 - website: https://iamgio.eu
@@ -67,6 +74,7 @@ class DocumentTest {
         ) {
             assertEquals("My Quarkdown document", documentInfo.name)
             assertEquals("A comprehensive guide to Quarkdown", documentInfo.description)
+            assertEquals(listOf("documentation", "markdown", "typesetting"), documentInfo.keywords)
             assertEquals(
                 listOf(
                     DocumentAuthor("iamgio", mapOf("website" to "https://iamgio.eu")),
@@ -109,12 +117,18 @@ class DocumentTest {
         execute(
             """
             .docname {My Quarkdown document}
+            
+            .dockeywords
+              - quarkdown
+              - markdown
+              - documentation
+            
             .docauthors
               - iamgio
                 - country: Italy
             .doctype {slides}
             .doclang {english}
-            
+
             .docdescription
                 A comprehensive guide to Quarkdown
 
@@ -129,6 +143,8 @@ class DocumentTest {
             .doctype
 
             .doclang
+            
+            .dockeywords
             """.trimIndent(),
         ) {
             assertEquals(
@@ -145,7 +161,8 @@ class DocumentTest {
                     "</table>" +
                     "<h1 data-decorative=\"\">iamgio</h1>" +
                     "<p>slides</p>" +
-                    "<p>English</p>",
+                    "<p>English</p>" +
+                    "<ol><li><p>quarkdown</p></li><li><p>markdown</p></li><li><p>documentation</p></li></ol>",
                 it,
             )
         }


### PR DESCRIPTION
This PR adds `.dockeywords` as a way to set the document's keywords.

In HTML, keywords are exported to SEO-friendly meta tags.

```
.dockeywords
  - quarkdown
  - markdown
  - typesetting
```