### PR TITLE
fix: adjust relative path to subdoc export when referencing from another subdoc

### DIFF
--- a/quarkdown-html/src/main/kotlin/com/quarkdown/rendering/html/node/BaseHtmlNodeRenderer.kt
+++ b/quarkdown-html/src/main/kotlin/com/quarkdown/rendering/html/node/BaseHtmlNodeRenderer.kt
@@ -281,10 +281,17 @@ open class BaseHtmlNodeRenderer(
 
         val isCurrentSubdocument = subdocument == this.context.subdocument
 
+        // Subdocuments are exported flatly. Links to other subdocuments must go up one level.
+        val pathToRoot =
+            when (this.context.subdocument) {
+                Subdocument.Root -> "."
+                else -> ".."
+            }
+
         val link =
             Link(
                 label = node.label,
-                url = "./${subdocument.getOutputFileName(context)}",
+                url = "$pathToRoot/${subdocument.getOutputFileName(context)}",
                 title = node.title,
             )
 

--- a/quarkdown-test/src/test/kotlin/com/quarkdown/test/SubdocumentTest.kt
+++ b/quarkdown-test/src/test/kotlin/com/quarkdown/test/SubdocumentTest.kt
@@ -273,7 +273,7 @@ class SubdocumentTest {
     }
 
     @Test
-    fun `subdocument link should mark current subdocument`() {
+    fun `subdocument link should mark current subdocument and  account for non-root path`() {
         arrayOf(
             "[Document](subdoc/nav-includer.qd)",
             ".subdocument {subdoc/nav-includer.qd} label:{Document}",
@@ -287,9 +287,9 @@ class SubdocumentTest {
             ) {
                 if (subdocument.name == "nav-includer") {
                     assertEquals(
-                        "<ul><li><a href=\"./simple-1\">1</a></li>" +
-                            "<li><a href=\"./simple-2\">2</a></li>" +
-                            "<li><a href=\"./nav-includer\" aria-current=\"page\">3</a></li></ul>",
+                        "<ul><li><a href=\"../simple-1\">1</a></li>" +
+                            "<li><a href=\"../simple-2\">2</a></li>" +
+                            "<li><a href=\"../nav-includer\" aria-current=\"page\">3</a></li></ul>",
                         it,
                     )
                 }


### PR DESCRIPTION
Subdocument links from non-root subdocuments should point to `../subdoc` rather than `./subdoc`