### PR TITLE
fix(ui): fix .pageformat not applying margins in plain docs

### DIFF
--- a/quarkdown-html/src/main/resources/render/html-wrapper.html.template
+++ b/quarkdown-html/src/main/resources/render/html-wrapper.html.template
@@ -100,11 +100,11 @@
             break-after: avoid;
         }
 
-        body.quarkdown-plain {
+        body.quarkdown-plain.quarkdown-plain {
             [[if:PAGEMARGIN]]margin: [[PAGEMARGIN]];[[endif:PAGEMARGIN]]
         }
 
-        body.quarkdown-slides .reveal {
+        body.quarkdown-slides.quarkdown-slides .reveal {
             [[if:PAGEWIDTH]]width: [[PAGEWIDTH]];[[endif:PAGEWIDTH]]
             [[if:PAGEHEIGHT]]height: [[PAGEHEIGHT]];[[endif:PAGEHEIGHT]]
         }


### PR DESCRIPTION
This PR fixes `.pageformat margin:{...}` not being applied on plain documents.