### PR TITLE
feat(stdlib)!: remove toc's includeunnumbered parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,11 @@ Both `.tableofcontents` and `.bibliography` now accept the following optional pa
 
 ### Changed
 
+#### Removed `includeunnumbered` parameter from `.tableofcontents`
+
+The `includeunnumbered` parameter has been removed, in favor of the more granular heading configuration previously mentioned.
+Now all indexable headings are included in the ToC by default, regardless of their numbering.
+
 #### `.fullspan` now relies on `.container`
 
 `.fullspan`, used to create a block spanning over multiple columns in a multi-column layout, is now shorthand for `.container fullspan:{yes}`.

--- a/docs/table-of-contents.qd
+++ b/docs/table-of-contents.qd
@@ -57,18 +57,12 @@ The table of contents adapts to different document types:
 
 ## Ignoring specific headings
 
-Sometimes you want certain headings to appear in your document but not in the table of contents. [Decorative headings](numbering.qd#decorative-headings) serve this purpose: they are not numbered and do not appear in the table of contents by default.
+Sometimes you want certain headings to appear in your document but not in the table of contents. [Decorative headings](numbering.qd#decorative-headings) serve this purpose: they are not numbered and are excluded from the table of contents.
 
 To mark a heading as decorative, append `!` to the last `#` sign:
 
 ```markdown
 ##! A decorative heading
-```
-
-If you want decorative headings to appear in the table of contents anyway, enable the `includeunnumbered` parameter:
-
-```markdown
-.tableofcontents includeunnumbered:{yes}
 ```
 
 ## Custom numbering

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/base/block/Heading.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/base/block/Heading.kt
@@ -48,7 +48,7 @@ class Heading(
      * Whether this heading is decorative, i.e. it cannot trigger page breaks and its location is not tracked.
      */
     val isDecorative: Boolean
-        get() = !canBreakPage && !canTrackLocation
+        get() = !canBreakPage && !canTrackLocation && excludeFromTableOfContents
 
     /**
      * If the heading has a custom ID, it can be used for cross-referencing.

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/quarkdown/block/toc/TableOfContentsUtils.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/quarkdown/block/toc/TableOfContentsUtils.kt
@@ -15,8 +15,7 @@ import com.quarkdown.core.visitor.node.NodeVisitor
 
 /**
  * Filters [TableOfContents.Item]s based on the given [TableOfContentsView]'s configuration:
- * - Items that exceed the maximum depth are filtered out.
- * - Unnumbered items are filtered out if [TableOfContentsView.includeUnnumbered] is `false`.
+ * items that exceed the maximum depth are filtered out.
  * @returns a sequence of filtered [TableOfContents.Item]s.
  */
 private fun filterTableOfContentsItems(
@@ -25,16 +24,7 @@ private fun filterTableOfContentsItems(
 ): Sequence<TableOfContents.Item> =
     items
         .asSequence()
-        // Items that exceed the maximum depth.
         .filter { it.depth <= view.maxDepth }
-        // Unnumbered items are excluded unless included. If excluded, their children are spread up.
-        .flatMap {
-            if (view.includeUnnumbered || (it.target as? LocationTrackableNode)?.canTrackLocation == true) {
-                sequenceOf(it)
-            } else {
-                filterTableOfContentsItems(view, it.subItems)
-            }
-        }
 
 /**
  * Converts a table of contents to a renderable [OrderedList].

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/quarkdown/block/toc/TableOfContentsView.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/quarkdown/block/toc/TableOfContentsView.kt
@@ -12,12 +12,10 @@ import com.quarkdown.core.visitor.node.NodeVisitor
  * retrieved from the auto-generated [AstAttributes.tableOfContents], is displayed.
  * @param maxDepth maximum depth the table of contents to display.
  *                 For instance, if `maxDepth` is 2, only headings of level 1 and 2 will be displayed
- * @param includeUnnumbered if `true`, unnumbered (decorative) headings are also included
  * @param focusedItem if not `null`, adds focus to the item of the table of contents with the same text content as this value
  */
 class TableOfContentsView(
     val maxDepth: Int,
-    val includeUnnumbered: Boolean = false,
     private val focusedItem: InlineContent? = null,
 ) : Node {
     override fun <T> accept(visitor: NodeVisitor<T>): T = visitor.visit(this)

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/parser/BlockTokenParser.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/parser/BlockTokenParser.kt
@@ -160,6 +160,7 @@ class BlockTokenParser(
             customId = customId,
             canBreakPage = !isDecorative,
             canTrackLocation = !isDecorative,
+            excludeFromTableOfContents = isDecorative,
         )
     }
 

--- a/quarkdown-html/src/main/kotlin/com/quarkdown/rendering/html/node/SidebarRenderer.kt
+++ b/quarkdown-html/src/main/kotlin/com/quarkdown/rendering/html/node/SidebarRenderer.kt
@@ -20,7 +20,7 @@ object SidebarRenderer {
     fun render(context: Context): CharSequence {
         val toc = context.attributes.tableOfContents ?: return ""
         val renderer = QuarkdownHtmlNodeRenderer(context)
-        val view = TableOfContentsView(maxDepth = MAX_DEPTH, includeUnnumbered = false)
+        val view = TableOfContentsView(maxDepth = MAX_DEPTH)
         val list =
             convertTableOfContentsToListNode(
                 view,

--- a/quarkdown-html/src/test/kotlin/com/quarkdown/rendering/html/HtmlNodeRendererTest.kt
+++ b/quarkdown-html/src/test/kotlin/com/quarkdown/rendering/html/HtmlNodeRendererTest.kt
@@ -513,7 +513,13 @@ class HtmlNodeRendererTest {
         assertEquals(out.next(), Heading(2, listOf(Text("Foo bar"))).render(noIdNoPageBreak))
         assertEquals(
             out.next(),
-            Heading(2, listOf(Text("Foo bar")), canBreakPage = false, canTrackLocation = false).render(noIdNoPageBreak),
+            Heading(
+                2,
+                listOf(Text("Foo bar")),
+                canBreakPage = false,
+                canTrackLocation = false,
+                excludeFromTableOfContents = true,
+            ).render(noIdNoPageBreak),
         )
         assertEquals(out.next(), Heading(3, listOf(Text("Foo bar")), customId = "my-id").render(noIdNoPageBreak))
         assertEquals(out.next(), Heading(3, listOf(Strong(listOf(Text("Foo bar"))))).render(noIdNoPageBreak))

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Document.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Document.kt
@@ -997,8 +997,6 @@ fun navigationContainer(
  * @param title title of the table of contents. If unset, the default localized title is used. If blank, no title is displayed.
  * @param maxDepth maximum depth of the table of contents.
  *                 Only headings with a depth (number of leading `#`s) equal to or less than this value are included.
- * @param includeUnnumbered if enabled, unnumbered (decorative) headings are also included in the table of contents.
- *                          By default, only numbered headings are included.
  * @param breakPage whether the heading preceding the table of contents triggers an automatic page break.
  *                  Enabled by default.
  * @param headingDepth depth of the heading preceding the table of contents.
@@ -1019,7 +1017,6 @@ fun tableOfContents(
     @Injected context: Context,
     @LikelyNamed title: InlineMarkdownContent? = null,
     @Name("maxdepth") maxDepth: Int = 3,
-    @Name("includeunnumbered") includeUnnumbered: Boolean = false,
     @Name("breakpage") breakPage: Boolean = true,
     @Name("headingdepth") headingDepth: Int? = null,
     @Name("numberheading") trackHeadingLocation: Boolean = false,
@@ -1042,7 +1039,6 @@ fun tableOfContents(
             ),
             TableOfContentsView(
                 maxDepth,
-                includeUnnumbered,
                 focusedItem?.children,
             ),
         ),

--- a/quarkdown-test/src/test/kotlin/com/quarkdown/test/BibliographyTest.kt
+++ b/quarkdown-test/src/test/kotlin/com/quarkdown/test/BibliographyTest.kt
@@ -141,12 +141,12 @@ class BibliographyTest {
     }
 
     @Test
-    fun `bibliography heading indexed in toc`() {
+    fun `bibliography heading indexed in toc, unnumbered`() {
         execute(
             """
             .doclang {en}
             .noautopagebreak
-            .tableofcontents title:{} includeunnumbered:{yes}
+            .tableofcontents title:{}
 
             .bibliography {bib/bibliography.bib} indexheading:{yes}
             """.trimIndent(),
@@ -155,6 +155,29 @@ class BibliographyTest {
             assertTrue(
                 it.contains(
                     "<li data-target-id=\"references\" data-depth=\"1\">" +
+                        "<a href=\"#references\">References</a></li>",
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun `bibliography heading indexed in toc, numbered`() {
+        execute(
+            """
+            .doclang {en}
+            .numbering
+               - headings: 1.A.a
+            .noautopagebreak
+            .tableofcontents title:{}
+
+            .bibliography {bib/bibliography.bib} indexheading:{yes} numberheading:{yes}
+            """.trimIndent(),
+            DEFAULT_OPTIONS.copy(enableAutomaticIdentifiers = true, enableLocationAwareness = true),
+        ) {
+            assertTrue(
+                it.contains(
+                    "<li data-target-id=\"references\" data-depth=\"1\" data-location=\"1\">" +
                         "<a href=\"#references\">References</a></li>",
                 ),
             )

--- a/quarkdown-test/src/test/kotlin/com/quarkdown/test/TableOfContentsTest.kt
+++ b/quarkdown-test/src/test/kotlin/com/quarkdown/test/TableOfContentsTest.kt
@@ -208,12 +208,11 @@ class TableOfContentsTest {
     }
 
     @Test
-    fun `include unnumbered headings in table of contents`() {
-        // Include unnumbered headings
+    fun `unnumbered headings excluded from table of contents`() {
         execute(
             """
             .noautopagebreak
-            .tableofcontents includeunnumbered:{true}
+            .tableofcontents
 
             #! Unnumbered 1
 
@@ -230,9 +229,7 @@ class TableOfContentsTest {
             assertEquals(
                 "<h1 id=\"table-of-contents\"></h1>" +
                     "<nav role=\"table-of-contents\" data-role=\"table-of-contents\"><ol>" +
-                    "<li data-target-id=\"unnumbered-1\" data-depth=\"1\"><a href=\"#unnumbered-1\">Unnumbered 1</a></li>" +
-                    "<li data-target-id=\"abc\" data-depth=\"1\"><a href=\"#abc\">ABC</a>" +
-                    "<ol><li data-target-id=\"unnumbered-2\" data-depth=\"2\"><a href=\"#unnumbered-2\">Unnumbered 2</a></li></ol></li>" +
+                    "<li data-target-id=\"abc\" data-depth=\"1\"><a href=\"#abc\">ABC</a></li>" +
                     "<li data-target-id=\"def\" data-depth=\"1\"><a href=\"#def\">DEF</a>" +
                     "<ol><li data-target-id=\"y\" data-depth=\"2\"><a href=\"#y\">Y</a></li></ol></li>" +
                     "</ol></nav>" +
@@ -251,7 +248,7 @@ class TableOfContentsTest {
         execute(
             """
             .noautopagebreak
-            .tableofcontents includeunnumbered:{no}
+            .tableofcontents
 
             #! ABC
 
@@ -340,7 +337,7 @@ class TableOfContentsTest {
         execute(
             """
             .noautopagebreak
-            .tableofcontents title:{TOC} indexheading:{yes} includeunnumbered:{yes}
+            .tableofcontents title:{TOC} indexheading:{yes}
 
             # ABC
 


### PR DESCRIPTION
New `excludeFromTableOfContents` granular heading control allows getting rid of `.tableofcontents`'s `includeunnumbered`.