### PR TITLE
feat(cli)!: replace `--no-subdoc-collisions` with `--subdoc-naming` strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,7 +367,10 @@ If you would like to familiarize yourself with Quarkdown instead, `quarkdown rep
 
 - `--no-media-storage`: turns the media storage system off. [(?)](https://github.com/iamgio/quarkdown/wiki/media-storage)
 
-- `--no-subdoc-collisions`: makes generated subdocument file names collision-proof. [(?)](https://github.com/iamgio/quarkdown/wiki/subdocuments)
+- `--subdoc-naming <strategy>`: sets the subdocument output naming strategy [(?)](https://github.com/iamgio/quarkdown/wiki/subdocuments). Defaults to `file-name`. Accepted values:
+  - `file-name`: uses the subdocument's file name (human-readable, but prone to collisions)
+  - `collision-proof`: appends a hash to `file-name` to minimize name collisions
+  - `document-name`: uses the document name set via `.docname`, falling back to `file-name` if unset
 
 - `-Dloglevel=<level>` (JVM property): sets the log level. If set to `warning` or higher, the output content is not printed out.
 

--- a/docs/Subdocuments.qd
+++ b/docs/Subdocuments.qd
@@ -143,10 +143,27 @@ MyDocument/
 
 If only the root subdocument is present, then only `MyDocument.pdf` is generated without the need for a directory.
 
-### Minimizing name collisions
+### Output naming
+
+By default, subdocument output files are named after their source file name. This behavior can be customized via the `--subdoc-naming <strategy>` compiler option. This applies to all output targets, such as HTML and PDF.
+
+.example
+    `getting-started.qd` -> `getting-started.pdf`
+
+#### Document name
+
+Launching the compiler with `--subdoc-naming document-name` names each subdocument output after their own [`.docname`](Document-metadata.qd), rather than the source file name. If a subdocument does not set `.docname`, the source file name is used as a fallback. Note that duplicate document names are not handled, and may lead to name collisions and overwritten files.
+
+.example
+    `getting-started.qd` with `.docname {Getting Started}` -> `Getting-Started.pdf`
+
+#### Minimizing name collisions
 
 Since the subdocument output files lie flatly in the same directory, it is possible that two subdocuments with the same name but from different directories end up colliding.
 
 By default, Quarkdown accepts this collision-prone behavior in order to generate human-readable URLs.
 
-If collisions cannot be avoided, launching the compiler with the `--no-subdoc-collisions` flag will append a hash to the output file names.
+If collisions cannot be avoided, launching the compiler with `--subdoc-naming collision-proof` will append a hash to the output file names.
+
+.example
+    `getting-started.qd` -> `getting-started@12345678.pdf`

--- a/quarkdown-cli/src/test/kotlin/com/quarkdown/cli/CompileCommandTest.kt
+++ b/quarkdown-cli/src/test/kotlin/com/quarkdown/cli/CompileCommandTest.kt
@@ -241,7 +241,7 @@ class CompileCommandTest : TempDirectory() {
             )
         }
 
-        test("--no-subdoc-collisions")
+        test("--subdoc-naming", "collision-proof")
         assertHtmlContentPresent()
         assertSubdocumentExistsWithHash("subdoc1", subdoc1)
         assertSubdocumentExistsWithHash("subdoc2", subdoc2)

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/document/sub/Subdocument.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/document/sub/Subdocument.kt
@@ -1,6 +1,5 @@
 package com.quarkdown.core.document.sub
 
-import com.quarkdown.core.context.Context
 import java.io.File
 
 private const val ROOT_NAME = "index"
@@ -65,16 +64,3 @@ sealed interface Subdocument {
             get() = UNIQUE_NAME_FORMAT.format(name, path.hashCode())
     }
 }
-
-/**
- * Returns the output file name for the subdocument, based on the context's options.
- * If the pipeline enforces minimal subdocument collisions ([com.quarkdown.core.pipeline.PipelineOptions.minimizeSubdocumentCollisions]),
- * [Subdocument.uniqueName] is returned, otherwise just [Subdocument.name], which is more human-readable but prone to collisions.
- * @param context the context that holds the pipeline options
- * @return the output file name for the subdocument
- */
-fun Subdocument.getOutputFileName(context: Context): String =
-    when {
-        context.attachedPipeline?.options?.minimizeSubdocumentCollisions == true -> uniqueName
-        else -> name
-    }

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/document/sub/SubdocumentOutputNaming.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/document/sub/SubdocumentOutputNaming.kt
@@ -1,0 +1,37 @@
+package com.quarkdown.core.document.sub
+
+import com.quarkdown.core.context.Context
+
+/**
+ * Strategy for naming subdocument output files.
+ * @see Subdocument.getOutputFileName
+ */
+enum class SubdocumentOutputNaming {
+    /**
+     * Uses the subdocument's file name.
+     */
+    FILE_NAME,
+
+    /**
+     * Uses a hash-based unique name to minimize collisions.
+     */
+    COLLISION_PROOF,
+
+    /**
+     * Uses the document name set via `.docname`, falling back to [FILE_NAME] if unset.
+     */
+    DOCUMENT_NAME,
+}
+
+/**
+ * Returns the output file name for the subdocument, based on the context's [SubdocumentOutputNaming] strategy.
+ * @param context the context that holds the pipeline options
+ * @return the output file name for the subdocument
+ * @see com.quarkdown.core.pipeline.PipelineOptions.subdocumentNaming
+ */
+fun Subdocument.getOutputFileName(context: Context): String =
+    when (context.attachedPipeline?.options?.subdocumentNaming) {
+        SubdocumentOutputNaming.COLLISION_PROOF -> uniqueName
+        SubdocumentOutputNaming.DOCUMENT_NAME -> context.documentInfo.name ?: name
+        else -> name
+    }

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/pipeline/PipelineOptions.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/pipeline/PipelineOptions.kt
@@ -1,5 +1,6 @@
 package com.quarkdown.core.pipeline
 
+import com.quarkdown.core.document.sub.SubdocumentOutputNaming
 import com.quarkdown.core.media.storage.options.MediaStorageOptions
 import com.quarkdown.core.media.storage.options.ReadOnlyMediaStorageOptions
 import com.quarkdown.core.pipeline.error.BasePipelineErrorHandler
@@ -21,8 +22,7 @@ import java.io.File
  * This doesn't take effect with the base Markdown flavor,
  * as the media architecture is defined by Quarkdown through a [com.quarkdown.core.context.hooks.MediaStorerHook].
  * If this is disabled, [MediaStorageOptions] are ignored.
- * @param minimizeSubdocumentCollisions whether to subdocument files should be named in a way that minimizes the risk of name collisions.
- * A collision-proof name is hash-based and less human-readable and user-friendly
+ * @param subdocumentNaming the strategy used to determine subdocument output file names
  * @param mediaStorageOptionsOverrides rules that override the default behavior of the media storage system
  * @param errorHandler the error handler strategy to use when an error occurs in the pipeline, during the processing of a Quarkdown file
  * @param serverPort port to communicate with the local server on. If not set, no server communication is performed. In a practical scenario,
@@ -34,7 +34,7 @@ data class PipelineOptions(
     val wrapOutput: Boolean = true,
     val workingDirectory: File? = null,
     val enableMediaStorage: Boolean = true,
-    val minimizeSubdocumentCollisions: Boolean = false,
+    val subdocumentNaming: SubdocumentOutputNaming = SubdocumentOutputNaming.FILE_NAME,
     val serverPort: Int? = null,
     val mediaStorageOptionsOverrides: MediaStorageOptions = ReadOnlyMediaStorageOptions(),
     val errorHandler: PipelineErrorHandler = BasePipelineErrorHandler(),

--- a/quarkdown-test/src/test/kotlin/com/quarkdown/test/SubdocumentTest.kt
+++ b/quarkdown-test/src/test/kotlin/com/quarkdown/test/SubdocumentTest.kt
@@ -4,6 +4,7 @@ import com.quarkdown.core.ast.attributes.presence.hasMermaidDiagram
 import com.quarkdown.core.context.subdocument.subdocumentGraph
 import com.quarkdown.core.document.DocumentType
 import com.quarkdown.core.document.sub.Subdocument
+import com.quarkdown.core.document.sub.SubdocumentOutputNaming
 import com.quarkdown.test.util.DATA_FOLDER
 import com.quarkdown.test.util.execute
 import com.quarkdown.test.util.getSubResources
@@ -60,11 +61,40 @@ class SubdocumentTest {
         execute(
             "",
             subdocumentGraph = { it.addVertex(simpleSubdoc).addEdge(Subdocument.Root, simpleSubdoc) },
-            minimizeSubdocumentCollisions = true,
+            subdocumentNaming = SubdocumentOutputNaming.COLLISION_PROOF,
             outputResourceHook = { group ->
                 val resources = getSubResources(group).map { it.name }
                 assertContains(resources, simpleSubdoc.uniqueName)
                 assertFalse(simpleSubdoc.name in resources)
+            },
+        ) {}
+    }
+
+    @Test
+    fun `document-name subdocument naming with docname set`() {
+        execute(
+            "",
+            subdocumentGraph = {
+                it.addVertex(modifyAndEchoDocumentNameSubdoc).addEdge(Subdocument.Root, modifyAndEchoDocumentNameSubdoc)
+            },
+            subdocumentNaming = SubdocumentOutputNaming.DOCUMENT_NAME,
+            outputResourceHook = { group ->
+                val resources = getSubResources(group).map { it.name }
+                assertContains(resources, "Changed name")
+                assertFalse(modifyAndEchoDocumentNameSubdoc.name in resources)
+            },
+        ) {}
+    }
+
+    @Test
+    fun `document-name subdocument naming falls back to file name`() {
+        execute(
+            "",
+            subdocumentGraph = { it.addVertex(simpleSubdoc).addEdge(Subdocument.Root, simpleSubdoc) },
+            subdocumentNaming = SubdocumentOutputNaming.DOCUMENT_NAME,
+            outputResourceHook = { group ->
+                val resources = getSubResources(group).map { it.name }
+                assertContains(resources, simpleSubdoc.name)
             },
         ) {}
     }

--- a/quarkdown-test/src/test/kotlin/com/quarkdown/test/util/Launcher.kt
+++ b/quarkdown-test/src/test/kotlin/com/quarkdown/test/util/Launcher.kt
@@ -5,6 +5,7 @@ import com.quarkdown.core.context.MutableContext
 import com.quarkdown.core.context.MutableContextOptions
 import com.quarkdown.core.context.subdocument.subdocumentGraph
 import com.quarkdown.core.document.sub.Subdocument
+import com.quarkdown.core.document.sub.SubdocumentOutputNaming
 import com.quarkdown.core.flavor.RendererFactory
 import com.quarkdown.core.flavor.quarkdown.QuarkdownFlavor
 import com.quarkdown.core.graph.VisitableOnceGraph
@@ -47,7 +48,7 @@ val DEFAULT_OPTIONS =
  * @param errorHandler error handler to use
  * @param enableMediaStorage whether the media storage system should be enabled.
  * If enabled, nodes that reference media (e.g. images) will instead reference the path to the media on the local storage
- * @param minimizeSubdocumentCollisions whether to minimize the risk of subdocument name collisions by using a hash-based name for subdocuments
+ * @param subdocumentNaming the strategy used to determine subdocument output file names
  * @param outputResourceHook action run after the pipeline execution, with the output resource as a parameter
  * @param afterPostRenderingHook action run after post-rendering. Parameters are the pipeline context and the post-rendered result
  * @param afterRenderingHook action run after rendering. Parameters are the pipeline context and the rendered result
@@ -62,7 +63,7 @@ fun execute(
     useDummyLibraryDirectory: Boolean = false,
     errorHandler: PipelineErrorHandler = StrictPipelineErrorHandler(),
     enableMediaStorage: Boolean = false,
-    minimizeSubdocumentCollisions: Boolean = false,
+    subdocumentNaming: SubdocumentOutputNaming = SubdocumentOutputNaming.FILE_NAME,
     outputResourceHook: Context.(OutputResource?) -> Unit = {},
     afterPostRenderingHook: Context.(CharSequence) -> Unit = {},
     afterRenderingHook: Context.(CharSequence) -> Unit,
@@ -102,7 +103,7 @@ fun execute(
                 errorHandler = errorHandler,
                 workingDirectory = workingDirectory,
                 enableMediaStorage = enableMediaStorage,
-                minimizeSubdocumentCollisions = minimizeSubdocumentCollisions,
+                subdocumentNaming = subdocumentNaming,
             ),
             libraries = setOf(Stdlib.library),
             renderer = renderer,


### PR DESCRIPTION
- Removed `--no-subdoc-collisions` CLI flag
- Added `--subdoc-naming`:
  - `file-name` (default)
  - `collision-proof` (formerly `--no-subdoc-collisions`)
  - `document-name` (new, equals to `.docname`)

Closes #289