### PR TITLE
feat(bibliography): support multi-key citation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ Quarkdown's internal bibliography management is now powered by [CSL](https://cit
 
 - Rendered bibliography entries are now localized to the document locale, set via `.doclang`.
 
+#### [Multi-key citations](https://quarkdown.com/wiki/bibliography#citations)
+
+`.cite` now accepts a comma-separated list of keys (e.g. `.cite {einstein, hawking}`) to produce a single combined citation label, whose format depends on the active citation style (e.g. `[1], [2]` for IEEE, `(Einstein, 1905; Hawking, 1988)` for APA).
+
 #### [`.heading` primitive function](https://quarkdown.com/wiki/headings)
 
 The new `.heading` function creates headings with granular control over their behavior, unlike standard Markdown headings (`#`, `##`, ...).

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,7 +37,9 @@ gradle.projectsEvaluated {
                     compileOnly(it)
                 }
 
-                else -> implementation(it)
+                else -> {
+                    implementation(it)
+                }
             }
         }
     }

--- a/docs/bibliography.qd
+++ b/docs/bibliography.qd
@@ -15,23 +15,31 @@ To get started, call the **`.bibliography {file}`** .docslink {quarkdown-stdlib/
 
 ## Citations
 
-You can cite an entry from the bibliography using the **`.cite {key}`** function.
+You can cite one or more entries from the bibliography using the **`.cite {key}`** function.
 
-Consider the following BibTeX entry:
+Consider the following BibTeX entries:
 
 ```text
 @article{einstein,
   author = "Albert Einstein",
   ...
 }
+
+@book{hawking,
+  author = "Stephen Hawking",
+  ...
+}
 ```
 
-You can cite it using the `einstein` key.
+You can cite them using their keys. Multiple keys can be specified as a comma-separated list
+to produce a single combined citation label, whose format depends on the active [citation style](#style).
 
 .examplemirror
     Einstein's publication .cite {einstein} in 1905 revolutionized the field of physics.
     Similarly, Hawking's book .cite {hawking} has had a profound impact
     on our understanding of cosmology and black holes.
+
+    These works .cite {einstein, hawking} are foundational to modern physics.
 
 ## Style
 
@@ -55,12 +63,12 @@ By default, the title is [localized](localization.qd) to the current locale set 
 
 The heading that precedes the bibliography can be further customized with the following parameters:
 
-| Parameter           | Description                                                                                                                   | Accepts | Default |
-|---------------------|-------------------------------------------------------------------------------------------------------------------------------|---------|---------|
-| `headingdepth`      | Depth of the heading that precedes the bibliography.                                                                          | Integer | `1`     |
-| `breakpage`  | Whether the heading triggers an automatic [page break](page-break.qd#automatic-break).                                       | Boolean | `yes`   |
-| `numberheading`     | Whether the heading should be [numbered](numbering.qd) and have its position tracked in the document hierarchy.               | Boolean | `no`    |
-| `indexheading`      | Whether the heading should be included in the document's [table of contents](table-of-contents.qd). Implicitly enables `numberheading`. | Boolean | `no`    |
+| Parameter       | Description                                                                                                                             | Accepts | Default |
+|-----------------|-----------------------------------------------------------------------------------------------------------------------------------------|---------|---------|
+| `headingdepth`  | Depth of the heading that precedes the bibliography.                                                                                    | Integer | `1`     |
+| `breakpage`     | Whether the heading triggers an automatic [page break](page-break.qd#automatic-break).                                                  | Boolean | `yes`   |
+| `numberheading` | Whether the heading should be [numbered](numbering.qd) and have its position tracked in the document hierarchy.                         | Boolean | `no`    |
+| `indexheading`  | Whether the heading should be included in the document's [table of contents](table-of-contents.qd). Implicitly enables `numberheading`. | Boolean | `no`    |
 
 For example, depending on the current [auto page break](page-break.qd#automatic-break) configuration, the title may cause a page break. You can prevent this:
 

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/quarkdown/bibliography/BibliographyCitation.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/quarkdown/bibliography/BibliographyCitation.kt
@@ -5,12 +5,14 @@ import com.quarkdown.core.bibliography.BibliographyEntry
 import com.quarkdown.core.visitor.node.NodeVisitor
 
 /**
- * Represents a citation to a bibliography entry.
- * @param citationKey the key used to identify the bibliography entry
+ * Represents a citation to one or more bibliography entries.
+ * Multiple keys produce a single combined label (e.g. `[1, 3]` or `(Einstein, 1905; Hawking, 1988)`),
+ * according to the active citation style.
+ * @param citationKeys the keys used to identify the bibliography entries
  */
 class BibliographyCitation(
-    val citationKey: String,
-) : ReferenceNode<BibliographyCitation, Pair<BibliographyEntry, BibliographyView>> {
+    val citationKeys: List<String>,
+) : ReferenceNode<BibliographyCitation, Pair<List<BibliographyEntry>, BibliographyView>> {
     override val reference: BibliographyCitation = this
 
     override fun <T> accept(visitor: NodeVisitor<T>): T = visitor.visit(this)

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/bibliography/style/BibliographyEntryLabelProviderStrategy.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/bibliography/style/BibliographyEntryLabelProviderStrategy.kt
@@ -10,23 +10,19 @@ import com.quarkdown.core.bibliography.BibliographyEntry
  */
 interface BibliographyEntryLabelProviderStrategy {
     /**
-     * Returns the label for an in-text citation (e.g. `[1]` or `(Einstein, 1905)`).
-     * @param entry the bibliography entry being cited
-     * @param index the index of the entry in the bibliography list, starting from 0
+     * Returns the combined label for an in-text citation of one or more bibliography entries
+     * (e.g. `[1]`, `[1, 2]`, or `(Einstein, 1905; Hawking, 1988)`).
+     * @param entries the bibliography entries being cited
      */
-    fun getCitationLabel(
-        entry: BibliographyEntry,
-        index: Int,
-    ): String
+    fun getCitationLabel(entries: List<BibliographyEntry>): String
 
     /**
      * Returns the label for a bibliography list entry (e.g. `[1]` or empty).
-     * Defaults to [getCitationLabel] unless overridden.
      * @param entry the bibliography entry in the list
      * @param index the index of the entry in the bibliography list, starting from 0
      */
     fun getListLabel(
         entry: BibliographyEntry,
         index: Int,
-    ): String = getCitationLabel(entry, index)
+    ): String
 }

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/bibliography/style/csl/CslBibliographyStyle.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/bibliography/style/csl/CslBibliographyStyle.kt
@@ -75,11 +75,8 @@ class CslBibliographyStyle(
 
     override val labelProvider =
         object : BibliographyEntryLabelProviderStrategy {
-            override fun getCitationLabel(
-                entry: BibliographyEntry,
-                index: Int,
-            ): String {
-                csl.makeCitation(entry.citationKey)
+            override fun getCitationLabel(entries: List<BibliographyEntry>): String {
+                csl.makeCitation(*entries.map { it.citationKey }.toTypedArray())
                 return format.lastCitationResult.toPlainText().ifBlank { "[?]" }
             }
 

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/context/hooks/reference/BibliographyCitationResolverHook.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/context/hooks/reference/BibliographyCitationResolverHook.kt
@@ -8,13 +8,13 @@ import com.quarkdown.core.bibliography.BibliographyEntry
 import com.quarkdown.core.context.MutableContext
 
 /**
- * Hook that associates a bibliography entry to each [BibliographyCitation]
- * that can be linked to an entry of a [Bibliography]
+ * Hook that associates bibliography entries to each [BibliographyCitation]
+ * that can be linked to entries of a [Bibliography]
  * within a [BibliographyView].
  */
 class BibliographyCitationResolverHook(
     context: MutableContext,
-) : ReferenceDefinitionResolverHook<BibliographyCitation, BibliographyView, Pair<BibliographyEntry, BibliographyView>>(context) {
+) : ReferenceDefinitionResolverHook<BibliographyCitation, BibliographyView, Pair<List<BibliographyEntry>, BibliographyView>>(context) {
     override fun collectReferences(iterator: ObservableAstIterator) = iterator.collectAll<BibliographyCitation>()
 
     override fun collectDefinitions(iterator: ObservableAstIterator) = iterator.collectAll<BibliographyView>()
@@ -23,11 +23,13 @@ class BibliographyCitationResolverHook(
         reference: BibliographyCitation,
         definitions: List<BibliographyView>,
         index: Int,
-    ): Pair<BibliographyView, Pair<BibliographyEntry, BibliographyView>>? =
+    ): Pair<BibliographyView, Pair<List<BibliographyEntry>, BibliographyView>>? =
         definitions
             .firstNotNullOfOrNull { bibliography ->
-                bibliography.bibliography
-                    .entries[reference.citationKey]
-                    ?.let { bibliography to (it to bibliography) }
+                val entries =
+                    reference.citationKeys.map { key ->
+                        bibliography.bibliography.entries[key] ?: return@firstNotNullOfOrNull null
+                    }
+                bibliography to (entries to bibliography)
             }
 }

--- a/quarkdown-core/src/test/kotlin/com/quarkdown/core/BibliographyCitationResolutionTest.kt
+++ b/quarkdown-core/src/test/kotlin/com/quarkdown/core/BibliographyCitationResolutionTest.kt
@@ -28,7 +28,9 @@ private val stubStyle =
 
         override val labelProvider =
             object : BibliographyEntryLabelProviderStrategy {
-                override fun getCitationLabel(
+                override fun getCitationLabel(entries: List<BibliographyEntry>) = ""
+
+                override fun getListLabel(
                     entry: BibliographyEntry,
                     index: Int,
                 ) = "[${index + 1}]"
@@ -53,7 +55,7 @@ class BibliographyCitationResolutionTest {
             style = stubStyle,
         )
 
-    private val citation = BibliographyCitation(CITATION_KEY)
+    private val citation = BibliographyCitation(listOf(CITATION_KEY))
 
     private fun traverse(root: Node) {
         ObservableAstIterator()
@@ -73,10 +75,9 @@ class BibliographyCitationResolutionTest {
 
         traverse(root)
 
-        assertEquals(
-            bibliographyView.bibliography.entries[CITATION_KEY],
-            citation.getDefinition(context)?.first,
-        )
+        val resolved = citation.getDefinition(context)?.first
+        assertEquals(1, resolved?.size)
+        assertEquals(bibliographyView.bibliography.entries[CITATION_KEY], resolved?.first())
     }
 
     @Test
@@ -91,9 +92,28 @@ class BibliographyCitationResolutionTest {
 
         traverse(root)
 
-        assertEquals(
-            bibliographyView.bibliography.entries[CITATION_KEY],
-            citation.getDefinition(context)?.first,
-        )
+        val resolved = citation.getDefinition(context)?.first
+        assertEquals(1, resolved?.size)
+        assertEquals(bibliographyView.bibliography.entries[CITATION_KEY], resolved?.first())
+    }
+
+    @Test
+    fun `multi-key citation`() {
+        val multiCitation = BibliographyCitation(listOf("einstein", "latexcompanion"))
+
+        val root =
+            buildBlock {
+                root {
+                    +bibliographyView
+                    +multiCitation
+                }
+            }
+
+        traverse(root)
+
+        val resolved = multiCitation.getDefinition(context)?.first
+        assertEquals(2, resolved?.size)
+        assertEquals(bibliographyView.bibliography.entries["einstein"], resolved?.get(0))
+        assertEquals(bibliographyView.bibliography.entries["latexcompanion"], resolved?.get(1))
     }
 }

--- a/quarkdown-core/src/test/kotlin/com/quarkdown/core/CslBibliographyStyleTest.kt
+++ b/quarkdown-core/src/test/kotlin/com/quarkdown/core/CslBibliographyStyleTest.kt
@@ -1,11 +1,9 @@
 package com.quarkdown.core
 
-import com.quarkdown.core.ast.NestableNode
-import com.quarkdown.core.ast.Node
 import com.quarkdown.core.ast.base.inline.Emphasis
 import com.quarkdown.core.ast.base.inline.Link
-import com.quarkdown.core.ast.base.inline.Text
 import com.quarkdown.core.bibliography.style.csl.CslBibliographyStyle
+import com.quarkdown.core.util.node.toPlainText
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -19,18 +17,11 @@ class CslBibliographyStyleTest {
     private fun cslStyle(styleName: String): CslBibliographyStyle =
         CslBibliographyStyle.from(styleName, bibResource("bibliography.bib"), "bibliography.bib")
 
-    private fun Node.toPlainText(): String =
-        when (this) {
-            is Text -> text
-            is NestableNode -> children.joinToString("") { it.toPlainText() }
-            else -> ""
-        }
-
     @Test
     fun `csl apa, article citation label`() {
         val style = cslStyle("apa")
         val entry = style.bibliography.entries["einstein"]!!
-        val label = style.labelProvider.getCitationLabel(entry, 0)
+        val label = style.labelProvider.getCitationLabel(listOf(entry))
         assertTrue("Einstein" in label, "APA citation label should contain author name, got: $label")
         assertTrue("1905" in label, "APA citation label should contain year, got: $label")
     }
@@ -40,7 +31,7 @@ class CslBibliographyStyleTest {
         val style = cslStyle("apa")
         val entry = style.bibliography.entries["einstein"]!!
         val content = style.contentOf(entry)
-        val plainText = content.joinToString("") { it.toPlainText() }
+        val plainText = content.toPlainText()
 
         // APA article: Author (Year). Title. *Journal*, *Volume*(Issue), Pages. DOI
         assertTrue("Einstein" in plainText, "Should contain author: $plainText")
@@ -48,7 +39,7 @@ class CslBibliographyStyleTest {
         assertTrue("Annalen" in plainText, "Should contain journal: $plainText")
 
         // Journal name should be emphasized (italic).
-        val hasEmphasizedJournal = content.any { node -> node is Emphasis && node.toPlainText().contains("Annalen") }
+        val hasEmphasizedJournal = content.any { node -> node is Emphasis && node.children.toPlainText().contains("Annalen") }
         assertTrue(hasEmphasizedJournal, "Journal name should be emphasized in APA: $content")
 
         // DOI should be a link.
@@ -61,14 +52,20 @@ class CslBibliographyStyleTest {
         val style = cslStyle("apa")
         val entry = style.bibliography.entries["latexcompanion"]!!
         val content = style.contentOf(entry)
-        val plainText = content.joinToString("") { it.toPlainText() }
+        val plainText = content.toPlainText()
 
         assertTrue("Goossens" in plainText, "Should contain author: $plainText")
         assertTrue("LaTeX Companion" in plainText || "latex companion" in plainText.lowercase(), "Should contain title: $plainText")
 
         // Book title should be emphasized in APA.
         val hasEmphasizedTitle =
-            content.any { node -> node is Emphasis && node.toPlainText().lowercase().contains("latex companion") }
+            content.any { node ->
+                node is Emphasis &&
+                    node.children
+                        .toPlainText()
+                        .lowercase()
+                        .contains("latex companion")
+            }
         assertTrue(hasEmphasizedTitle, "Book title should be emphasized in APA: $content")
     }
 
@@ -77,7 +74,7 @@ class CslBibliographyStyleTest {
         val style = cslStyle("apa")
         val entry = style.bibliography.entries["knuthwebsite"]!!
         val content = style.contentOf(entry)
-        val plainText = content.joinToString("") { it.toPlainText() }
+        val plainText = content.toPlainText()
         assertTrue("Knuth" in plainText, "Should contain author: $plainText")
     }
 
@@ -85,7 +82,7 @@ class CslBibliographyStyleTest {
     fun `csl ieee, article citation label`() {
         val style = cslStyle("ieee")
         val entry = style.bibliography.entries["einstein"]!!
-        val label = style.labelProvider.getCitationLabel(entry, 0)
+        val label = style.labelProvider.getCitationLabel(listOf(entry))
         assertTrue("[" in label && "]" in label, "IEEE citation label should be bracketed, got: $label")
     }
 
@@ -94,7 +91,7 @@ class CslBibliographyStyleTest {
         val style = cslStyle("ieee")
         val entry = style.bibliography.entries["einstein"]!!
         val content = style.contentOf(entry)
-        val plainText = content.joinToString("") { it.toPlainText() }
+        val plainText = content.toPlainText()
 
         assertTrue("Einstein" in plainText, "Should contain author: $plainText")
         assertTrue("1905" in plainText, "Should contain year: $plainText")

--- a/quarkdown-html/src/main/kotlin/com/quarkdown/rendering/html/node/QuarkdownHtmlNodeRenderer.kt
+++ b/quarkdown-html/src/main/kotlin/com/quarkdown/rendering/html/node/QuarkdownHtmlNodeRenderer.kt
@@ -477,11 +477,10 @@ class QuarkdownHtmlNodeRenderer(
     }
 
     override fun visit(node: BibliographyCitation): CharSequence {
-        val (entry: BibliographyEntry, view: BibliographyView) =
+        val (entries: List<BibliographyEntry>, view: BibliographyView) =
             node.getDefinition(context) ?: return Text("[???]").accept(this)
 
-        val index = view.bibliography.indexOf(entry)
-        val label = view.style.labelProvider.getCitationLabel(entry, index)
+        val label = view.style.labelProvider.getCitationLabel(entries)
         return Text(label).accept(this)
     }
 

--- a/quarkdown-html/src/test/kotlin/com/quarkdown/rendering/html/HtmlNodeRendererTest.kt
+++ b/quarkdown-html/src/test/kotlin/com/quarkdown/rendering/html/HtmlNodeRendererTest.kt
@@ -1219,7 +1219,9 @@ class HtmlNodeRendererTest {
 
                 override val labelProvider =
                     object : BibliographyEntryLabelProviderStrategy {
-                        override fun getCitationLabel(
+                        override fun getCitationLabel(entries: List<BibliographyEntry>) = ""
+
+                        override fun getListLabel(
                             entry: BibliographyEntry,
                             index: Int,
                         ) = "[${index + 1}]"

--- a/quarkdown-plaintext/src/main/kotlin/com/quarkdown/rendering/plaintext/node/PlainTextNodeRenderer.kt
+++ b/quarkdown-plaintext/src/main/kotlin/com/quarkdown/rendering/plaintext/node/PlainTextNodeRenderer.kt
@@ -320,12 +320,10 @@ class PlainTextNodeRenderer(
     }
 
     override fun visit(node: BibliographyCitation): CharSequence {
-        val (entry: BibliographyEntry, view: BibliographyView) =
+        val (entries: List<BibliographyEntry>, view: BibliographyView) =
             node.getDefinition(context) ?: return "[???]"
 
-        val index = view.bibliography.indexOf(entry)
-        val label = view.style.labelProvider.getCitationLabel(entry, index)
-        return label
+        return view.style.labelProvider.getCitationLabel(entries)
     }
 
     override fun visit(node: SlidesFragment) = ""

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Bibliography.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Bibliography.kt
@@ -45,8 +45,7 @@ private const val DEFAULT_CSL_STYLE = "ieee"
  *
  * Example:
  * ```markdown
- * .bibliography {bibliography.bib}
- *     style:{apa}
+ * .bibliography {bibliography.bib} style:{apa}
  * ```
  *
  * @param path path to the bibliography file, with extension
@@ -102,9 +101,11 @@ fun bibliography(
 }
 
 /**
- * Creates a citation to a bibliography entry.
+ * Creates a citation to one or more bibliography entries.
  *
- * The result is a label that matches with that of the bibliography entry with the given [key].
+ * The result is a label that matches with that of the bibliography entries with the given [key].
+ * Multiple keys can be specified as a comma-separated list,
+ * producing a single combined label (e.g. `[1], [3]` or `(Einstein, 1905; Hawking, 1988)`).
  *
  * Example:
  *
@@ -123,17 +124,30 @@ fun bibliography(
  * ```markdown
  * Einstein's work .cite {einstein} is fundamental to modern physics.
  *
+ * These results .cite {einstein, latexcompanion} are well-known.
+ *
  * .bibliography {bibliography.bib}
  * ```
  *
  * Result:
  * ```text
  * Einstein's work [1] is fundamental to modern physics.
+ *
+ * These results [1], [2] are well-known.
  * ```
- * @param key the key of the bibliography entry to cite
+ * @param key the key (or comma-separated keys) of the bibliography entries to cite
  * @return a wrapped [BibliographyCitation] node
+ * @throws IllegalArgumentException if no non-blank citation key is provided
  * @wiki Bibliography#citations
  */
-fun cite(key: String) =
-    BibliographyCitation(key)
-        .wrappedAsValue()
+fun cite(key: String): NodeValue {
+    val keys =
+        key
+            .split(",")
+            .filter { it.isNotBlank() }
+            .map { it.trim() }
+
+    require(keys.isNotEmpty()) { "At least one citation key must be specified." }
+
+    return BibliographyCitation(keys).wrappedAsValue()
+}

--- a/quarkdown-test/src/test/kotlin/com/quarkdown/test/BibliographyTest.kt
+++ b/quarkdown-test/src/test/kotlin/com/quarkdown/test/BibliographyTest.kt
@@ -185,9 +185,58 @@ class BibliographyTest {
     }
 
     @Test
+    fun `multi-key citation`() {
+        execute(
+            """
+            abc .cite {einstein, latexcompanion} def
+
+            $BIBLIOGRAPHY_CALL
+            """.trimIndent(),
+        ) {
+            assertEquals(
+                "<p>abc [1], [2] def</p>" +
+                    ieeeBibliographyOutput(),
+                it,
+            )
+        }
+    }
+
+    @Test
+    fun `multi-key citation (apa)`() {
+        execute(
+            """
+            abc .cite {einstein, latexcompanion} def
+
+            .bibliography {bib/bibliography.bib} style:{apa} breakpage:{no}
+            """.trimIndent(),
+        ) {
+            // APA uses "et al." for works with 3+ authors.
+            val citation = it.toString().substringAfter("abc ").substringBefore(" def")
+            assertEquals(
+                "(Einstein, 1905; Goossens et al., 1993)",
+                citation,
+            )
+        }
+    }
+
+    @Test
     fun `unresolved citation`() {
         execute(
             "abc .cite {abc}\n\n" +
+                BIBLIOGRAPHY_CALL,
+        ) {
+            assertEquals(
+                "<p>abc [???]</p>" +
+                    ieeeBibliographyOutput(),
+                it,
+            )
+        }
+    }
+
+    @Test
+    fun `partially unresolved multi-key citation`() {
+        execute(
+            "abc .cite {einstein, invalidkey}\n\n" +
                 BIBLIOGRAPHY_CALL,
         ) {
             assertEquals(


### PR DESCRIPTION
`cite {first, second, third}`

Closes #399
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/iamgio/quarkdown/pull/400" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
