### PR TITLE
feat(project-creator): add keywords metadata

### DIFF
--- a/quarkdown-cli/src/main/kotlin/com/quarkdown/cli/creator/command/CreateProjectCommand.kt
+++ b/quarkdown-cli/src/main/kotlin/com/quarkdown/cli/creator/command/CreateProjectCommand.kt
@@ -66,6 +66,16 @@ class CreateProjectCommand : CliktCommand("create") {
     private val description: String by option("--description", help = "Document description")
         .prompt("Document description (optional)")
 
+    private val keywordsRaw: String? by option("--keywords", help = "Document keywords (comma-separated)")
+
+    private val keywords: List<String> by lazy {
+        keywordsRaw
+            ?.split(",")
+            ?.filter { it.isNotBlank() }
+            ?.map { it.trim() }
+            ?: emptyList()
+    }
+
     private fun findLocale(language: String): Locale? = LocaleLoader.SYSTEM.find(language)
 
     private val languageRaw: String? by option("--lang", help = "Document language")
@@ -93,6 +103,7 @@ class CreateProjectCommand : CliktCommand("create") {
             name = name?.takeUnless { it.isBlank() } ?: directory.name,
             description = description.takeUnless { it.isBlank() },
             authors = authors.toMutableList(),
+            keywords = keywords,
             type = type,
             locale = language,
             theme = DocumentTheme(colorTheme, layoutTheme),

--- a/quarkdown-cli/src/main/kotlin/com/quarkdown/cli/creator/template/DefaultProjectCreatorTemplateProcessorFactory.kt
+++ b/quarkdown-cli/src/main/kotlin/com/quarkdown/cli/creator/template/DefaultProjectCreatorTemplateProcessorFactory.kt
@@ -22,6 +22,8 @@ class DefaultProjectCreatorTemplateProcessorFactory(
             TemplateProcessor.fromResourceName(TEMPLATE).apply {
                 optionalValue(NAME, info.name)
                 optionalValue(DESCRIPTION, info.description)
+                conditional(KEYWORDS, info.keywords.isNotEmpty())
+                iterable(KEYWORDS, info.keywords)
                 conditional(AUTHORS, info.authors.isNotEmpty())
                 iterable(AUTHORS, info.authors.map { it.name })
                 optionalValue(TYPE, info.type.quarkdownName)

--- a/quarkdown-cli/src/main/kotlin/com/quarkdown/cli/creator/template/ProjectCreatorTemplatePlaceholders.kt
+++ b/quarkdown-cli/src/main/kotlin/com/quarkdown/cli/creator/template/ProjectCreatorTemplatePlaceholders.kt
@@ -6,6 +6,7 @@ package com.quarkdown.cli.creator.template
 object ProjectCreatorTemplatePlaceholders {
     const val NAME = "NAME"
     const val DESCRIPTION = "DESCRIPTION"
+    const val KEYWORDS = "KEYWORDS"
     const val AUTHORS = "AUTHORS"
     const val TYPE = "TYPE"
     const val LANGUAGE = "LANG"

--- a/quarkdown-cli/src/main/resources/creator/main.qd.template
+++ b/quarkdown-cli/src/main/resources/creator/main.qd.template
@@ -6,6 +6,13 @@
 .theme[[if:COLORTHEME]] {[[COLORTHEME]]}[[endif:COLORTHEME]][[if:LAYOUTTHEME]] layout:{[[LAYOUTTHEME]]}[[endif:LAYOUTTHEME]]
 [[endif:THEME]]
 
+[[if:KEYWORDS]]
+.dockeywords
+[[for:KEYWORDS]]
+  - [[KEYWORDS]]
+[[endfor:KEYWORDS]]
+[[endif:KEYWORDS]]
+
 [[if:AUTHORS]]
 .docauthors
 [[for:AUTHORS]]

--- a/quarkdown-cli/src/test/kotlin/com/quarkdown/cli/ProjectCreatorCommandTest.kt
+++ b/quarkdown-cli/src/test/kotlin/com/quarkdown/cli/ProjectCreatorCommandTest.kt
@@ -25,6 +25,7 @@ class ProjectCreatorCommandTest : TempDirectory() {
      * @param fixedMainFileName whether to use a fixed main file name
      * @param directory directory to create the project in
      * @param includeDescription whether to include the description argument
+     * @param includeKeywords whether to include the keywords argument
      * @return content of the main file
      */
     private fun test(
@@ -32,6 +33,7 @@ class ProjectCreatorCommandTest : TempDirectory() {
         fixedMainFileName: Boolean = true,
         directory: File = super.directory,
         includeDescription: Boolean = true,
+        includeKeywords: Boolean = true,
     ): String {
         // resolve(".") tests the canonical path instead of the actual one.
         command.test(
@@ -51,6 +53,7 @@ class ProjectCreatorCommandTest : TempDirectory() {
             "--layout-theme",
             "latex",
             *additionalArgs,
+            *if (includeKeywords) arrayOf("--keywords", "testing,slides, quarkdown") else emptyArray(),
             *if (fixedMainFileName) arrayOf("--main-file", "main") else emptyArray(),
         )
         assertTrue(directory.exists())
@@ -63,6 +66,9 @@ class ProjectCreatorCommandTest : TempDirectory() {
         assertTrue(main.startsWith(".docname {test}"))
         if (includeDescription) {
             assertTrue(".docdescription {A test document for slides}" in main)
+        }
+        if (includeKeywords) {
+            assertTrue(".dockeywords\n  - testing\n  - slides\n  - quarkdown" in main)
         }
         assertTrue("- Aaa" in main)
         assertTrue("- Bbb" in main)
@@ -103,5 +109,11 @@ class ProjectCreatorCommandTest : TempDirectory() {
     fun `empty description`() {
         val main = test(includeDescription = false)
         assertTrue(".docdescription" !in main)
+    }
+
+    @Test
+    fun `no keywords`() {
+        val main = test(includeKeywords = false)
+        assertTrue(".dockeywords" !in main)
     }
 }

--- a/quarkdown-cli/src/test/kotlin/com/quarkdown/cli/ProjectCreatorTest.kt
+++ b/quarkdown-cli/src/test/kotlin/com/quarkdown/cli/ProjectCreatorTest.kt
@@ -70,6 +70,28 @@ class ProjectCreatorTest {
         assertEquals(".docname {Test}\n.docdescription {A test document}\n.doctype {plain}", resources.first().textContent)
     }
 
+    @Test
+    fun `only keywords`() {
+        val creator = projectCreator(DocumentInfo(keywords = listOf("kotlin", "testing")))
+        val resources = creator.createResources()
+        assertEquals(1, resources.size)
+        assertEquals(
+            ".doctype {plain}\n\n.dockeywords\n  - kotlin\n  - testing",
+            resources.first().textContent,
+        )
+    }
+
+    @Test
+    fun `name and keywords`() {
+        val creator = projectCreator(DocumentInfo(name = "Test", keywords = listOf("kotlin", "documentation")))
+        val resources = creator.createResources()
+        assertEquals(1, resources.size)
+        assertEquals(
+            ".docname {Test}\n.doctype {plain}\n\n.dockeywords\n  - kotlin\n  - documentation",
+            resources.first().textContent,
+        )
+    }
+
     private val singleAuthor: MutableList<DocumentAuthor>
         get() = mutableListOf(DocumentAuthor("Giorgio"))
 
@@ -186,12 +208,13 @@ class ProjectCreatorTest {
     }
 
     @Test
-    fun `name, description, locale, theme and author`() {
+    fun `name, description, keywords, locale, theme and author`() {
         val creator =
             projectCreator(
                 DocumentInfo(
                     name = "Comprehensive Test",
                     description = "A comprehensive test document",
+                    keywords = listOf("test", "kotlin", "quarkdown"),
                     locale = LocaleLoader.SYSTEM.find("en")!!,
                     theme = DocumentTheme(color = "dark", layout = "minimal"),
                     authors = singleAuthor,
@@ -206,6 +229,11 @@ class ProjectCreatorTest {
             .doctype {plain}
             .doclang {English}
             .theme {dark} layout:{minimal}
+
+            .dockeywords
+              - test
+              - kotlin
+              - quarkdown
 
             .docauthors
               - Giorgio


### PR DESCRIPTION
This PR introduces document keywords (introduced in #252) into the project creator wizard (`quarkdown create --keywords a,b,c`).