### PR TITLE
fix: fall back to xdg-open when Desktop API is unavailable on Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,8 +57,10 @@ Infinite recursion in function calls is now detected and reported as a clear err
 
 #### Fixed default browser not opening on Linux (Wayland and XDG environments)
 
-On Linux systems where the Java AWT Desktop API does not support the BROWSE action (e.g., Wayland), `DefaultBrowserLauncher` now falls back to `xdg-open` automatically.
-Additionally, `--browser xdg-open` is now a supported named choice for the `--browser` CLI option.
+On Linux systems where the Java AWT Desktop API does not support the BROWSE action (e.g., Wayland), `--browser default` now falls back to `xdg-open` automatically.
+Additionally, `--browser xdg` is now a supported named choice for the `--browser` CLI option.
+
+Thanks @szy1840!
 
 ## [1.14.1] - 2026-03-06
 

--- a/README.md
+++ b/README.md
@@ -358,6 +358,7 @@ If you would like to familiarize yourself with Quarkdown instead, `quarkdown rep
 - `-b <browser>` or `--browser <browser>`: sets the browser to launch the preview with. Defaults to `default`. Accepted values:
   - `default`
   - `none`
+  - `xdg` (uses `xdg-open`). `default` falls back to this.
   - `chrome`
   - `chromium`
   - `firefox`

--- a/quarkdown-cli/src/main/kotlin/com/quarkdown/cli/server/BrowserLauncherOption.kt
+++ b/quarkdown-cli/src/main/kotlin/com/quarkdown/cli/server/BrowserLauncherOption.kt
@@ -11,11 +11,11 @@ import com.quarkdown.server.browser.DefaultBrowserLauncher
 import com.quarkdown.server.browser.EnvBrowserLauncher
 import com.quarkdown.server.browser.NoneBrowserLauncher
 import com.quarkdown.server.browser.PathBrowserLauncher
-import java.io.File
+import com.quarkdown.server.browser.XdgBrowserLauncher
 import kotlin.io.path.Path
 
 /**
- * Attempts to create a [BrowserLauncher] from fixed choices: `default`, `xdg-open`, or `none`.
+ * Attempts to create a [BrowserLauncher] from fixed choices: `default`, `xdg`, or `none`.
  * @param input the input string representing the browser choice
  * @return the corresponding [BrowserLauncher], if any
  */
@@ -23,13 +23,7 @@ private fun fromFixedChoices(input: String): BrowserLauncher? =
     when (input) {
         "default" -> DefaultBrowserLauncher()
         "none" -> NoneBrowserLauncher()
-        "xdg-open" ->
-            System
-                .getenv("PATH")
-                ?.split(File.pathSeparator)
-                ?.map { File(it, "xdg-open") }
-                ?.firstOrNull { it.exists() && it.canExecute() }
-                ?.let { PathBrowserLauncher(Path(it.absolutePath)) }
+        "xdg" -> XdgBrowserLauncher().takeIf { it.isValid }
         else -> null
     }
 
@@ -74,7 +68,7 @@ fun CliktCommand.browserLauncherOption(
     option(
         "-b",
         "--browser",
-        help = "Browser to open the served file in (name, path, 'default', 'xdg-open', 'none')",
+        help = "Browser to open the served file in (name, path, 'default', 'xdg', 'none')",
     ).convert { input ->
         val caseInsensitiveInput = input.lowercase()
         val launcher =

--- a/quarkdown-cli/src/test/kotlin/com/quarkdown/cli/BrowserLauncherSelectionTest.kt
+++ b/quarkdown-cli/src/test/kotlin/com/quarkdown/cli/BrowserLauncherSelectionTest.kt
@@ -7,8 +7,7 @@ import com.quarkdown.server.browser.BrowserLauncher
 import com.quarkdown.server.browser.DefaultBrowserLauncher
 import com.quarkdown.server.browser.EnvBrowserLauncher
 import com.quarkdown.server.browser.NoneBrowserLauncher
-import com.quarkdown.server.browser.PathBrowserLauncher
-import java.io.File
+import com.quarkdown.server.browser.XdgBrowserLauncher
 import kotlin.test.Test
 import kotlin.test.assertFails
 import kotlin.test.assertIs
@@ -67,18 +66,13 @@ class BrowserLauncherSelectionTest {
     }
 
     @Test
-    fun `xdg-open choice resolves to PathBrowserLauncher when available`() {
-        val xdgOpen =
-            System
-                .getenv("PATH")
-                ?.split(File.pathSeparator)
-                ?.map { File(it, "xdg-open") }
-                ?.firstOrNull { it.exists() && it.canExecute() }
-        if (xdgOpen != null) {
-            assertIs<PathBrowserLauncher>(test("xdg-open"))
+    fun `xdg choice resolves to XdgBrowserLauncher when available`() {
+        val xdgLauncher = XdgBrowserLauncher()
+        if (xdgLauncher.isValid) {
+            assertIs<XdgBrowserLauncher>(test("xdg"))
         } else {
-            // xdg-open is not available on this platform (e.g. macOS): expect failure.
-            assertFails { test("xdg-open") }
+            // xdg-open is not available on this platform
+            assertFails { test("xdg") }
         }
     }
 

--- a/quarkdown-server/src/main/kotlin/com/quarkdown/server/browser/DefaultBrowserLauncher.kt
+++ b/quarkdown-server/src/main/kotlin/com/quarkdown/server/browser/DefaultBrowserLauncher.kt
@@ -1,16 +1,14 @@
 package com.quarkdown.server.browser
 
 import java.awt.Desktop
-import java.io.File
 import java.net.URI
-import kotlin.io.path.Path
 
 /**
  * Launcher of a URL in the default system browser.
  *
  * On platforms where the Java AWT Desktop API supports the BROWSE action (e.g., macOS, most Windows setups),
  * it is used directly. On platforms where it is not supported (e.g., Linux on Wayland),
- * this launcher falls back to `xdg-open` via [PathBrowserLauncher] if it is available in the system PATH.
+ * this launcher falls back to [XdgBrowserLauncher] if `xdg-open` is available in the system PATH.
  */
 class DefaultBrowserLauncher : BrowserLauncher {
     /**
@@ -20,30 +18,28 @@ class DefaultBrowserLauncher : BrowserLauncher {
         get() = Desktop.isDesktopSupported() && Desktop.getDesktop().isSupported(Desktop.Action.BROWSE)
 
     /**
-     * A [PathBrowserLauncher] that uses `xdg-open` found in the system PATH,
-     * or `null` if `xdg-open` is not available.
-     * Used as a fallback when the Desktop API is not supported.
+     * Fallback launcher using `xdg-open`, used when the Desktop API is not supported.
      */
-    private val xdgFallback: PathBrowserLauncher? by lazy {
-        System
-            .getenv("PATH")
-            ?.split(File.pathSeparator)
-            ?.map { File(it, "xdg-open") }
-            ?.firstOrNull { it.exists() && it.canExecute() }
-            ?.let { PathBrowserLauncher(Path(it.absolutePath)) }
-    }
+    private val xdgFallback: XdgBrowserLauncher by lazy { XdgBrowserLauncher() }
 
     override val isValid: Boolean
-        get() = isDesktopSupported || xdgFallback != null
+        get() = isDesktopSupported || xdgFallback.isValid
 
     override fun launch(url: String) {
-        if (isDesktopSupported) {
-            Desktop.getDesktop().browse(URI(url))
-        } else {
-            xdgFallback?.launch(url)
-                ?: throw UnsupportedOperationException(
+        when {
+            isDesktopSupported -> {
+                Desktop.getDesktop().browse(URI(url))
+            }
+
+            xdgFallback.isValid -> {
+                xdgFallback.launch(url)
+            }
+
+            else -> {
+                throw UnsupportedOperationException(
                     "Cannot open URL: neither the Desktop API nor xdg-open is available on this platform.",
                 )
+            }
         }
     }
 }

--- a/quarkdown-server/src/main/kotlin/com/quarkdown/server/browser/XdgBrowserLauncher.kt
+++ b/quarkdown-server/src/main/kotlin/com/quarkdown/server/browser/XdgBrowserLauncher.kt
@@ -1,0 +1,38 @@
+package com.quarkdown.server.browser
+
+import java.io.File
+import kotlin.io.path.Path
+
+/**
+ * Browser launcher that uses `xdg-open` to open URLs on Linux systems.
+ *
+ * This is typically available on Linux systems with XDG-compliant desktop environments.
+ * `xdg-open` delegates to the user's preferred browser.
+ *
+ * Delegates to [PathBrowserLauncher] if `xdg-open` is found in the system `PATH`.
+ */
+class XdgBrowserLauncher : BrowserLauncher {
+    /**
+     * The underlying [PathBrowserLauncher] pointing to the resolved `xdg-open` executable,
+     * or `null` if `xdg-open` is not available in the system `PATH`.
+     */
+    private val delegate: PathBrowserLauncher? by lazy {
+        System
+            .getenv("PATH")
+            ?.split(File.pathSeparator)
+            ?.firstNotNullOfOrNull { directory ->
+                File(directory, "xdg-open")
+                    .takeIf { it.exists() && it.canExecute() }
+            }?.let { PathBrowserLauncher(Path(it.absolutePath)) }
+    }
+
+    override val isValid: Boolean
+        get() = delegate != null && delegate?.isValid == true
+
+    override fun launch(url: String) {
+        delegate?.launch(url)
+            ?: throw UnsupportedOperationException(
+                "Cannot open URL: xdg-open is not available in the system PATH.",
+            )
+    }
+}


### PR DESCRIPTION
On Linux systems where the Java AWT Desktop API does not support the BROWSE action (e.g. Wayland), `DefaultBrowserLauncher` now falls back to `xdg-open` via `PathBrowserLauncher` if it is available in the system PATH.

Additionally, `xdg-open` is now a supported named choice for the `--browser` CLI option, so users can also explicitly pass `--browser xdg-open`.

Fixes #285
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/iamgio/quarkdown/pull/370" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
