### PR TITLE
fix(html): fix typed blockquote rendering with non-paragraph first child

### DIFF
--- a/quarkdown-html/src/main/kotlin/com/quarkdown/rendering/html/HtmlTagBuilder.kt
+++ b/quarkdown-html/src/main/kotlin/com/quarkdown/rendering/html/HtmlTagBuilder.kt
@@ -119,6 +119,13 @@ class HtmlTagBuilder(
     fun hidden() = attribute("data-hidden", "")
 
     /**
+     * Adds a `data-accept-empty` attribute to this tag as a flag that this element is to keep even if it has no content.
+     * By default, empty elements, such as paragraphs without text, are hidden to avoid unwanted empty spaces.
+     * @return this for concatenation
+     */
+    fun acceptEmpty() = attribute("data-accept-empty", "")
+
+    /**
      * @return this builder and its nested content into stringified HTML code.
      */
     override fun build(): String =

--- a/quarkdown-html/src/main/kotlin/com/quarkdown/rendering/html/node/QuarkdownHtmlNodeRenderer.kt
+++ b/quarkdown-html/src/main/kotlin/com/quarkdown/rendering/html/node/QuarkdownHtmlNodeRenderer.kt
@@ -12,6 +12,7 @@ import com.quarkdown.core.ast.base.TextNode
 import com.quarkdown.core.ast.base.block.BlockQuote
 import com.quarkdown.core.ast.base.block.Code
 import com.quarkdown.core.ast.base.block.Heading
+import com.quarkdown.core.ast.base.block.Paragraph
 import com.quarkdown.core.ast.base.block.Table
 import com.quarkdown.core.ast.base.block.list.ListBlock
 import com.quarkdown.core.ast.base.inline.CodeSpan
@@ -654,11 +655,14 @@ class QuarkdownHtmlNodeRenderer(
                 }
             }
 
+            // If the quote has a type, the first child must be a paragraph, because the label is rendered as ::before.
+            if (node.type != null && node.children.firstOrNull() !is Paragraph) {
+                +tagBuilder("p").acceptEmpty().build()
+            }
+
             +node.children
             node.attribution?.let {
-                +tagBuilder("p", it)
-                    .className("attribution")
-                    .build()
+                +tagBuilder("p", it).className("attribution").build()
             }
         }
 

--- a/quarkdown-html/src/main/scss/components/_empty.scss
+++ b/quarkdown-html/src/main/scss/components/_empty.scss
@@ -1,0 +1,7 @@
+$accept-empty: '[data-accept-empty]';
+
+.quarkdown {
+  p:not(#{$accept-empty}):empty {
+    display: none !important;
+  }
+}

--- a/quarkdown-html/src/main/scss/components/_paragraph.scss
+++ b/quarkdown-html/src/main/scss/components/_paragraph.scss
@@ -3,10 +3,6 @@
     margin-top: 0;
     margin-bottom: 0;
     text-indent: var(--qd-paragraph-text-indent);
-
-    &:empty {
-      display: none;
-    }
   }
 
   &:not(.quarkdown-slides) p {

--- a/quarkdown-html/src/main/scss/global.scss
+++ b/quarkdown-html/src/main/scss/global.scss
@@ -4,6 +4,7 @@
 @use "components/block";
 @use "components/heading";
 @use "components/paragraph";
+@use "components/empty";
 @use "components/link";
 @use "components/math";
 @use "components/hr";

--- a/quarkdown-test/src/test/kotlin/com/quarkdown/test/TextTest.kt
+++ b/quarkdown-test/src/test/kotlin/com/quarkdown/test/TextTest.kt
@@ -149,6 +149,53 @@ class TextTest {
     }
 
     @Test
+    fun `quote type`() {
+        arrayOf("> Tip: this is a tip", "> [!TIP]\n> this is a tip").forEach { source ->
+            execute(".doclang {English}\n$source") {
+                assertEquals(
+                    "<blockquote class=\"tip\" style=\"--quote-type-label: 'Tip';\" data-labeled=\"\"><p>this is a tip</p></blockquote>",
+                    it,
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `quote type with non-paragraph first child`() {
+        execute(
+            """
+            .doclang {English}
+            > [!TIP]
+            > - this is
+            > - a tip
+            """.trimIndent(),
+        ) {
+            assertEquals(
+                "<blockquote class=\"tip\" style=\"--quote-type-label: 'Tip';\" data-labeled=\"\">" +
+                    "<p data-accept-empty=\"\"></p>" +
+                    "<ul><li>this is</li><li>a tip</li></ul>" +
+                    "</blockquote>",
+                it,
+            )
+        }
+    }
+
+    @Test
+    fun `quote type with empty content`() {
+        execute(
+            """
+            .doclang {English}
+            > [!TIP]
+            """.trimIndent(),
+        ) {
+            assertEquals(
+                "<blockquote class=\"tip\" style=\"--quote-type-label: 'Tip';\" data-labeled=\"\"><p data-accept-empty=\"\"></p></blockquote>",
+                it,
+            )
+        }
+    }
+
+    @Test
     fun `quote attribution`() {
         execute(
             """


### PR DESCRIPTION
```markdown
> [!TIP]
> - A
> - B
> - C
```

The `Tip` label is now positioned correctly