### PR TITLE
feat: allow wrapping function call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,14 @@ Quarkdown's internal bibliography management is now powered by [CSL](https://cit
 The new `.heading` function creates headings with granular control over their behavior, unlike standard Markdown headings (`#`, `##`, ...).
 It allows explicit control over numbering (`numbered`), table of contents indexing (`indexed`), page breaks (`breakpage`), depth, and reference ID (`ref`).
 
+#### New syntax: [Tight function calls](https://quarkdown.com/wiki/syntax-of-a-function-call#tight-function-calls)
+
+Inline function calls can now be wrapped in curly braces to delimit them from surrounding content, without relying on whitespace.
+
+```markdown
+abc{.uppercase {def}}ghi
+```
+
 #### [`.pagebreak` primitive function](https://quarkdown.com/wiki/page-break)
 
 The new `.pagebreak` function provides an explicit way to insert a page break as an alternative to the `<<<` syntax.

--- a/docs/syntax-of-a-function-call.qd
+++ b/docs/syntax-of-a-function-call.qd
@@ -98,6 +98,18 @@ You can append additional arguments to any function in the chain. Just keep in m
 
 Many core functions are designed to be called in a chain, for example [`None` operations](none.qd#examples).
 
+## Tight function calls
+
+A function call must normally be surrounded by whitespace, a symbol, or the beginning or end of a line. This means that a call directly adjacent to a word character is not recognized:
+
+.examplemirror type:{warning}
+    H.text {2} script:{sub}O
+
+Wrapping the entire function call in curly braces allows it to appear anywhere, regardless of the surrounding characters. The wrapping braces are consumed by the compiler and do not appear in the output:
+
+.examplemirror
+    H{.text {2} script:{sub}}O
+
 ## Block vs. inline function calls
 
 Function calls can appear in two contexts: inline or block.

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/lexer/patterns/FunctionCallPatterns.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/lexer/patterns/FunctionCallPatterns.kt
@@ -24,9 +24,11 @@ class FunctionCallPatterns {
             wrap = { error("Inline function call tokens are constructed by the walker") },
             // The name of the function prefixed by a dot.
             regex =
-                RegexBuilder("(?<=before)(?=begin(name))")
+                RegexBuilder("(?:(?<=before)(?=call))|(?:(?=wrapcall))")
                     .withReference("before", FUNCTION_CALL_PATTERN_BEFORE)
-                    .withReference("begin", "\\" + FunctionCallGrammar.BEGIN)
+                    .withReference("call", "begin(name)")
+                    .withReference("wrap", Regex.escape(FunctionCallGrammar.ARGUMENT_BEGIN.toString()))
+                    .withReference("begin", Regex.escape(FunctionCallGrammar.BEGIN.toString()))
                     .withReference("name", FunctionCallGrammar.IDENTIFIER_PATTERN)
                     .build(),
             walker = { data, remaining ->
@@ -55,7 +57,7 @@ class FunctionCallPatterns {
             name = "FunctionCall",
             wrap = { error("Block function call tokens are constructed by the walker") },
             regex =
-                RegexBuilder("^ {0,3}call)")
+                RegexBuilder("^ {0,3}(?:call))")
                     .withReference("call", inlineFunctionCall.regex.dropLast(1))
                     .build(),
             walker = { data, remaining ->

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/lexer/regex/RegexLexer.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/lexer/regex/RegexLexer.kt
@@ -1,5 +1,6 @@
 package com.quarkdown.core.lexer.regex
 
+import com.github.h0tk3y.betterParse.parser.ParseException
 import com.quarkdown.core.lexer.AbstractLexer
 import com.quarkdown.core.lexer.Lexer
 import com.quarkdown.core.lexer.Token
@@ -102,13 +103,24 @@ abstract class RegexLexer(
             // In most cases, a pattern will not have a walker.
             // Currently, only function calls have walkers (see parser.walker.funcall),
             // as regex cannot handle balanced argument delimiters.
-            val walked = pattern.walker?.invoke(data, source.substring(currentIndex))
+            // A ParseException from the walker's grammar is treated as a rejection (same as returning null).
+            val walked =
+                if (pattern.walker != null) {
+                    try {
+                        pattern.walker(data, source.substring(currentIndex))
+                    } catch (_: ParseException) {
+                        null
+                    }
+                } else {
+                    null
+                }
             if (walked != null) {
                 currentIndex += walked.charsConsumed
                 tokens += walked.token
             } else if (pattern.walker != null) {
                 // The walker rejected this match (e.g., a block function call pattern determined
-                // the content is actually inline-level). Revert position and signal rejection.
+                // the content is actually inline-level, or a wrapped function call is incomplete).
+                // Revert position and signal rejection.
                 currentIndex = savedIndex
                 return emptyList()
             } else {
@@ -129,16 +141,33 @@ abstract class RegexLexer(
 
             while (currentIndex < source.length) {
                 val prevIndex = currentIndex
-                var result = regex.find(paddedSource, currentIndex) ?: break
+                val result = regex.find(paddedSource, currentIndex) ?: break
                 var tokens = extractMatchingTokens(result)
 
                 // If a walker rejected the match, retry with the fallback regex
                 // (which excludes walker-based patterns), allowing other patterns
                 // (e.g. paragraph) to match at the same position.
                 if (tokens.isEmpty() && currentIndex == prevIndex) {
-                    val (fallback, fallbackPats) = fallbackPatterns ?: break
-                    result = fallback.find(paddedSource, currentIndex) ?: break
-                    tokens = extractMatchingTokens(result, fallbackPats)
+                    val fallbackTokens =
+                        fallbackPatterns?.let { (fallback, fallbackPatterns) ->
+                            fallback.find(paddedSource, currentIndex)?.let {
+                                extractMatchingTokens(it, fallbackPatterns)
+                            }
+                        }
+
+                    if (!fallbackTokens.isNullOrEmpty()) {
+                        tokens = fallbackTokens
+                    } else if (currentIndex == prevIndex) {
+                        // Neither the main regex nor the fallback produced tokens at this position.
+                        // Emit a fill token for the rejected character and advance by one,
+                        // so the main regex can retry at the next position.
+                        // This handles e.g. a malformed wrapped function call `{.func {x}`
+                        // where the walker rejects the wrapped parse but the standard (non-wrapped)
+                        // match `.func {x}` should still be recognized at the next position.
+                        createFillToken(position = currentIndex..currentIndex)?.let { yield(it) }
+                        currentIndex++
+                        continue
+                    }
                 }
 
                 yieldAll(tokens)

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/parser/walker/funcall/FunctionCallGrammar.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/parser/walker/funcall/FunctionCallGrammar.kt
@@ -3,6 +3,7 @@ package com.quarkdown.core.parser.walker.funcall
 import com.github.h0tk3y.betterParse.combinators.and
 import com.github.h0tk3y.betterParse.combinators.map
 import com.github.h0tk3y.betterParse.combinators.optional
+import com.github.h0tk3y.betterParse.combinators.or
 import com.github.h0tk3y.betterParse.combinators.unaryMinus
 import com.github.h0tk3y.betterParse.combinators.zeroOrMore
 import com.github.h0tk3y.betterParse.grammar.Grammar
@@ -39,6 +40,11 @@ class FunctionCallGrammar(
     private val allowsBody: Boolean,
 ) : Grammar<WalkedFunctionCall>() {
     /**
+     * Whether the parser has begun parsing the actual function call.
+     */
+    private var began = false
+
+    /**
      * Whether the parser is currently parsing an argument.
      * While parsing an argument, the parser should not perform syntactic checks as the argument may contain any content, including Markdown.
      * This is a mutable state variable that is set to true when an argument is being parsed and false when the argument ends.
@@ -49,7 +55,7 @@ class FunctionCallGrammar(
         /**
          * The character that prefixes a function call.
          */
-        const val BEGIN = "."
+        const val BEGIN = '.'
 
         /**
          * The pattern for an identifier (function name or argument name).
@@ -104,7 +110,11 @@ class FunctionCallGrammar(
     /**
      * Token that matches the beginning of a function call.
      */
-    private val begin by literalToken(BEGIN)
+    private val begin by token { string, position ->
+        unescapedMatch(string, position, BEGIN) {
+            began = true
+        }
+    }
 
     /**
      * Token that matches whitespace, ignored between arguments
@@ -118,7 +128,11 @@ class FunctionCallGrammar(
      */
     private val argumentBegin by token { string, position ->
         unescapedMatch(string, position, ARGUMENT_BEGIN) {
-            inArg = true
+            if (!began) {
+                began = true
+            } else {
+                inArg = true
+            }
         }
     }
 
@@ -247,12 +261,11 @@ class FunctionCallGrammar(
         }
 
     /**
-     * Entry point of the grammar.
-     * Parses the whole chain of function calls.
+     * Parses a chain of function calls, separated by [chainSeparator].
      * The result is an ordered linked list of [WalkedFunctionCall]s, and the first of them is returned.
      */
-    override val rootParser =
-        -begin and callParser and zeroOrMore(-chainSeparator and callParser) map { (first, rest) ->
+    private val chainCallParser =
+        callParser and zeroOrMore(-chainSeparator and callParser) map { (first, rest) ->
             var current = first
             for (next in rest) {
                 current.next = next
@@ -260,4 +273,12 @@ class FunctionCallGrammar(
             }
             first
         }
+
+    /**
+     * Entry point of the grammar.
+     * Parses the whole chain of function calls.
+     */
+    override val rootParser =
+        (-begin and chainCallParser) or
+            (-argumentBegin and -begin and chainCallParser and -argumentEnd)
 }

--- a/quarkdown-core/src/test/kotlin/com/quarkdown/core/BlockParserTest.kt
+++ b/quarkdown-core/src/test/kotlin/com/quarkdown/core/BlockParserTest.kt
@@ -1226,6 +1226,38 @@ class BlockParserTest {
         }
     }
 
+    /**
+     * Verifies that wrapped function calls (`{.func {args}}`) are parsed as inline function calls
+     * within paragraphs, with the wrapping braces stripped from the output.
+     */
+    @Test
+    fun wrappedInlineFunctionCall() {
+        // Standalone wrapped call on a line is treated as a block-level function call.
+        with(blocksIterator<FunctionCallNode>("{.function {x}}").next()) {
+            assertEquals("function", name)
+            assertEquals(1, arguments.size)
+            assertEquals("x", arguments[0].value.unwrappedValue)
+        }
+
+        // Wrapped call between text: parsed as a paragraph containing an inline function call.
+        with(blocksIterator<Paragraph>("hello {.function {x}} world").next()) {
+            val children = children.iterator()
+            assertEquals("hello ", assertIs<Text>(children.next()).text)
+            assertIs<FunctionCallNode>(children.next())
+            assertEquals(" world", assertIs<Text>(children.next()).text)
+            assertFalse(children.hasNext())
+        }
+
+        // Tight wrapped call (no spacing around braces).
+        with(blocksIterator<Paragraph>("hello{.function {x}}world").next()) {
+            val children = children.iterator()
+            assertEquals("hello", assertIs<Text>(children.next()).text)
+            assertIs<FunctionCallNode>(children.next())
+            assertEquals("world", assertIs<Text>(children.next()).text)
+            assertFalse(children.hasNext())
+        }
+    }
+
     @Test
     fun chainedFunctionCall() {
         val nodes =

--- a/quarkdown-core/src/test/kotlin/com/quarkdown/core/InlineParserTest.kt
+++ b/quarkdown-core/src/test/kotlin/com/quarkdown/core/InlineParserTest.kt
@@ -26,13 +26,13 @@ import com.quarkdown.core.flavor.MarkdownFlavor
 import com.quarkdown.core.flavor.quarkdown.QuarkdownFlavor
 import com.quarkdown.core.misc.color.Color
 import com.quarkdown.core.util.node.toPlainText
+import java.util.UUID
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertIs
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
-import kotlin.test.assertTrue
 
 /**
  * Parser tests for inline content.
@@ -200,12 +200,12 @@ class InlineParserTest {
             assertEquals("this is a definition!", definition.toPlainText())
         }
         with(nodes.next()) {
-            assertTrue(
-                label.length ==
-                    java.util.UUID
-                        .randomUUID()
-                        .toString()
-                        .length,
+            assertEquals(
+                label.length,
+                UUID
+                    .randomUUID()
+                    .toString()
+                    .length,
             )
             assertEquals("this is an anonymous definition!", definition.toPlainText())
         }

--- a/quarkdown-core/src/test/kotlin/com/quarkdown/core/LexerTest.kt
+++ b/quarkdown-core/src/test/kotlin/com/quarkdown/core/LexerTest.kt
@@ -638,6 +638,40 @@ class LexerTest {
                     .arguments.size,
             )
         }
+
+        // Wrapped function calls.
+
+        with(walk("{.function {x}}")) {
+            assertEquals("function", value.name)
+            assertEquals("{.function {x}}".length, endIndex)
+            with(value.arguments.single()) {
+                assertEquals("x", value)
+                assertNull(name)
+            }
+        }
+
+        with(walk("{.function {x} {y}}")) {
+            assertEquals("function", value.name)
+            assertEquals("{.function {x} {y}}".length, endIndex)
+            assertEquals("x", value.arguments[0].value)
+            assertEquals("y", value.arguments[1].value)
+        }
+
+        with(walk("{.function {x} name:{y}}")) {
+            assertEquals("function", value.name)
+            assertEquals("x", value.arguments[0].value)
+            with(value.arguments[1]) {
+                assertEquals("name", name)
+                assertEquals("y", value)
+            }
+        }
+
+        with(walk("{.foo {a}::bar {b}}")) {
+            assertEquals("foo", value.name)
+            assertEquals(1, value.arguments.size)
+            assertEquals("bar", value.next!!.name)
+            assertEquals(1, value.next!!.arguments.size)
+        }
     }
 
     /**
@@ -683,6 +717,67 @@ class LexerTest {
         with(walk(".func {a {b {c {d}}}}")) {
             assertEquals("func", value.name)
             assertEquals("a {b {c {d}}}", value.arguments.single().value)
+        }
+    }
+
+    /**
+     * Verifies that wrapped function calls (e.g. `{.func {x}}`) are tokenized correctly.
+     */
+    @Test
+    fun wrappedInlineFunctionCall() {
+        // Standalone wrapped call.
+        with(inlineLex("{.func {x}}")) {
+            assertIs<FunctionCallToken>(next())
+            assertFalse(hasNext())
+        }
+
+        // Wrapped call between text (loose).
+        with(inlineLex("hello {.func {x}} world")) {
+            assertIs<PlainTextToken>(next())
+            assertIs<FunctionCallToken>(next())
+            assertIs<PlainTextToken>(next())
+            assertFalse(hasNext())
+        }
+
+        // Wrapped call between text (tight).
+        with(inlineLex("hello{.func {x}}world")) {
+            assertIs<PlainTextToken>(next())
+            assertIs<FunctionCallToken>(next())
+            assertIs<PlainTextToken>(next())
+            assertFalse(hasNext())
+        }
+
+        // Multiple wrapped calls.
+        with(inlineLex("{.a {x}} {.b {y}}")) {
+            assertIs<FunctionCallToken>(next())
+            assertIs<PlainTextToken>(next())
+            assertIs<FunctionCallToken>(next())
+            assertFalse(hasNext())
+        }
+
+        // Wrapped call with multiple arguments.
+        with(inlineLex("{.func {x} {y}}")) {
+            val token = next()
+            assertIs<FunctionCallToken>(token)
+            assertEquals("func", token.walkerResult.value.name)
+            assertEquals(2, token.walkerResult.value.arguments.size)
+            assertFalse(hasNext())
+        }
+
+        // Escaped wrapping brace: not treated as a wrapped call.
+        with(inlineLex("\\{.func {x}}")) {
+            assertIs<EscapeToken>(next())
+            assertIs<FunctionCallToken>(next())
+            assertIs<PlainTextToken>(next())
+            assertFalse(hasNext())
+        }
+
+        // Incomplete wrapped call: the opening brace is plain text,
+        // and the function call falls back to the standard (non-wrapped) match.
+        with(inlineLex("{.func {x}")) {
+            assertIs<PlainTextToken>(next())
+            assertIs<FunctionCallToken>(next())
+            assertFalse(hasNext())
         }
     }
 

--- a/quarkdown-lsp/src/main/kotlin/com/quarkdown/lsp/pattern/QuarkdownPatterns.kt
+++ b/quarkdown-lsp/src/main/kotlin/com/quarkdown/lsp/pattern/QuarkdownPatterns.kt
@@ -16,7 +16,7 @@ object QuarkdownPatterns {
         /**
          * The character that prefixes a function call.
          */
-        const val BEGIN: String = FunctionCallGrammar.BEGIN
+        const val BEGIN: String = FunctionCallGrammar.BEGIN.toString()
 
         /**
          * The pattern for an identifier (function name or argument name).

--- a/quarkdown-lsp/src/test/kotlin/com/quarkdown/lsp/FunctionCallTokenizerTest.kt
+++ b/quarkdown-lsp/src/test/kotlin/com/quarkdown/lsp/FunctionCallTokenizerTest.kt
@@ -176,4 +176,77 @@ class FunctionCallTokenizerTest {
         assertTrue("function1" in functionNames)
         assertTrue("function2" in functionNames)
     }
+
+    @Test
+    fun `wrapped function call`() {
+        val text = "{.function {x}}"
+        val calls = tokenizer.getFunctionCalls(text)
+
+        assertEquals(1, calls.size)
+
+        val call = calls.first()
+        assertEquals(0..text.length, call.range)
+
+        val nameToken = call.tokens.find { it.type == FunctionCallToken.Type.FUNCTION_NAME }
+        assertNotNull(nameToken)
+        assertEquals("function", nameToken.lexeme)
+
+        // The wrapping braces appear as argument delimiters in the grammar tokens.
+        val argBeginTokens = call.tokens.filter { it.type == FunctionCallToken.Type.INLINE_ARGUMENT_BEGIN }
+        val argEndTokens = call.tokens.filter { it.type == FunctionCallToken.Type.INLINE_ARGUMENT_END }
+
+        // Two opens: wrap '{' + argument '{'. Two closes: argument '}' + wrap '}'.
+        assertEquals(2, argBeginTokens.size)
+        assertEquals(2, argEndTokens.size)
+    }
+
+    @Test
+    fun `tight wrapped function call`() {
+        val text = "hello{.func {x}}hello"
+        val calls = tokenizer.getFunctionCalls(text)
+
+        assertEquals(1, calls.size)
+
+        val call = calls.first()
+        val nameToken = call.tokens.find { it.type == FunctionCallToken.Type.FUNCTION_NAME }
+        assertNotNull(nameToken)
+        assertEquals("func", nameToken.lexeme)
+
+        // The call range starts at '{' and ends after the closing '}'.
+        assertEquals(5..16, call.range)
+    }
+
+    @Test
+    fun `wrapped function call with chaining`() {
+        val text = "{.func1 {x}::func2 {y}}"
+        val calls = tokenizer.getFunctionCalls(text)
+
+        assertEquals(1, calls.size)
+
+        val call = calls.first()
+        val functionNames =
+            call.tokens
+                .filter { it.type == FunctionCallToken.Type.FUNCTION_NAME }
+                .map { it.lexeme }
+
+        assertEquals(listOf("func1", "func2"), functionNames)
+
+        // The wrapping braces are the first and last tokens.
+        assertEquals(FunctionCallToken.Type.INLINE_ARGUMENT_BEGIN, call.tokens.first().type)
+        assertEquals(FunctionCallToken.Type.INLINE_ARGUMENT_END, call.tokens.last().type)
+    }
+
+    @Test
+    fun `wrapped function call with named parameter`() {
+        val text = "{.function param:{value}}"
+        val calls = tokenizer.getFunctionCalls(text)
+
+        assertEquals(1, calls.size)
+
+        val call = calls.first()
+
+        val paramNameToken = call.tokens.find { it.type == FunctionCallToken.Type.PARAMETER_NAME }
+        assertNotNull(paramNameToken)
+        assertEquals("param", paramNameToken.lexeme)
+    }
 }

--- a/quarkdown-lsp/src/test/kotlin/com/quarkdown/lsp/FunctionCallTokensSupplierTest.kt
+++ b/quarkdown-lsp/src/test/kotlin/com/quarkdown/lsp/FunctionCallTokensSupplierTest.kt
@@ -364,4 +364,54 @@ class FunctionCallTokensSupplierTest {
             assertNext(TYPE_INLINE_ARGUMENT_DELIMITER, 25..26)
         }
     }
+
+    // Wrapped (tight) function calls
+
+    @Test
+    fun `wrapped function call, no args`() {
+        tokenize("{.funcall}") {
+            assertNext(TYPE_INLINE_ARGUMENT_DELIMITER, 0..1) // Wrap open '{'
+            assertNext(TYPE_BEGIN, 1..2) // '.'
+            assertNext(TYPE_NAME, 2..9) // 'funcall'
+            assertNext(TYPE_INLINE_ARGUMENT_DELIMITER, 9..10) // Wrap close '}'
+        }
+    }
+
+    @Test
+    fun `wrapped function call with one positional argument`() {
+        tokenize("{.funcall {arg1}}") {
+            assertNext(TYPE_INLINE_ARGUMENT_DELIMITER, 0..1) // Wrap open
+            assertNext(TYPE_BEGIN, 1..2)
+            assertNext(TYPE_NAME, 2..9)
+            assertNext(TYPE_INLINE_ARGUMENT_DELIMITER, 10..11) // Arg open
+            assertNext(TokenType.ENUM, 11..15) // arg1
+            assertNext(TYPE_INLINE_ARGUMENT_DELIMITER, 15..16) // Arg close
+            assertNext(TYPE_INLINE_ARGUMENT_DELIMITER, 16..17) // Wrap close
+        }
+    }
+
+    @Test
+    fun `tight wrapped function call in surrounding text`() {
+        tokenize("hello{.funcall {arg1}}hello") {
+            assertNext(TYPE_INLINE_ARGUMENT_DELIMITER, 5..6) // Wrap open
+            assertNext(TYPE_BEGIN, 6..7)
+            assertNext(TYPE_NAME, 7..14)
+            assertNext(TYPE_INLINE_ARGUMENT_DELIMITER, 15..16) // Arg open
+            assertNext(TokenType.ENUM, 16..20) // arg1
+            assertNext(TYPE_INLINE_ARGUMENT_DELIMITER, 20..21) // Arg close
+            assertNext(TYPE_INLINE_ARGUMENT_DELIMITER, 21..22) // Wrap close
+        }
+    }
+
+    @Test
+    fun `wrapped chained function calls`() {
+        tokenize("{.func1::func2}") {
+            assertNext(TYPE_INLINE_ARGUMENT_DELIMITER, 0..1) // Wrap open
+            assertNext(TYPE_BEGIN, 1..2)
+            assertNext(TYPE_NAME, 2..7)
+            assertNext(TYPE_CHAINING_SEPARATOR, 7..9)
+            assertNext(TYPE_NAME, 9..14)
+            assertNext(TYPE_INLINE_ARGUMENT_DELIMITER, 14..15) // Wrap close
+        }
+    }
 }

--- a/quarkdown-lsp/src/test/kotlin/com/quarkdown/lsp/FunctionCompletionSupplierTest.kt
+++ b/quarkdown-lsp/src/test/kotlin/com/quarkdown/lsp/FunctionCompletionSupplierTest.kt
@@ -297,4 +297,42 @@ class FunctionCompletionSupplierTest {
 
         assertTrue(completions.isEmpty())
     }
+
+    // Wrapped (tight) function calls
+
+    @Test
+    fun `name completions in wrapped function call`() {
+        val text = "hello{."
+        val completions = getCompletions(text, Position(0, text.length))
+        assertEquals(4, completions.size)
+    }
+
+    @Test
+    fun `name completions in wrapped function call for partial name`() {
+        val text = "hello{.ali"
+        val completions = getCompletions(text, Position(0, text.length))
+
+        assertEquals(1, completions.size)
+        assertEquals(ALIGN_FUNCTION, completions.first().label)
+    }
+
+    @Test
+    fun `name completions in closed wrapped function call for partial name`() {
+        val text = "hello{.ali}"
+        // Cursor before the closing brace.
+        val completions = getCompletions(text, Position(0, text.length - 1))
+
+        assertEquals(1, completions.size)
+        assertEquals(ALIGN_FUNCTION, completions.first().label)
+    }
+
+    @Test
+    fun `parameter completions in wrapped function call`() {
+        val text = "hello{.$ALIGN_FUNCTION "
+        val completions = getCompletions(text, Position(0, text.length)).map { it.label }
+
+        assertEquals(2, completions.size)
+        assertContains(completions, ALIGNMENT_PARAMETER)
+        assertContains(completions, BODY_PARAMETER)
+    }
 }

--- a/quarkdown-lsp/src/test/kotlin/com/quarkdown/lsp/FunctionDocumentationHoverSupplierTest.kt
+++ b/quarkdown-lsp/src/test/kotlin/com/quarkdown/lsp/FunctionDocumentationHoverSupplierTest.kt
@@ -102,4 +102,23 @@ class FunctionDocumentationHoverSupplierTest {
             ".$CSV_FUNCTION",
         )
     }
+
+    // Wrapped (tight) function calls
+
+    @Test
+    fun `hover over wrapped function call`() {
+        val text = "hello{.$ALIGN_FUNCTION {center}}hello"
+        val position = Position(0, text.indexOf(ALIGN_FUNCTION) + ALIGN_FUNCTION.length / 2)
+
+        val hover = getHover(text, position)
+        assertNotNull(hover)
+        assertContains(hover.contents.right.value, ".$ALIGN_FUNCTION")
+    }
+
+    @Test
+    fun `hover outside wrapped function call returns null`() {
+        val text = "hello{.$ALIGN_FUNCTION {center}}hello"
+        // Position on "hello" before the wrap.
+        assertNull(getHover(text, Position(0, 2)))
+    }
 }

--- a/quarkdown-quarkdoc/src/main/kotlin/com/quarkdown/quarkdoc/dokka/signature/QuarkdownSignatureProvider.kt
+++ b/quarkdown-quarkdoc/src/main/kotlin/com/quarkdown/quarkdoc/dokka/signature/QuarkdownSignatureProvider.kt
@@ -13,7 +13,7 @@ import org.jetbrains.dokka.pages.ContentNode
 import org.jetbrains.dokka.pages.TokenStyle
 import org.jetbrains.dokka.plugability.DokkaContext
 
-internal const val BEGIN = FunctionCallGrammar.BEGIN
+internal const val BEGIN = FunctionCallGrammar.BEGIN.toString()
 internal const val CHAINING_DELIMITER = FunctionCallGrammar.CHAIN_SEPARATOR
 private const val INLINE_PARAMETER_START = FunctionCallGrammar.ARGUMENT_BEGIN.toString()
 private const val INLINE_PARAMETER_END = FunctionCallGrammar.ARGUMENT_END.toString()
@@ -48,13 +48,16 @@ class QuarkdownSignatureProvider(
             )
 
         return when (documentable) {
-            is DFunction ->
+            is DFunction -> {
                 builder
                     .buildGroup {
                         codeBlock { signature(documentable) }
                     }.children
+            }
 
-            else -> kotlin.signature(documentable)
+            else -> {
+                kotlin.signature(documentable)
+            }
         }
     }
 

--- a/quarkdown-test/src/test/kotlin/com/quarkdown/test/FunctionCallChainingTest.kt
+++ b/quarkdown-test/src/test/kotlin/com/quarkdown/test/FunctionCallChainingTest.kt
@@ -29,4 +29,11 @@ class FunctionCallChainingTest {
             assertEquals("<p>5</p>", it)
         }
     }
+
+    @Test
+    fun wrapped() {
+        execute("abc{.sum {2} {4}::subtract {1}}def") {
+            assertEquals("<p>abc5def</p>", it)
+        }
+    }
 }

--- a/quarkdown-test/src/test/kotlin/com/quarkdown/test/FunctionCallTest.kt
+++ b/quarkdown-test/src/test/kotlin/com/quarkdown/test/FunctionCallTest.kt
@@ -77,4 +77,64 @@ class FunctionCallTest {
             assertEquals("<p>3 abc {}</p>", it)
         }
     }
+
+    @Test
+    fun `wrapped block function call`() {
+        execute("{.sum {1} {2}}") {
+            assertEquals("<p>3</p>", it)
+        }
+
+        execute(
+            """
+            .if {yes}
+                {.sum {1} {2}}jkl
+            """.trimIndent(),
+        ) {
+            assertEquals("<p>3jkl</p>", it)
+        }
+    }
+
+    @Test
+    fun `wrapped inline function call (loose)`() {
+        execute("hello {.sum {1} {2}} hello") {
+            assertEquals("<p>hello 3 hello</p>", it)
+        }
+    }
+
+    @Test
+    fun `wrapped inline function call (tight)`() {
+        execute("hello{.sum {1} {2}}hello") {
+            assertEquals("<p>hello3hello</p>", it)
+        }
+    }
+
+    @Test
+    fun `escaped wrap`() {
+        execute("hello\\{.sum {1} {2}}hello") {
+            assertEquals("<p>hello{3}hello</p>", it)
+        }
+    }
+
+    @Test
+    fun `malformed wrap`() {
+        execute("{.sum {1} {2} .sum {1} {2}}") {
+            assertEquals("<p>{3 3}</p>", it)
+        }
+
+        execute(
+            """
+            .if {yes}
+                abc{.uppercase {def} .uppercase {ghi}}jkl
+            """.trimIndent(),
+        ) {
+            assertEquals("<p>abc{DEF GHI}jkl</p>", it)
+        }
+    }
+
+    @Test
+    fun `incomplete wrap`() {
+        execute("hello{.sum {1} {2}") {
+            assertEquals("<p>hello{3</p>", it)
+        }
+    }
 }

--- a/quarkdown-test/src/test/kotlin/com/quarkdown/test/ScriptingTest.kt
+++ b/quarkdown-test/src/test/kotlin/com/quarkdown/test/ScriptingTest.kt
@@ -548,7 +548,7 @@ class ScriptingTest {
             
             .table
                 .foreach {0..4}
-                    | $ F_{.1} $ |
+                    | $ F_\{.1} $ |
                     |:-------------:|
                     |      .t1      |
                     .var {tmp} {.sum {.t1} {.t2}}
@@ -565,7 +565,7 @@ class ScriptingTest {
                 
                 .table
                     .repeat {.n}
-                        | $ F_{.subtract {.1} {1}} $ |
+                        | $ F_\{.subtract {.1} {1}} $ |
                         |:--------------------------:|
                         |             .t1            |
                         .var {tmp} {.sum {.t1} {.t2}}
@@ -582,7 +582,7 @@ class ScriptingTest {
             
             .function {newtablecolumn}
                 n:
-                |  $ F_{.n} $  |
+                |  $ F_\{.n} $  |
                 |:-------------:|
                 |      .t1      |
             
@@ -610,7 +610,7 @@ class ScriptingTest {
               
             .table
                 .foreach {0..4}
-                    | $ F_{.1} $  |
+                    | $ F_\{.1} $  |
                     |:------------:|
                     | .fib {.1} |
             """.trimIndent()

--- a/quarkdown-test/src/test/kotlin/com/quarkdown/test/TextTest.kt
+++ b/quarkdown-test/src/test/kotlin/com/quarkdown/test/TextTest.kt
@@ -113,6 +113,16 @@ class TextTest {
     }
 
     @Test
+    fun `subscript and superscript`() {
+        execute("H{.text {2} script:{sub}}O is water. E = mc{.text {2} script:{sup}}") {
+            assertEquals(
+                "<p>H<sub>2</sub>O is water. E = mc<sup>2</sup></p>",
+                it,
+            )
+        }
+    }
+
+    @Test
     fun `simple whitespace`() {
         execute(
             """


### PR DESCRIPTION
Tight/wrapped function calls allow for function calls surrounded by text content.

```
abc{.uppercase {def}}ghi
```
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/iamgio/quarkdown/pull/394" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
