### PR TITLE
feat: allow including library as content

### DIFF
--- a/quarkdown-cli/src/main/kotlin/com/quarkdown/cli/lib/QdLibraries.kt
+++ b/quarkdown-cli/src/main/kotlin/com/quarkdown/cli/lib/QdLibraries.kt
@@ -22,7 +22,7 @@ object QdLibraries {
             .listFiles()!!
             .asSequence()
             .filter { it.extension == EXTENSION_FILTER }
-            .map { QdLibraryExporter(it.nameWithoutExtension, it.reader()) }
+            .map { QdLibraryExporter(it.nameWithoutExtension) { it.reader() } }
             .toSet()
     }
 }

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/context/MutableContext.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/context/MutableContext.kt
@@ -9,6 +9,7 @@ import com.quarkdown.core.flavor.MarkdownFlavor
 import com.quarkdown.core.function.call.FunctionCall
 import com.quarkdown.core.function.library.Library
 import com.quarkdown.core.function.library.LibraryRegistrant
+import com.quarkdown.core.function.value.OutputValue
 import com.quarkdown.core.localization.MutableLocalizationTables
 import com.quarkdown.core.media.storage.MutableMediaStorage
 
@@ -75,15 +76,13 @@ open class MutableContext(
 
     /**
      * Loads a loadable library by name and registers it in the context.
-     * After a successful load, the library is removed from [loadableLibraries] and added to [libraries],
-     * with its [Library.onLoad] action executed.
+     * After a successful load, the library is added to [libraries], with its [Library.onLoad] action executed.
      * @param name name of the library to load, case-sensitive
-     * @return the loaded library, if it exists
+     * @return the loaded library, if it exists, paired with the value returned by its [Library.onLoad] action if it exists
      */
-    fun loadLibrary(name: String): Library? =
-        loadableLibraries.find { it.name == name }?.also {
-            loadableLibraries.remove(it)
-            LibraryRegistrant(this).register(it)
+    fun loadLibrary(name: String): Pair<Library, OutputValue<*>?>? =
+        loadableLibraries.find { it.name == name }?.let { library ->
+            library to LibraryRegistrant(this).register(library)
         }
 
     /**

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/function/library/Library.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/function/library/Library.kt
@@ -2,19 +2,20 @@ package com.quarkdown.core.function.library
 
 import com.quarkdown.core.context.Context
 import com.quarkdown.core.function.Function
+import com.quarkdown.core.function.value.OutputValue
 import com.quarkdown.core.pipeline.PipelineHooks
 
 /**
  * A bundle of functions that can be called from a Quarkdown source.
  * @param name name of the library
  * @param functions functions the library makes available to call
- * @param onLoad optional action to run when the library is loaded in a context
+ * @param onLoad optional action to run when the library is loaded in a context. Returns an optional value to be used as the result of loading the library
  * @param hooks optional actions to run after each stage of a pipeline where this library is registered in has been completed
  */
 data class Library(
     val name: String,
     val functions: Set<Function<*>>,
-    val onLoad: ((Context) -> Unit)? = null,
+    val onLoad: ((Context) -> OutputValue<*>)? = null,
     val hooks: PipelineHooks? = null,
 ) {
     /**

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/function/library/LibraryRegistrant.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/function/library/LibraryRegistrant.kt
@@ -2,6 +2,7 @@ package com.quarkdown.core.function.library
 
 import com.quarkdown.core.context.Context
 import com.quarkdown.core.context.MutableContext
+import com.quarkdown.core.function.value.OutputValue
 
 /**
  * Component that is responsible for registering libraries in a pipeline's [Context],
@@ -16,9 +17,9 @@ class LibraryRegistrant(
      * and its [Library.onLoad] action is executed.
      * @param library library to register
      */
-    fun register(library: Library) {
+    fun register(library: Library): OutputValue<*>? {
         context.libraries += library
-        library.onLoad?.invoke(context)
+        return library.onLoad?.invoke(context)
     }
 
     /**

--- a/quarkdown-libs/src/main/resources/paper.qd
+++ b/quarkdown-libs/src/main/resources/paper.qd
@@ -81,25 +81,25 @@
     .var {numberingtag} {.concatenate {.type} {s}}
     .namedparagraph {.localizedname} {.numberingtag} {.content}
 
-<-- A numerable 'definition' block -->
+<!-- A numerable 'definition' block -->
 
 .function {definition}
     content:
     .INTERNALtypedparagraph {definition} {.content}
 
-<-- A numerable 'lemma' block -->
+<!-- A numerable 'lemma' block -->
 
 .function {lemma}
     content:
     .INTERNALtypedparagraph {lemma} {.content}
 
-<-- A numerable 'theorem' block -->
+<!-- A numerable 'theorem' block -->
 
 .function {theorem}
     content:
     .INTERNALtypedparagraph {theorem} {.content}
 
-<-- A numerable 'proof' block -->
+<!-- A numerable 'proof' block -->
 
 .function {proof}
     content:

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Ecosystem.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Ecosystem.kt
@@ -75,7 +75,8 @@ enum class ContextSandbox {
  * This function has two behaviors:
  * - Reads a Quarkdown file and includes its parsed content in the current document,
  *   using the specified [sandbox] strategy to determine what information is shared between the main context and the included file's context.
- * - Loads a library into the current context. Loadable libraries are fetched from the library folder (`--libs` CLI option).
+ * - Loads a library into the current context and includes its parsed content in the current document.
+ *   Loadable libraries are fetched from the library folder (`--libs` CLI option).
  *   [sandbox] is ignored in this case.
  *
  * The context of the included file is always inherited from the main file, with an updated working directory that matches the included file's location.
@@ -86,7 +87,7 @@ enum class ContextSandbox {
  *            This is represented by [SharedContext].
  *
  * - `scope`: like `share`, but the included file's context does not share new declarations (functions and variables) back to the main file's context.
- *            This is the behavior used within lambda blocks, such as [foreach], and is represented by [ScopeContext].
+ *            This is the behavior used within lambda blocks, such as [forEach], and is represented by [ScopeContext].
  *
  * - `subdocument`: no information is shared back to the main file's context, only inherited from it. This also applies to the document info (metadata, title, etc.),
  *                  This is the behavior used for subdocuments, and is represented by [SubdocumentContext].
@@ -104,7 +105,7 @@ fun include(
     @LikelyNamed sandbox: ContextSandbox = ContextSandbox.SHARE,
 ): OutputValue<*> {
     // Load library by name if it exists.
-    context.loadLibrary(path)?.let { return VoidValue }
+    context.loadLibrary(path)?.let { (_, value) -> return value ?: VoidValue }
 
     // File lookup
     val file = file(context, path)

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/external/QdLibraryExporter.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/external/QdLibraryExporter.kt
@@ -13,14 +13,14 @@ import java.io.Reader
  */
 class QdLibraryExporter(
     private val name: String,
-    private val reader: Reader,
+    private val reader: () -> Reader,
 ) : LibraryExporter {
-    override val library: Library
-        get() =
-            Library(
-                name,
-                functions = emptySet(),
-                // The stdlib's includeResource function is used to include the content of the .qd file
-                onLoad = { context -> includeResource(context, reader) },
-            )
+    override val library: Library by lazy {
+        Library(
+            name,
+            functions = emptySet(),
+            // The stdlib's includeResource function is used to include the content of the .qd file
+            onLoad = { context -> includeResource(context, reader()) },
+        )
+    }
 }

--- a/quarkdown-test/src/test/kotlin/com/quarkdown/test/EcosystemTest.kt
+++ b/quarkdown-test/src/test/kotlin/com/quarkdown/test/EcosystemTest.kt
@@ -314,6 +314,20 @@ class EcosystemTest {
     }
 
     @Test
+    fun `include library content`() {
+        execute(
+            ".include {content}",
+            loadableLibraries = setOf("content"),
+            useDummyLibraryDirectory = true,
+        ) {
+            assertEquals(
+                "<h2>Title</h2><p>Content</p>",
+                it,
+            )
+        }
+    }
+
+    @Test
     fun `include multiple sources`() {
         forSandboxes(ContextSandbox.SHARE) { sandbox ->
             execute(

--- a/quarkdown-test/src/test/kotlin/com/quarkdown/test/util/LibraryUtils.kt
+++ b/quarkdown-test/src/test/kotlin/com/quarkdown/test/util/LibraryUtils.kt
@@ -22,7 +22,6 @@ object LibraryUtils {
             .map {
                 QdLibraryExporter(
                     it,
-                    File(directory, "$it.qd").reader(),
-                ).library
+                ) { File(directory, "$it.qd").reader() }.library
             }.toSet()
 }

--- a/quarkdown-test/src/test/resources/data/libraries/content.qd
+++ b/quarkdown-test/src/test/resources/data/libraries/content.qd
@@ -1,0 +1,3 @@
+## Title
+
+Content

--- a/quarkdown-test/src/test/resources/data/subdoc/include-lib-1.qd
+++ b/quarkdown-test/src/test/resources/data/subdoc/include-lib-1.qd
@@ -1,0 +1,1 @@
+.include {content}

--- a/quarkdown-test/src/test/resources/data/subdoc/include-lib-2.qd
+++ b/quarkdown-test/src/test/resources/data/subdoc/include-lib-2.qd
@@ -1,0 +1,1 @@
+.include {hello}


### PR DESCRIPTION
`.include {library}` now also includes its Markdown content, as `.include {file.qd}` already does.