### PR TITLE
feat(parser): support github-style quote types

### DIFF
--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/parser/BlockTokenParser.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/parser/BlockTokenParser.kt
@@ -351,10 +351,13 @@ class BlockTokenParser(
                     // :---:
                     delimiter.firstOrNull() == TABLE_ALIGNMENT_CHAR &&
                         delimiter.lastOrNull() == TABLE_ALIGNMENT_CHAR -> Table.Alignment.CENTER
+
                     // :---
                     delimiter.firstOrNull() == TABLE_ALIGNMENT_CHAR -> Table.Alignment.LEFT
+
                     // ---:
                     delimiter.lastOrNull() == TABLE_ALIGNMENT_CHAR -> Table.Alignment.RIGHT
+
                     // ---
                     else -> Table.Alignment.NONE
                 }
@@ -429,6 +432,7 @@ class BlockTokenParser(
         return when (val singleChild = text.singleOrNull()) {
             // Single image -> a figure.
             is Image -> ImageFigure(singleChild)
+
             // Regular paragraph otherwise (most cases).
             else -> Paragraph(text)
         }
@@ -444,16 +448,14 @@ class BlockTokenParser(
         // Blockquote type, if any. e.g. Tip, note, warning.
         val type: BlockQuote.Type? =
             BlockQuote.Type.entries.find { type ->
-                val prefix = type.name + ": " // e.g. Tip:, Note:, Warning:
-                // If the text begins with the prefix, it's a blockquote of that type.
-                val (newText, prefixFound) = text.removeOptionalPrefix(prefix, ignoreCase = true)
-                // If the prefix was found, it is stripped off.
-                if (prefixFound) {
-                    text = newText
+                sequenceOf(
+                    "${type.name}: ", // e.g. Tip:, Note:, Warning:
+                    "[!${type.name}]", // e.g. [!TIP], [!NOTE], [!WARNING]
+                ).any { prefix ->
+                    val (newText, found) = text.removeOptionalPrefix(prefix, ignoreCase = true)
+                    if (found) text = newText.trimStart()
+                    found
                 }
-
-                // If the prefix was found, the type is set.
-                prefixFound
             }
 
         // Content nodes.

--- a/quarkdown-core/src/test/kotlin/com/quarkdown/core/BlockParserTest.kt
+++ b/quarkdown-core/src/test/kotlin/com/quarkdown/core/BlockParserTest.kt
@@ -19,6 +19,7 @@ import com.quarkdown.core.ast.base.block.list.TaskListItemVariant
 import com.quarkdown.core.ast.base.block.list.UnorderedList
 import com.quarkdown.core.ast.base.inline.Emphasis
 import com.quarkdown.core.ast.base.inline.PlainTextNode
+import com.quarkdown.core.ast.base.inline.ReferenceLink
 import com.quarkdown.core.ast.base.inline.Strong
 import com.quarkdown.core.ast.base.inline.Text
 import com.quarkdown.core.ast.dsl.buildInline
@@ -341,24 +342,37 @@ class BlockParserTest {
             assertEquals(2, children.size)
         }
 
-        with(nodes.next()) {
-            assertEquals("A note.", rawText(this))
-            assertEquals(BlockQuote.Type.NOTE, type)
+        repeat(2) {
+            with(nodes.next()) {
+                assertEquals("A note.", rawText(this))
+                assertEquals(BlockQuote.Type.NOTE, type)
+            }
         }
 
-        with(nodes.next()) {
-            assertEquals("This is a tip!", rawText(this))
-            assertIs<UnorderedList>(children[1])
-            assertEquals(BlockQuote.Type.TIP, type)
+        repeat(2) {
+            with(nodes.next()) {
+                assertEquals("This is a tip!", rawText(this))
+                assertIs<UnorderedList>(children[1])
+                assertEquals(BlockQuote.Type.TIP, type)
+            }
         }
 
-        with(nodes.next()) {
-            assertEquals("you should be\nmore careful.", rawText(this))
-            assertEquals(BlockQuote.Type.WARNING, type)
+        repeat(2) {
+            with(nodes.next()) {
+                assertEquals("you should be\nmore careful.", rawText(this))
+                assertEquals(BlockQuote.Type.WARNING, type)
+            }
         }
 
         with(nodes.next()) {
             assertEquals("Something: not a typed quote.", rawText(this))
+            assertNull(type)
+        }
+
+        with(nodes.next()) {
+            val paragraph = children.first() as Paragraph
+            assertIs<ReferenceLink>(paragraph.children.first())
+            assertEquals("not a typed quote.", (paragraph.children[1] as Text).text.trimStart())
             assertNull(type)
         }
 

--- a/quarkdown-core/src/test/resources/parsing/blockquote.md
+++ b/quarkdown-core/src/test/resources/parsing/blockquote.md
@@ -33,14 +33,29 @@ Code
 
 > Note: A note.
 
+> [!NOTE]
+> A note.
+
 > Tip: This is a tip!
+> - A
+> - B
+
+> [!TIP]
+> This is a tip!
 > - A
 > - B
 
 > Warning: you should be
 > more careful.
 
+> [!WARNING]
+> you should be
+> more careful.
+
 > Something: not a typed quote.
+
+> [!SOMETHING]
+> not a typed quote.
 
 > To be, or not to be, that is the question.
 > - William Shakespeare, Hamlet


### PR DESCRIPTION
This PR introduces a new additional syntax for quote types (aka alerts).

Original syntax (still preferred):
```markdown
> Tip: This is a tip
```

New syntax (GitHub syntax):
```markdown
> [!TIP]
> This is a tip
```

Closes #258 