### PR TITLE
feat(stdlib): add alphanumeric sorting

### DIFF
--- a/quarkdown-stdlib/build.gradle.kts
+++ b/quarkdown-stdlib/build.gradle.kts
@@ -6,6 +6,7 @@ dependencies {
     testImplementation("org.jetbrains.kotlin:kotlin-test")
     testImplementation(testFixtures(project(":quarkdown-core")))
     implementation(project(":quarkdown-core"))
+    implementation("se.sawano.java:alphanumeric-comparator:2.0.0")
     implementation("com.github.doyaaaaaken:kotlin-csv-jvm:1.10.0")
     implementation("org.kodein.emoji:emoji-kt:2.2.0")
     dokkaPlugin(project(":quarkdown-quarkdoc"))

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Data.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Data.kt
@@ -18,6 +18,7 @@ import com.quarkdown.core.function.value.data.Range
 import com.quarkdown.core.function.value.data.subList
 import com.quarkdown.core.function.value.wrappedAsValue
 import com.quarkdown.core.util.normalizeLineSeparators
+import com.quarkdown.stdlib.internal.AlphanumericComparator
 import com.quarkdown.stdlib.internal.Ordering
 import com.quarkdown.stdlib.internal.Sorting
 import com.quarkdown.stdlib.internal.sortedBy
@@ -104,7 +105,7 @@ enum class FileSorting(
 
     /** Files are sorted by name. */
     NAME({ files, ordering ->
-        files.sortedBy(ordering) { it.name.lowercase() }
+        files.sortedBy(ordering, AlphanumericComparator) { it.name.lowercase() }
     }),
 
     /** Files are sorted by last modified date. */

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/TableComputation.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/TableComputation.kt
@@ -21,6 +21,7 @@ import com.quarkdown.core.function.value.data.Lambda
 import com.quarkdown.core.function.value.factory.ValueFactory
 import com.quarkdown.core.function.value.wrappedAsValue
 import com.quarkdown.core.util.toPlainText
+import com.quarkdown.stdlib.internal.AlphanumericComparator
 import com.quarkdown.stdlib.internal.Ordering
 import com.quarkdown.stdlib.internal.sortedBy
 
@@ -125,6 +126,8 @@ private fun reconstructTable(
 /**
  * Sorts a table based on the values of a column.
  *
+ * The sorting is done alphanumerically, hence, for example, `$120` > `$30`, as opposed to the usual lexicographical order.
+ *
  * Example:
  * ```
  * .tablesort {2}
@@ -163,7 +166,7 @@ fun tableSort(
         values
             .asSequence()
             .withIndex()
-            .sortedBy(order) { item -> item.value }
+            .sortedBy(order, AlphanumericComparator) { item -> item.value }
             .map { it.index }
             .toList()
 

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/internal/Sorting.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/internal/Sorting.kt
@@ -24,15 +24,33 @@ enum class Ordering {
 
 /**
  * Sorts elements by a [selector] value in the given [ordering].
+ *
+ * `null` values are always sorted first, regardless of the ordering.
+ *
  * @param ordering whether to sort in ascending or descending order
+ * @param comparator optional additional comparator to use for comparing the selected values
  * @param selector function that extracts a comparable value from each element
  * @return a new sequence with elements sorted according to the selector and ordering
  */
 fun <T, R : Comparable<R>> Sequence<T>.sortedBy(
     ordering: Ordering,
+    comparator: Comparator<in R>? = null,
     selector: (T) -> R?,
-): Sequence<T> =
-    when (ordering) {
-        Ordering.ASCENDING -> this.sortedBy(selector)
-        Ordering.DESCENDING -> this.sortedByDescending(selector)
-    }
+): Sequence<T> {
+    val nullSafeComparator = comparator?.let(::nullsFirst) ?: nullsFirst()
+    val finalComparator =
+        when (ordering) {
+            Ordering.ASCENDING -> compareBy(nullSafeComparator, selector)
+            Ordering.DESCENDING -> compareByDescending(nullSafeComparator, selector)
+        }
+    return this.sortedWith(finalComparator)
+}
+
+/**
+ * A comparator that sorts alphanumeric strings in a human-friendly way.
+ * For example, `$120` comes after `$30`, as opposed to the usual lexicographical order.
+ *
+ * Wrapped around the `alphanumeric-comparator` library.
+ */
+object AlphanumericComparator : Comparator<CharSequence> by se.sawano.java.text
+    .AlphanumericComparator()

--- a/quarkdown-stdlib/src/test/kotlin/com/quarkdown/stdlib/internal/SortingTest.kt
+++ b/quarkdown-stdlib/src/test/kotlin/com/quarkdown/stdlib/internal/SortingTest.kt
@@ -53,6 +53,20 @@ class SortingTest {
     }
 
     @Test
+    fun `sortedBy with AlphanumericComparator`() {
+        val sequence = sequenceOf("$120", "$30", "$5", "$1000")
+        val sorted = sequence.sortedBy(Ordering.ASCENDING, AlphanumericComparator) { it }
+        assertEquals(listOf("$5", "$30", "$120", "$1000"), sorted.toList())
+    }
+
+    @Test
+    fun `sortedBy with AlphanumericComparator descending`() {
+        val sequence = sequenceOf("item2", "item10", "item1", "item20")
+        val sorted = sequence.sortedBy(Ordering.DESCENDING, AlphanumericComparator) { it }
+        assertEquals(listOf("item20", "item10", "item2", "item1"), sorted.toList())
+    }
+
+    @Test
     fun `sorting interface implementation`() {
         val stringSorting =
             object : Sorting<String> {

--- a/quarkdown-test/src/test/kotlin/com/quarkdown/test/TableComputationTest.kt
+++ b/quarkdown-test/src/test/kotlin/com/quarkdown/test/TableComputationTest.kt
@@ -11,14 +11,16 @@ import kotlin.test.assertEquals
 class TableComputationTest {
     private val table =
         """
-        | Name | Age | City |
-        |------|-----|------|
-        | John | 25  | NY   |
-        | Lisa | 32  | LA   |
-        | Mike | 19  | CHI  |
+        | Name    | Age | City |
+        |---------|-----|------|
+        | John    | 25  | NY   |
+        | Barbara | 102  | SF   |
+        | Lisa    | 32  | LA   |
+        | Mike    | 19  | CHI  |
         """.trimIndent().indent("\t")
 
     private val john = "<tr><td>John</td><td>25</td><td>NY</td></tr>"
+    private val barbara = "<tr><td>Barbara</td><td>102</td><td>SF</td></tr>"
     private val lisa = "<tr><td>Lisa</td><td>32</td><td>LA</td></tr>"
     private val mike = "<tr><td>Mike</td><td>19</td><td>CHI</td></tr>"
 
@@ -34,7 +36,7 @@ class TableComputationTest {
     fun `plain sorting, ascending`() {
         execute(".tablesort column:{2}\n$table") {
             assertEquals(
-                htmlTable(mike + john + lisa),
+                htmlTable(mike + john + lisa + barbara),
                 it,
             )
         }
@@ -44,7 +46,7 @@ class TableComputationTest {
     fun `plain sorting, descending`() {
         execute(".tablesort column:{2} order:{descending}\n$table") {
             assertEquals(
-                htmlTable(lisa + john + mike),
+                htmlTable(barbara + lisa + john + mike),
                 it,
             )
         }
@@ -54,7 +56,7 @@ class TableComputationTest {
     fun `plain filtering`() {
         execute(".tablefilter {2} {@lambda x: .x::isgreater {20}}\n$table") {
             assertEquals(
-                htmlTable(john + lisa),
+                htmlTable(john + barbara + lisa),
                 it,
             )
         }
@@ -65,8 +67,8 @@ class TableComputationTest {
         execute(".tablecompute {2} {@lambda x: .x::sumall}\n$table") {
             assertEquals(
                 htmlTable(
-                    john + lisa + mike +
-                        "<tr><td></td><td>76</td><td></td></tr>",
+                    john + barbara + lisa + mike +
+                        "<tr><td></td><td>178</td><td></td></tr>",
                 ),
                 it,
             )
@@ -78,8 +80,8 @@ class TableComputationTest {
         execute(".tablecompute {2} {@lambda .1::average::round}\n$table") {
             assertEquals(
                 htmlTable(
-                    john + lisa + mike +
-                        "<tr><td></td><td>25</td><td></td></tr>",
+                    john + barbara + lisa + mike +
+                        "<tr><td></td><td>44</td><td></td></tr>",
                 ),
                 it,
             )
@@ -95,8 +97,8 @@ class TableComputationTest {
         ) {
             assertEquals(
                 htmlTable(
-                    mike + john + lisa +
-                        "<tr><td></td><td>25</td><td></td></tr>",
+                    mike + john + lisa + barbara +
+                        "<tr><td></td><td>44</td><td></td></tr>",
                 ),
                 it,
             )
@@ -169,6 +171,7 @@ class TableComputationTest {
         ) {
             assertEquals(
                 "<p>Cell = 25</p>" +
+                    "<p>Cell = 102</p>" +
                     "<p>Cell = 32</p>" +
                     "<p>Cell = 19</p>",
                 it,


### PR DESCRIPTION
This PR brings alphanumeric sorting to the stdlib (`.listfiles` and `.tablesort`).

Alphanumeric sorting is human-friendlier than the previous lexicographic one. For instance, now `$120` is (correctly) greater than `$15`.

Thanks to @sawano for [alphanumeric-comparator](https://github.com/sawano/alphanumeric-comparator)!