### PR TITLE
feat(filetree): add highlighted entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,29 @@ It allows explicit control over numbering (`numbered`), table of contents indexi
 
 #### [`.pagebreak` primitive function](https://quarkdown.com/wiki/page-break)
 
-The new `.pagebreak` function provides an explicit way to insert a page break, and can be used within other function calls where the `<<<` syntax would not be recognized.
+The new `.pagebreak` function provides an explicit way to insert a page break as an alternative to the `<<<` syntax.
+
+#### [File tree](https://quarkdown.com/wiki/file-tree)
+
+The new `.filetree` function renders a visual file tree from a Markdown list.
+
+```markdown
+.filetree
+    - src
+      - main.ts
+      - ...
+    - README.md
+```
+
+Bold entries (`**name**`) are highlighted with a distinct background color, useful for drawing attention to specific items.
+
+```markdown
+.filetree
+    - src
+      - **main.ts**
+      - utils.ts
+    - README.md
+```
 
 #### [Better heading configuration for table of contents and bibliography](https://quarkdown.com/wiki/table-of-contents)
 
@@ -69,6 +91,10 @@ On Linux systems where the Java AWT Desktop API does not support the BROWSE acti
 Additionally, `--browser xdg` is now a supported named choice for the `--browser` CLI option.
 
 Thanks @szy1840!
+
+#### Improved lexer performance
+
+The lexer has been optimized to reduce regex builds to a minimum, resulting in significantly improved performance for large documents.
 
 ## [1.14.1] - 2026-03-06
 

--- a/docs/_nav.qd
+++ b/docs/_nav.qd
@@ -55,6 +55,7 @@
 - [Figure](custom-figure.qd)
 - [Clip](clip.qd)
 - [Box](box.qd)
+- [File tree](file-tree.qd)
 - [Collapsible](collapsible.qd)
 - [Landscape](landscape-content.qd)
 - [Whitespace](whitespace.qd)

--- a/docs/assets/style.css
+++ b/docs/assets/style.css
@@ -19,13 +19,17 @@ header .version {
 }
 
 .quarkdown-output :is(h1, h2, h3, h4, h5, h6) {
-    margin-top: 0 !important;
     padding: 0 !important;
     border: none !important;
 }
 
 .quarkdown-output :is(h1, h2, h3, h4, h5, h6):first-child {
     margin-top: 0 !important;
+}
+
+.quarkdown-output .file-tree:only-child {
+    margin-top: 0 !important;
+    margin-bottom: 0 !important;
 }
 
 .quarkdown-output img[src*="sky"] {

--- a/docs/file-tree.qd
+++ b/docs/file-tree.qd
@@ -1,0 +1,38 @@
+.docname {File Tree}
+.include {docs}
+
+The **`.filetree`** .docslink {quarkdown-stdlib/com.quarkdown.stdlib.module.MiscElements/fileTree.html} function creates a visual file tree from a standard Markdown list.
+Each inline item becomes a file, and each nested list becomes a directory.
+
+.examplemirror
+    .filetree
+        - src
+          - components
+            - Button.ts
+            - Card.ts
+          - index.ts
+        - README.md
+
+## Ellipsis
+
+An item with `...` as its text is rendered as an ellipsis, representing omitted content in the tree.
+
+.examplemirror
+    .filetree
+        - src
+          - main.ts
+          - ...
+        - LICENSE
+        - README.md
+
+## Highlighting entries
+
+Wrapping an entry's name in **bold** (`**...**`) highlights it, useful for drawing attention to specific files or directories.
+
+.examplemirror
+    .filetree
+        - **src**
+          - main.ts
+          - utils.ts
+        - LICENSE
+        - **README.md**

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/quarkdown/block/FileTree.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/quarkdown/block/FileTree.kt
@@ -19,25 +19,38 @@ class FileTree(
  */
 sealed interface FileTreeEntry {
     /**
+     * Whether this entry is visually highlighted (e.g. rendered in bold).
+     * An entry is highlighted when its text is wrapped in strong emphasis (`**name**`).
+     */
+    val highlighted: Boolean
+
+    /**
      * A leaf entry representing a file.
      * @param name file name, including extension
+     * @param highlighted whether this file should be visually highlighted
      */
     data class File(
         val name: String,
+        override val highlighted: Boolean = false,
     ) : FileTreeEntry
 
     /**
      * A branch entry representing a directory, which contains nested [entries].
      * @param name directory name
      * @param entries children of this directory (files and subdirectories)
+     * @param highlighted whether this directory should be visually highlighted
      */
     data class Directory(
         val name: String,
         val entries: List<FileTreeEntry>,
+        override val highlighted: Boolean = false,
     ) : FileTreeEntry
 
     /**
      * A placeholder entry indicating omitted content, created by a `- ...` item.
+     * @param highlighted whether this ellipsis should be visually highlighted
      */
-    data object Ellipsis : FileTreeEntry
+    data class Ellipsis(
+        override val highlighted: Boolean = false,
+    ) : FileTreeEntry
 }

--- a/quarkdown-html/src/main/kotlin/com/quarkdown/rendering/html/node/BaseHtmlNodeRenderer.kt
+++ b/quarkdown-html/src/main/kotlin/com/quarkdown/rendering/html/node/BaseHtmlNodeRenderer.kt
@@ -106,13 +106,7 @@ open class BaseHtmlNodeRenderer(
         pretty: Boolean,
     ) = HtmlTagBuilder(name, renderer = this, pretty)
 
-    override fun escapeCriticalContent(unescaped: String) =
-        unescaped
-            .replace("&", "&amp;")
-            .replace("<", "&lt;")
-            .replace(">", "&gt;")
-            .replace("\"", "&quot;")
-            .replace("\'", "&#39;")
+    override fun escapeCriticalContent(unescaped: String) = Escape.Html.escape(unescaped)
 
     // Root
 

--- a/quarkdown-html/src/main/kotlin/com/quarkdown/rendering/html/node/QuarkdownHtmlNodeRenderer.kt
+++ b/quarkdown-html/src/main/kotlin/com/quarkdown/rendering/html/node/QuarkdownHtmlNodeRenderer.kt
@@ -17,6 +17,7 @@ import com.quarkdown.core.ast.base.block.Table
 import com.quarkdown.core.ast.base.block.isMarker
 import com.quarkdown.core.ast.base.block.list.ListBlock
 import com.quarkdown.core.ast.base.inline.CodeSpan
+import com.quarkdown.core.ast.base.inline.CriticalContent
 import com.quarkdown.core.ast.base.inline.Text
 import com.quarkdown.core.ast.quarkdown.CaptionableNode
 import com.quarkdown.core.ast.quarkdown.FunctionCallNode
@@ -378,21 +379,24 @@ class QuarkdownHtmlNodeRenderer(
                             when (entry) {
                                 is FileTreeEntry.File -> {
                                     className("file")
-                                    attribute("data-name", entry.name)
-                                    +entry.name
+                                    attribute("data-name", escapeCriticalContent(entry.name))
+                                    +CriticalContent(entry.name)
                                 }
 
                                 is FileTreeEntry.Directory -> {
                                     className("directory")
-                                    attribute("data-name", entry.name)
-                                    +entry.name
+                                    attribute("data-name", escapeCriticalContent(entry.name))
+                                    +CriticalContent(entry.name)
                                     +buildEntries(entry.entries)
                                 }
 
-                                FileTreeEntry.Ellipsis -> {
+                                is FileTreeEntry.Ellipsis -> {
                                     className("ellipsis")
                                     +"&hellip;"
                                 }
+                            }
+                            if (entry.highlighted) {
+                                attribute("data-highlighted", "")
                             }
                         }
                     }

--- a/quarkdown-html/src/main/scss/components/_filetree.scss
+++ b/quarkdown-html/src/main/scss/components/_filetree.scss
@@ -4,7 +4,7 @@
   ul {
     list-style: none;
     margin: 0.5em 0 0 0.5em;
-    padding: 0 0 0 0.75em;
+    padding: 0 0.75em 0 0.75em;
 
     ul {
       padding-left: 1em;
@@ -20,6 +20,14 @@
         vertical-align: middle;
         position: relative;
         top: -1px;
+      }
+
+      &[data-highlighted] {
+        width: fit-content;
+        padding: 0.3em;
+        margin: -0.3em;
+        border-radius: 4px;
+        background-color: var(--qd-file-tree-highlight-color);
       }
 
       &.file::before {

--- a/quarkdown-html/src/main/scss/global.scss
+++ b/quarkdown-html/src/main/scss/global.scss
@@ -169,6 +169,9 @@
   --qd-mermaid-node-line-color: var(--qd-main-color);
   --qd-mermaid-node-filter: none;
 
+  // File tree
+  --qd-file-tree-highlight-color: color-mix(in srgb, var(--qd-link-color) 10%, transparent);
+
   // Docs
   --qd-docs-header-height: 60px;
   --qd-docs-header-vertical-padding: 12px;

--- a/quarkdown-html/src/test/e2e/filetree/filetree.spec.ts
+++ b/quarkdown-html/src/test/e2e/filetree/filetree.spec.ts
@@ -1,0 +1,99 @@
+import {getBeforeContent} from "../__util/css";
+import {suite} from "../quarkdown";
+
+const {test, expect} = suite(__dirname);
+
+test("list has no unexpected margin or padding", async (page) => {
+    const rootList = page.locator(".file-tree > ul");
+    await expect(rootList).toHaveCount(1);
+
+    // Root ul should have controlled margin and padding from _filetree.scss,
+    // not polluted by global list styles.
+    const rootStyle = await rootList.evaluate((el) => {
+        const s = getComputedStyle(el);
+        return {
+            listStyle: s.listStyleType,
+            marginLeft: parseFloat(s.marginLeft),
+            paddingLeft: parseFloat(s.paddingLeft),
+        };
+    });
+    expect(rootStyle.listStyle).toBe("none");
+    
+    expect(rootStyle.marginLeft).toBeLessThanOrEqual(16);
+    expect(rootStyle.paddingLeft).toBeLessThanOrEqual(16);
+
+    // Nested ul should also have no list style, controlled padding, and a left border.
+    const nestedUl = page.locator(".file-tree ul ul");
+    await expect(nestedUl).toHaveCount(1);
+    const nestedStyle = await nestedUl.evaluate((el) => {
+        const s = getComputedStyle(el);
+        return {
+            listStyle: s.listStyleType,
+            paddingLeft: parseFloat(s.paddingLeft),
+            borderLeftStyle: s.borderLeftStyle,
+            borderLeftWidth: parseFloat(s.borderLeftWidth),
+        };
+    });
+    expect(nestedStyle.listStyle).toBe("none");
+    expect(nestedStyle.paddingLeft).toBeLessThanOrEqual(20);
+    expect(nestedStyle.borderLeftStyle).toBe("solid");
+    expect(nestedStyle.borderLeftWidth).toBeGreaterThan(0);
+});
+
+test("icons are present on all entries", async (page) => {
+    const files = page.locator(".file-tree li.file");
+    const directories = page.locator(".file-tree li.directory");
+    const ellipsis = page.locator(".file-tree li.ellipsis");
+
+    await expect(files).toHaveCount(3); // main.ts, utils.ts, README.md
+    await expect(directories).toHaveCount(1); // src
+    await expect(ellipsis).toHaveCount(1);
+
+    // Each file entry has a ::before icon.
+    for (const file of await files.all()) {
+        const content = await getBeforeContent(file);
+        expect(content).not.toBe("none");
+        expect(content).not.toBe('""');
+    }
+
+    // Directory entry has a ::before icon.
+    const dirContent = await getBeforeContent(directories.first());
+    expect(dirContent).not.toBe("none");
+    expect(dirContent).not.toBe('""');
+
+    // Ellipsis entry has a ::before icon.
+    const ellipsisContent = await getBeforeContent(ellipsis.first());
+    expect(ellipsisContent).not.toBe("none");
+    expect(ellipsisContent).not.toBe('""');
+});
+
+test("highlighted entries have background and fit-content width", async (page) => {
+    const highlighted = page.locator(".file-tree li[data-highlighted]");
+    await expect(highlighted).toHaveCount(2); // main.ts, README.md
+
+    const highlightColor = await page.evaluate(() =>
+        getComputedStyle(document.documentElement).getPropertyValue("--qd-file-tree-highlight-color").trim()
+    );
+    // The variable should be defined.
+    expect(highlightColor).toBeTruthy();
+
+    for (const entry of await highlighted.all()) {
+        // Background color should be applied (not transparent/empty).
+        const bg = await entry.evaluate((el) => getComputedStyle(el).backgroundColor);
+        expect(bg).not.toBe("rgba(0, 0, 0, 0)");
+
+        // Width should be fit-content, meaning the element is narrower than its parent.
+        const {entryWidth, parentWidth} = await entry.evaluate((el) => ({
+            entryWidth: el.getBoundingClientRect().width,
+            parentWidth: el.parentElement!.getBoundingClientRect().width,
+        }));
+        expect(entryWidth).toBeLessThan(parentWidth);
+    }
+
+    // Non-highlighted entries should not have a background.
+    const nonHighlighted = page.locator(".file-tree li:not([data-highlighted])");
+    for (const entry of await nonHighlighted.all()) {
+        const bg = await entry.evaluate((el) => getComputedStyle(el).backgroundColor);
+        expect(bg).toBe("rgba(0, 0, 0, 0)");
+    }
+});

--- a/quarkdown-html/src/test/e2e/filetree/main.qd
+++ b/quarkdown-html/src/test/e2e/filetree/main.qd
@@ -1,0 +1,6 @@
+.filetree
+    - src
+      - **main.ts**
+      - utils.ts
+    - **README.md**
+    - ...

--- a/quarkdown-html/src/test/kotlin/com/quarkdown/rendering/html/HtmlNodeRendererTest.kt
+++ b/quarkdown-html/src/test/kotlin/com/quarkdown/rendering/html/HtmlNodeRendererTest.kt
@@ -1180,7 +1180,27 @@ class HtmlNodeRendererTest {
             FileTree(
                 listOf(
                     FileTreeEntry.File("index.ts"),
-                    FileTreeEntry.Ellipsis,
+                    FileTreeEntry.Ellipsis(),
+                ),
+            ).render(),
+        )
+
+        // Highlighted entries.
+        assertEquals(
+            out.next(),
+            FileTree(
+                listOf(
+                    FileTreeEntry.File("file1.txt"),
+                    FileTreeEntry.File("file2.txt", highlighted = true),
+                    FileTreeEntry.Directory(
+                        "src",
+                        listOf(
+                            FileTreeEntry.File("main.ts", highlighted = true),
+                            FileTreeEntry.File("utils.ts"),
+                        ),
+                        highlighted = true,
+                    ),
+                    FileTreeEntry.Ellipsis(highlighted = true),
                 ),
             ).render(),
         )

--- a/quarkdown-html/src/test/resources/rendering/block/table.html
+++ b/quarkdown-html/src/test/resources/rendering/block/table.html
@@ -96,6 +96,6 @@
         </tr>
     </tbody>
     <caption class="caption-bottom">
-        Table &#39;caption&#39;.
+        Table 'caption'.
     </caption>
 </table>

--- a/quarkdown-html/src/test/resources/rendering/quarkdown/filetree.html
+++ b/quarkdown-html/src/test/resources/rendering/quarkdown/filetree.html
@@ -38,3 +38,28 @@
         </li>
     </ul>
 </div>
+---
+<div class="file-tree">
+    <ul>
+        <li class="file" data-name="file1.txt">
+            file1.txt
+        </li>
+        <li class="file" data-name="file2.txt" data-highlighted="">
+            file2.txt
+        </li>
+        <li class="directory" data-name="src" data-highlighted="">
+            src
+            <ul>
+                <li class="file" data-name="main.ts" data-highlighted="">
+                    main.ts
+                </li>
+                <li class="file" data-name="utils.ts">
+                    utils.ts
+                </li>
+            </ul>
+        </li>
+        <li class="ellipsis" data-highlighted="">
+            &hellip;
+        </li>
+    </ul>
+</div>

--- a/quarkdown-plaintext/src/main/kotlin/com/quarkdown/rendering/plaintext/node/PlainTextNodeRenderer.kt
+++ b/quarkdown-plaintext/src/main/kotlin/com/quarkdown/rendering/plaintext/node/PlainTextNodeRenderer.kt
@@ -258,7 +258,7 @@ class PlainTextNodeRenderer(
                                     +FileTree(entry.entries)
                                 }
 
-                                FileTreeEntry.Ellipsis -> {
+                                is FileTreeEntry.Ellipsis -> {
                                     paragraph { text("...") }
                                 }
                             }

--- a/quarkdown-plaintext/src/test/kotlin/com/quarkdown/rendering/plaintext/PlainTextNodeRendererTest.kt
+++ b/quarkdown-plaintext/src/test/kotlin/com/quarkdown/rendering/plaintext/PlainTextNodeRendererTest.kt
@@ -419,13 +419,34 @@ class PlainTextNodeRendererTest {
     }
 
     @Test
+    fun `file tree, highlighted entries`() {
+        assertEquals(
+            "- file1.txt\n- file2.txt\n- src/\n\t- main.ts\n\t- utils.ts\n\n",
+            FileTree(
+                listOf(
+                    FileTreeEntry.File("file1.txt"),
+                    FileTreeEntry.File("file2.txt", highlighted = true),
+                    FileTreeEntry.Directory(
+                        "src",
+                        listOf(
+                            FileTreeEntry.File("main.ts", highlighted = true),
+                            FileTreeEntry.File("utils.ts"),
+                        ),
+                        highlighted = true,
+                    ),
+                ),
+            ).render(),
+        )
+    }
+
+    @Test
     fun `file tree, ellipsis`() {
         assertEquals(
             "- index.ts\n- ...\n\n",
             FileTree(
                 listOf(
                     FileTreeEntry.File("index.ts"),
-                    FileTreeEntry.Ellipsis,
+                    FileTreeEntry.Ellipsis(),
                 ),
             ).render(),
         )

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/internal/FileTree.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/internal/FileTree.kt
@@ -1,6 +1,10 @@
 package com.quarkdown.stdlib.internal
 
+import com.quarkdown.core.ast.NestableNode
+import com.quarkdown.core.ast.Node
 import com.quarkdown.core.ast.base.block.list.ListBlock
+import com.quarkdown.core.ast.base.inline.Strong
+import com.quarkdown.core.ast.base.inline.StrongEmphasis
 import com.quarkdown.core.ast.quarkdown.block.FileTreeEntry
 import com.quarkdown.core.util.node.conversion.list.MarkdownListToList
 import com.quarkdown.core.util.node.toPlainText
@@ -13,21 +17,37 @@ import com.quarkdown.core.util.node.toPlainText
 private val ELLIPSIS_TEXTS = setOf("...", "\u2026")
 
 /**
+ * Checks whether a node tree contains a [Strong] or [StrongEmphasis] node at any depth,
+ * indicating that the entry should be highlighted.
+ */
+private fun Node.isHighlighted(): Boolean =
+    this is Strong ||
+        this is StrongEmphasis ||
+        (this is NestableNode && children.any { it.isHighlighted() })
+
+/**
  * Recursively converts a Markdown [ListBlock] into a flat list of [FileTreeEntry] elements.
  * Inline items become [FileTreeEntry.File]s, nested items become [FileTreeEntry.Directory]s,
  * and items with `...` as text become [FileTreeEntry.Ellipsis].
+ * Entries wrapped in strong emphasis are marked as highlighted.
  */
 internal fun fileTreeFromList(list: ListBlock): List<FileTreeEntry> =
     MarkdownListToList(
         list,
         inlineValueMapper = { node ->
             val text = listOf(node).toPlainText()
-            if (text in ELLIPSIS_TEXTS) FileTreeEntry.Ellipsis else FileTreeEntry.File(text)
+            val highlighted = node.isHighlighted()
+            if (text in ELLIPSIS_TEXTS) {
+                FileTreeEntry.Ellipsis(highlighted)
+            } else {
+                FileTreeEntry.File(text, highlighted)
+            }
         },
         nestedValueMapper = { parent, nestedList ->
             FileTreeEntry.Directory(
                 listOf(parent).toPlainText(),
                 fileTreeFromList(nestedList),
+                highlighted = parent.isHighlighted(),
             )
         },
     ).convert()

--- a/quarkdown-stdlib/src/test/kotlin/com/quarkdown/stdlib/FileTreeTest.kt
+++ b/quarkdown-stdlib/src/test/kotlin/com/quarkdown/stdlib/FileTreeTest.kt
@@ -120,7 +120,7 @@ class FileTreeTest {
         assertEquals(
             listOf(
                 FileTreeEntry.File("file1.txt"),
-                FileTreeEntry.Ellipsis,
+                FileTreeEntry.Ellipsis(),
             ),
             tree.entries,
         )
@@ -147,8 +147,108 @@ class FileTreeTest {
                     "src",
                     listOf(
                         FileTreeEntry.File("main.ts"),
-                        FileTreeEntry.Ellipsis,
+                        FileTreeEntry.Ellipsis(),
                     ),
+                ),
+            ),
+            tree.entries,
+        )
+    }
+
+    @Test
+    fun `highlighted file`() {
+        val tree =
+            buildBlocks {
+                unorderedList(loose = false) {
+                    listItem { paragraph { text("file1.txt") } }
+                    listItem { paragraph { strong { text("file2.txt") } } }
+                }
+            }.let(::buildFileTree)
+
+        assertEquals(
+            listOf(
+                FileTreeEntry.File("file1.txt"),
+                FileTreeEntry.File("file2.txt", highlighted = true),
+            ),
+            tree.entries,
+        )
+    }
+
+    @Test
+    fun `highlighted directory`() {
+        val tree =
+            buildBlocks {
+                unorderedList(loose = false) {
+                    listItem {
+                        paragraph { strong { text("src") } }
+                        unorderedList(loose = false) {
+                            listItem { paragraph { text("file1.txt") } }
+                            listItem { paragraph { text("file2.txt") } }
+                        }
+                    }
+                }
+            }.let(::buildFileTree)
+
+        assertEquals(
+            listOf(
+                FileTreeEntry.Directory(
+                    "src",
+                    listOf(
+                        FileTreeEntry.File("file1.txt"),
+                        FileTreeEntry.File("file2.txt"),
+                    ),
+                    highlighted = true,
+                ),
+            ),
+            tree.entries,
+        )
+    }
+
+    @Test
+    fun `highlighted ellipsis`() {
+        val tree =
+            buildBlocks {
+                unorderedList(loose = false) {
+                    listItem { paragraph { text("file1.txt") } }
+                    listItem { paragraph { strong { text("...") } } }
+                }
+            }.let(::buildFileTree)
+
+        assertEquals(
+            listOf(
+                FileTreeEntry.File("file1.txt"),
+                FileTreeEntry.Ellipsis(highlighted = true),
+            ),
+            tree.entries,
+        )
+    }
+
+    @Test
+    fun `multiple highlighted entries`() {
+        val tree =
+            buildBlocks {
+                unorderedList(loose = false) {
+                    listItem { paragraph { strong { text("file1.txt") } } }
+                    listItem {
+                        paragraph { strong { text("src") } }
+                        unorderedList(loose = false) {
+                            listItem { paragraph { strong { text("main.ts") } } }
+                            listItem { paragraph { text("utils.ts") } }
+                        }
+                    }
+                }
+            }.let(::buildFileTree)
+
+        assertEquals(
+            listOf(
+                FileTreeEntry.File("file1.txt", highlighted = true),
+                FileTreeEntry.Directory(
+                    "src",
+                    listOf(
+                        FileTreeEntry.File("main.ts", highlighted = true),
+                        FileTreeEntry.File("utils.ts"),
+                    ),
+                    highlighted = true,
                 ),
             ),
             tree.entries,

--- a/quarkdown-test/src/test/kotlin/com/quarkdown/test/FileTreeTest.kt
+++ b/quarkdown-test/src/test/kotlin/com/quarkdown/test/FileTreeTest.kt
@@ -85,6 +85,36 @@ class FileTreeTest {
     }
 
     @Test
+    fun highlighted() {
+        execute(
+            """
+            .filetree
+                - file1.txt
+                - **file2.txt**
+                - **src**
+                  - **main.ts**
+                  - utils.ts
+                - **...**
+            """.trimIndent(),
+        ) {
+            assertEquals(
+                "<div class=\"file-tree\"><ul>" +
+                    "<li class=\"file\" data-name=\"file1.txt\">file1.txt</li>" +
+                    "<li class=\"file\" data-name=\"file2.txt\" data-highlighted=\"\">file2.txt</li>" +
+                    "<li class=\"directory\" data-name=\"src\" data-highlighted=\"\">src" +
+                    "<ul>" +
+                    "<li class=\"file\" data-name=\"main.ts\" data-highlighted=\"\">main.ts</li>" +
+                    "<li class=\"file\" data-name=\"utils.ts\">utils.ts</li>" +
+                    "</ul>" +
+                    "</li>" +
+                    "<li class=\"ellipsis\" data-highlighted=\"\">&hellip;</li>" +
+                    "</ul></div>",
+                it,
+            )
+        }
+    }
+
+    @Test
     fun ellipsis() {
         execute(
             """

--- a/quarkdown-test/src/test/kotlin/com/quarkdown/test/SecurityTest.kt
+++ b/quarkdown-test/src/test/kotlin/com/quarkdown/test/SecurityTest.kt
@@ -46,6 +46,20 @@ class SecurityTest {
     }
 
     @Test
+    fun `file tree injection`() {
+        execute(
+            """
+            .filetree
+                - </div><script>alert('XSS')</script>
+            """.trimIndent(),
+        ) {
+            val escaped = "&lt;/div&gt;&lt;script&gt;alert(&rsquo;XSS&rsquo;)&lt;/script&gt;"
+            assertContains(it, ">$escaped</li>")
+            assertContains(it, "data-name=\"$escaped\"")
+        }
+    }
+
+    @Test
     fun `infinite recursion in strict mode`() {
         assertFailsWith<PipelineException> {
             execute(


### PR DESCRIPTION
```markdown
.filetree
    - a.txt
    - **b**
      - c.txt
      - d.txt
      - ...
    - e
      - f
        - **g.txt**
        - h.txt
        - ...
      - i.txt
      - j.txt
```

![image.png](https://app.graphite.com/user-attachments/assets/a4606da0-708d-4d5b-ba8b-5c41e0868552.png)


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/iamgio/quarkdown/pull/392" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
