### PR TITLE
fix(docs): fix anchor scroll

### DIFF
--- a/quarkdown-html/src/main/scss/components/_viewport.scss
+++ b/quarkdown-html/src/main/scss/components/_viewport.scss
@@ -101,6 +101,7 @@ body.quarkdown {
   &.quarkdown-docs {
     --max-content-width: 50rem;
     --header-height: calc(var(--qd-docs-header-height) + var(--qd-docs-header-vertical-padding) * 2);
+    --content-padding-top: 32px;
 
     margin: 0;
     display: flex;
@@ -129,7 +130,7 @@ body.quarkdown {
 
         // Offset anchor scroll position to account for the fixed header.
         :target {
-          scroll-margin-top: calc(var(--header-height) + 32px);
+          scroll-margin-top: calc(var(--header-height) + var(--content-padding-top));
         }
       }
 
@@ -138,7 +139,7 @@ body.quarkdown {
         position: sticky;
         top: var(--header-height);
         max-height: calc(100vh - var(--header-height));
-        padding-top: 32px;
+        padding-top: var(--content-padding-top);
       }
     }
 

--- a/quarkdown-html/src/test/e2e/docs/layout/layout.spec.ts
+++ b/quarkdown-html/src/test/e2e/docs/layout/layout.spec.ts
@@ -1,0 +1,108 @@
+import {suite} from "../../quarkdown";
+
+const {test, expect} = suite(__dirname);
+
+/** Asserts two values are approximately equal within 2px tolerance (accounts for scrollbar and sub-pixel rendering). */
+function expectApprox(actual: number, expected: number) {
+    expect(Math.abs(actual - expected)).toBeLessThanOrEqual(2);
+}
+
+test("header and content-wrapper have full viewport width", async (page) => {
+    const viewportSize = page.viewportSize()!;
+
+    const header = page.locator(".quarkdown-docs > header");
+    const contentWrapper = page.locator(".quarkdown-docs > .content-wrapper");
+
+    const headerBox = await header.boundingBox();
+    const contentWrapperBox = await contentWrapper.boundingBox();
+
+    expect(headerBox).not.toBeNull();
+    expect(contentWrapperBox).not.toBeNull();
+
+    expect(headerBox!.width).toBe(viewportSize.width);
+    expect(contentWrapperBox!.width).toBe(viewportSize.width);
+});
+
+test("header starts at y=0 and ends where content-wrapper starts", async (page) => {
+    const header = page.locator(".quarkdown-docs > header");
+    const contentWrapper = page.locator(".quarkdown-docs > .content-wrapper");
+
+    const headerBox = await header.boundingBox();
+    const contentWrapperBox = await contentWrapper.boundingBox();
+
+    expect(headerBox).not.toBeNull();
+    expect(contentWrapperBox).not.toBeNull();
+
+    expect(headerBox!.y).toBe(0);
+    expect(headerBox!.y + headerBox!.height).toBeCloseTo(contentWrapperBox!.y, 0);
+});
+
+test("content-wrapper extends to viewport height", async (page) => {
+    const viewportSize = page.viewportSize()!;
+    const contentWrapper = page.locator(".quarkdown-docs > .content-wrapper");
+
+    const contentWrapperBox = await contentWrapper.boundingBox();
+    expect(contentWrapperBox).not.toBeNull();
+
+    // Content wrapper should extend to at least the viewport height
+    // (it may be taller if content overflows)
+    expect(contentWrapperBox!.y + contentWrapperBox!.height).toBeGreaterThanOrEqual(viewportSize.height);
+});
+
+test("header and content-wrapper columns are aligned", async (page) => {
+    const headerAsideFirst = page.locator(".quarkdown-docs > header > aside:first-child");
+    const headerMain = page.locator(".quarkdown-docs > header > main");
+    const headerAsideLast = page.locator(".quarkdown-docs > header > aside:last-child");
+
+    const contentAsideFirst = page.locator(".quarkdown-docs > .content-wrapper > aside:first-child");
+    const contentMain = page.locator(".quarkdown-docs > .content-wrapper > main");
+    const contentAsideLast = page.locator(".quarkdown-docs > .content-wrapper > aside:last-child");
+
+    const [
+        headerAsideFirstBox,
+        headerMainBox,
+        headerAsideLastBox,
+        contentAsideFirstBox,
+        contentMainBox,
+        contentAsideLastBox,
+    ] = await Promise.all([
+        headerAsideFirst.boundingBox(),
+        headerMain.boundingBox(),
+        headerAsideLast.boundingBox(),
+        contentAsideFirst.boundingBox(),
+        contentMain.boundingBox(),
+        contentAsideLast.boundingBox(),
+    ]);
+
+    expect(headerAsideFirstBox).not.toBeNull();
+    expect(headerMainBox).not.toBeNull();
+    expect(headerAsideLastBox).not.toBeNull();
+    expect(contentAsideFirstBox).not.toBeNull();
+    expect(contentMainBox).not.toBeNull();
+    expect(contentAsideLastBox).not.toBeNull();
+
+    // First aside (left sidebar): same x and width
+    expectApprox(headerAsideFirstBox!.x, contentAsideFirstBox!.x);
+    expectApprox(headerAsideFirstBox!.width, contentAsideFirstBox!.width);
+
+    // Main content area: same x and width
+    expectApprox(headerMainBox!.x, contentMainBox!.x);
+    expectApprox(headerMainBox!.width, contentMainBox!.width);
+
+    // Last aside (right sidebar): same x and width
+    expectApprox(headerAsideLastBox!.x, contentAsideLastBox!.x);
+    expectApprox(headerAsideLastBox!.width, contentAsideLastBox!.width);
+});
+
+test("search field aligns with main content first child", async (page) => {
+    const searchField = page.locator(".quarkdown-docs > header > main .search-field");
+    const mainFirstChild = page.locator(".quarkdown-docs > .content-wrapper > main > :first-child");
+
+    const searchFieldBox = await searchField.boundingBox();
+    const mainFirstChildBox = await mainFirstChild.boundingBox();
+
+    expect(searchFieldBox).not.toBeNull();
+    expect(mainFirstChildBox).not.toBeNull();
+
+    expectApprox(searchFieldBox!.x, mainFirstChildBox!.x);
+});

--- a/quarkdown-html/src/test/e2e/docs/layout/main.qd
+++ b/quarkdown-html/src/test/e2e/docs/layout/main.qd
@@ -1,0 +1,40 @@
+.doctype {docs}
+.doclang {en}
+
+.pagemargin {lefttop}
+    # Left Sidebar
+
+    .repeat {20}
+        .loremipsum
+
+.pagemargin {righttop}
+    .tableofcontents
+
+# Alpha
+
+First section content.
+
+## Alpha One
+
+Alpha One content.
+
+.repeat {10}
+    .loremipsum
+
+## Alpha Two
+
+Alpha Two content.
+
+# Beta
+
+Beta section content.
+
+.repeat {10}
+    .loremipsum
+
+# Gamma
+
+Gamma section content.
+
+.repeat {10}
+    .loremipsum

--- a/quarkdown-html/src/test/e2e/docs/layout/scroll.spec.ts
+++ b/quarkdown-html/src/test/e2e/docs/layout/scroll.spec.ts
@@ -1,0 +1,106 @@
+import {suite} from "../../quarkdown";
+
+const {test, expect} = suite(__dirname);
+
+test("asides have correct scroll CSS properties", async (page) => {
+    const contentAsideFirst = page.locator(".quarkdown-docs > .content-wrapper > aside:first-child");
+    const contentAsideLast = page.locator(".quarkdown-docs > .content-wrapper > aside:last-child");
+
+    // Asides have overflow-y: auto from the SCSS
+    const [asideFirstOverflowY, asideLastOverflowY] = await Promise.all([
+        contentAsideFirst.evaluate((el) => getComputedStyle(el).overflowY),
+        contentAsideLast.evaluate((el) => getComputedStyle(el).overflowY),
+    ]);
+
+    expect(asideFirstOverflowY).toBe("auto");
+    expect(asideLastOverflowY).toBe("auto");
+
+    // Asides are sticky positioned
+    const [asideFirstPosition, asideLastPosition] = await Promise.all([
+        contentAsideFirst.evaluate((el) => getComputedStyle(el).position),
+        contentAsideLast.evaluate((el) => getComputedStyle(el).position),
+    ]);
+
+    expect(asideFirstPosition).toBe("sticky");
+    expect(asideLastPosition).toBe("sticky");
+});
+
+test("scrolling left aside does not affect main or right aside", async (page) => {
+    const contentAsideFirst = page.locator(".quarkdown-docs > .content-wrapper > aside:first-child");
+    const contentAsideLast = page.locator(".quarkdown-docs > .content-wrapper > aside:last-child");
+
+    // Get initial scroll positions
+    const [initialAsideFirstScroll, initialAsideLastScroll, initialWindowScroll] = await Promise.all([
+        contentAsideFirst.evaluate((el) => el.scrollTop),
+        contentAsideLast.evaluate((el) => el.scrollTop),
+        page.evaluate(() => window.scrollY),
+    ]);
+
+    // Scroll the left aside
+    await contentAsideFirst.evaluate((el) => el.scrollBy(0, 100));
+
+    // Verify left aside scrolled
+    const asideFirstScrollAfter = await contentAsideFirst.evaluate((el) => el.scrollTop);
+    expect(asideFirstScrollAfter).toBeGreaterThan(initialAsideFirstScroll);
+
+    // Verify main (window) and right aside did not scroll
+    const [asideLastScrollAfter, windowScrollAfter] = await Promise.all([
+        contentAsideLast.evaluate((el) => el.scrollTop),
+        page.evaluate(() => window.scrollY),
+    ]);
+
+    expect(asideLastScrollAfter).toBe(initialAsideLastScroll);
+    expect(windowScrollAfter).toBe(initialWindowScroll);
+});
+
+test("scrolling window does not affect aside internal scroll", async (page) => {
+    const contentAsideFirst = page.locator(".quarkdown-docs > .content-wrapper > aside:first-child");
+    const contentAsideLast = page.locator(".quarkdown-docs > .content-wrapper > aside:last-child");
+
+    // Get initial aside scroll positions
+    const [initialAsideFirstScroll, initialAsideLastScroll] = await Promise.all([
+        contentAsideFirst.evaluate((el) => el.scrollTop),
+        contentAsideLast.evaluate((el) => el.scrollTop),
+    ]);
+
+    // Scroll the window
+    await page.evaluate(() => window.scrollBy(0, 200));
+
+    // Verify window scrolled
+    const windowScrollAfter = await page.evaluate(() => window.scrollY);
+    expect(windowScrollAfter).toBeGreaterThan(0);
+
+    // Verify aside internal scroll positions are unchanged
+    const [asideFirstScrollAfter, asideLastScrollAfter] = await Promise.all([
+        contentAsideFirst.evaluate((el) => el.scrollTop),
+        contentAsideLast.evaluate((el) => el.scrollTop),
+    ]);
+
+    expect(asideFirstScrollAfter).toBe(initialAsideFirstScroll);
+    expect(asideLastScrollAfter).toBe(initialAsideLastScroll);
+});
+
+test("anchor scroll positions heading correctly", async (page) => {
+    const header = page.locator(".quarkdown-docs > header");
+    const headerBox = await header.boundingBox();
+    expect(headerBox).not.toBeNull();
+
+    // Get the aside's padding-top value
+    const asidePaddingTop = await page.locator(".quarkdown-docs > .content-wrapper > aside:first-child")
+        .evaluate((el) => parseFloat(getComputedStyle(el).paddingTop));
+
+    const expectedHeadingY = headerBox!.height + asidePaddingTop;
+
+    // Navigate to the #gamma anchor
+    await page.goto(page.url() + "#gamma");
+    await page.waitForTimeout(100); // Wait for scroll to complete
+
+    const gammaHeading = page.locator("h1#gamma");
+    await expect(gammaHeading).toBeVisible();
+
+    const gammaBox = await gammaHeading.boundingBox();
+    expect(gammaBox).not.toBeNull();
+
+    // The heading should be positioned at header height + aside padding-top
+    expect(gammaBox!.y).toBeCloseTo(expectedHeadingY, 0);
+});


### PR DESCRIPTION
Anchor-scrolling was causing the heading to be hidden underneath the header