### PR TITLE
feat: allow formatted captions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,16 @@ Quarkdown's internal bibliography management is now powered by [CSL](https://cit
 
 `.cite` now accepts a comma-separated list of keys (e.g. `.cite {einstein, hawking}`) to produce a single combined citation label, whose format depends on the active citation style (e.g. `[1], [2]` for IEEE, `(Einstein, 1905; Hawking, 1988)` for APA).
 
+#### Formatted captions
+
+Captions for all supported elements now accept inline formatting (including inline function calls), rather than plain text. 
+
+```markdown
+![Pi](pi.png "The symbol of *pi*, which approximately equals .pi")
+```
+
+<img width="500" alt="Formatted caption" src="https://github.com/user-attachments/assets/589241b1-9273-41fa-9ffc-54104671a389" />
+
 #### [Scoped page formatting](https://quarkdown.com/wiki/page-format#scoped-formatting)
 
 `.pageformat` now supports scoping formats to specific pages in `paged` documents via two combinable parameters:
@@ -41,11 +51,6 @@ Quarkdown's internal bibliography management is now powered by [CSL](https://cit
 .pageformat pages:{1..3} borderbottom:{4px}
 ```
 
-#### [`.heading` primitive function](https://quarkdown.com/wiki/headings)
-
-The new `.heading` function creates headings with granular control over their behavior, unlike standard Markdown headings (`#`, `##`, ...).
-It allows explicit control over numbering (`numbered`), table of contents indexing (`indexed`), page breaks (`breakpage`), depth, and reference ID (`ref`).
-
 #### New syntax: [Tight function calls](https://quarkdown.com/wiki/syntax-of-a-function-call#tight-function-calls)
 
 Inline function calls can now be wrapped in curly braces to delimit them from surrounding content, without relying on whitespace.
@@ -53,6 +58,11 @@ Inline function calls can now be wrapped in curly braces to delimit them from su
 ```markdown
 abc{.uppercase {def}}ghi
 ```
+
+#### [`.heading` primitive function](https://quarkdown.com/wiki/headings)
+
+The new `.heading` function creates headings with granular control over their behavior, unlike standard Markdown headings (`#`, `##`, ...).
+It allows explicit control over numbering (`numbered`), table of contents indexing (`indexed`), page breaks (`breakpage`), depth, and reference ID (`ref`).
 
 #### [`.pagebreak` primitive function](https://quarkdown.com/wiki/page-break)
 
@@ -95,7 +105,7 @@ The `.text` function now accepts a `script` parameter with `sub` and `sup` value
 
 ### Changed
 
-#### Removed `includeunnumbered` parameter from `.tableofcontents`
+#### Removed `includeunnumbered` parameter from `.tableofcontents` (breaking change)
 
 The `includeunnumbered` parameter has been removed, in favor of the more granular heading configuration previously mentioned.
 Now all indexable headings are included in the ToC by default, regardless of their numbering.

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/base/LinkNode.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/base/LinkNode.kt
@@ -23,7 +23,7 @@ interface LinkNode : Node {
     /**
      * Optional title.
      */
-    val title: String?
+    val title: InlineContent?
 
     /**
      * Optional file system where this link is defined, used for resolving relative paths.

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/base/block/Code.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/base/block/Code.kt
@@ -1,5 +1,6 @@
 package com.quarkdown.core.ast.base.block
 
+import com.quarkdown.core.ast.InlineContent
 import com.quarkdown.core.ast.attributes.localization.LocalizedKind
 import com.quarkdown.core.ast.attributes.localization.LocalizedKindKeys
 import com.quarkdown.core.ast.attributes.location.LocationTrackableNode
@@ -24,7 +25,7 @@ class Code(
     val showLineNumbers: Boolean = true,
     val highlight: Boolean = true,
     val focusedLines: Range? = null,
-    override val caption: String? = null,
+    override val caption: InlineContent? = null,
     override val referenceId: String? = null,
 ) : LocationTrackableNode,
     CrossReferenceableNode,

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/base/block/LinkDefinition.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/base/block/LinkDefinition.kt
@@ -10,13 +10,13 @@ import com.quarkdown.core.visitor.node.NodeVisitor
  * Creation of a referenceable link definition.
  * @param label inline content of the displayed label
  * @param url URL this link points to
- * @param title optional title
+ * @param title optional inline title
  * @param fileSystem optional file system this link is relative to
  */
 class LinkDefinition(
     override val label: InlineContent,
     override val url: String,
-    override val title: String?,
+    override val title: InlineContent?,
     override val fileSystem: FileSystem? = null,
 ) : LinkNode,
     TextNode {

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/base/block/Table.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/base/block/Table.kt
@@ -16,12 +16,12 @@ import com.quarkdown.core.visitor.node.NodeVisitor
  * A table, consisting of columns, each of which has a header and multiple cells.
  * A table is location-trackable since, if requested by the user, it may show a caption displaying its location-based label.
  * @param columns columns of the table. Each column has a header and multiple cells
- * @param caption optional caption of the table (Quarkdown extension)
+ * @param caption optional inline caption of the table (Quarkdown extension)
  * @param referenceId optional ID of the table to cross-reference via [com.quarkdown.core.ast.quarkdown.reference.CrossReference] (Quarkdown extension)
  */
 class Table(
     val columns: List<Column>,
-    override val caption: String? = null,
+    override val caption: InlineContent? = null,
     override val referenceId: String? = null,
 ) : NestableNode,
     LocationTrackableNode,

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/base/inline/Link.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/base/inline/Link.kt
@@ -14,13 +14,13 @@ import com.quarkdown.core.visitor.node.NodeVisitor
  * A link.
  * @param label inline content of the displayed label
  * @param url URL this link points to
- * @param title optional title
+ * @param title optional inline title
  * @param fileSystem optional file system where this link is defined, used for resolving relative paths
  */
 class Link(
     override val label: InlineContent,
     override val url: String,
-    override val title: String?,
+    override val title: InlineContent?,
     override val fileSystem: FileSystem? = null,
 ) : LinkNode,
     TextNode {

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/dsl/InlineAstBuilder.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/dsl/InlineAstBuilder.kt
@@ -54,7 +54,7 @@ class InlineAstBuilder : AstBuilder() {
         url: String,
         title: String? = null,
         label: InlineAstBuilder.() -> Unit,
-    ) = +Link(buildInline(label), url, title)
+    ) = +Link(buildInline(label), url, title?.let { listOf(Text(it)) })
 
     /**
      * @see CodeSpan
@@ -72,7 +72,7 @@ class InlineAstBuilder : AstBuilder() {
         referenceId: String? = null,
         label: InlineAstBuilder.() -> Unit = {},
     ) = +Image(
-        Link(buildInline(label), url, title, fileSystem = SimpleFileSystem()),
+        Link(buildInline(label), url, title?.let { listOf(Text(it)) }, fileSystem = SimpleFileSystem()),
         width,
         height,
         referenceId,

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/quarkdown/CaptionableNode.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/quarkdown/CaptionableNode.kt
@@ -1,14 +1,15 @@
 package com.quarkdown.core.ast.quarkdown
 
+import com.quarkdown.core.ast.InlineContent
 import com.quarkdown.core.ast.Node
 
 /**
  * A node that may have a caption, such as a [com.quarkdown.core.ast.base.block.Table] or a [com.quarkdown.core.ast.quarkdown.block.ImageFigure].
- * The caption is a plain text string, which does not accept further inline formatting.
+ * The caption is a sequence of inline nodes, which accepts further inline formatting (e.g. emphasis, links).
  */
 interface CaptionableNode : Node {
     /**
-     * The optional caption.
+     * The optional caption, as inline content. If `null`, this node has no caption.
      */
-    val caption: String?
+    val caption: InlineContent?
 }

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/quarkdown/block/Figure.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/quarkdown/block/Figure.kt
@@ -1,5 +1,6 @@
 package com.quarkdown.core.ast.quarkdown.block
 
+import com.quarkdown.core.ast.InlineContent
 import com.quarkdown.core.ast.Node
 import com.quarkdown.core.ast.SingleChildNestableNode
 import com.quarkdown.core.ast.attributes.localization.LocalizedKind
@@ -14,13 +15,13 @@ import com.quarkdown.core.visitor.node.NodeVisitor
  * A block which displays a single child, with an optional caption.
  * If a [caption] is provided or [referenceId] is set, the block is numbered.
  * @param child wrapped child
- * @param caption optional caption of the figure block
+ * @param caption optional inline caption of the figure block
  * @param referenceId optional ID that can be cross-referenced via a [com.quarkdown.core.ast.quarkdown.reference.CrossReference]
  * @param T type of the wrapped child node
  */
 open class Figure<T : Node>(
     override val child: T,
-    override val caption: String? = null,
+    override val caption: InlineContent? = null,
     override val referenceId: String? = null,
 ) : SingleChildNestableNode<T>,
     LocationTrackableNode,

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/function/value/MarkdownContentValue.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/function/value/MarkdownContentValue.kt
@@ -9,7 +9,8 @@ import com.quarkdown.core.function.expression.visitor.ExpressionVisitor
  */
 data class MarkdownContentValue(
     override val unwrappedValue: MarkdownContent,
-) : InputValue<MarkdownContent> {
+) : InputValue<MarkdownContent>,
+    AdaptableValue<InlineMarkdownContentValue> {
     override fun <T> accept(visitor: ExpressionVisitor<T>): T = visitor.visit(this)
 
     /**
@@ -18,9 +19,11 @@ data class MarkdownContentValue(
     fun asNodeValue(): NodeValue = NodeValue(unwrappedValue)
 
     /**
-     * @return this Markdown content value to an [InlineMarkdownContent] value. Wrapped content is identical
+     * Adapts this block-level content to inline content.
+     * Wrapped content is identical, allowing seamless conversion when a function parameter
+     * expects [InlineMarkdownContent] but receives [MarkdownContent].
      */
-    fun asInline() = InlineMarkdownContentValue(InlineMarkdownContent(unwrappedValue.children))
+    override fun adapt() = InlineMarkdownContentValue(InlineMarkdownContent(unwrappedValue.children))
 }
 
 /**

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/function/value/factory/ValueFactory.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/function/value/factory/ValueFactory.kt
@@ -395,7 +395,7 @@ object ValueFactory {
                     context.flavor.lexerFactory.newInlineLexer(raw.toString()),
                     context,
                     expandFunctionCalls = true,
-                ).asInline()
+                ).adapt()
             }
         }
 

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/parser/BlockTokenParser.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/parser/BlockTokenParser.kt
@@ -108,14 +108,13 @@ class BlockTokenParser(
             groups
                 .next()
                 .lineSequence()
-                .map { it.replace("^ {0,$initialSpaces}".toRegex(), "") }
-                .joinToString(separator = "\n")
+                .joinToString(separator = "\n") { it.replace("^ {0,$initialSpaces}".toRegex(), "") }
                 .removePrefix("\n")
                 .removeSuffix("\n")
 
         return Code(
             language = language?.takeIf { it.isNotBlank() }?.trim(),
-            caption = caption?.trimDelimiters(),
+            caption = caption?.trimDelimiters()?.toInline(),
             referenceId = referenceId,
             content = content,
         )
@@ -189,7 +188,12 @@ class BlockTokenParser(
             label = groups.next().trim().toInline(),
             url = groups.next().trim(),
             // Remove first and last character
-            title = groups.nextOrNull()?.trimDelimiters()?.trim(),
+            title =
+                groups
+                    .nextOrNull()
+                    ?.trimDelimiters()
+                    ?.trim()
+                    ?.toInline(),
             fileSystem = context.fileSystem,
         )
     }
@@ -413,7 +417,7 @@ class BlockTokenParser(
 
         return Table(
             columns = columns.map { it.toColumn() },
-            caption = caption,
+            caption = caption?.toInline(),
             referenceId = customId,
         )
     }

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/parser/InlineTokenParser.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/parser/InlineTokenParser.kt
@@ -166,7 +166,12 @@ class InlineTokenParser(
                 label = parseLinkLabelSubContent(groups.next()),
                 url = groups.next().trim(),
                 // Removes leading and trailing delimiters.
-                title = groups.nextOrNull()?.trimDelimiters()?.trim(),
+                title =
+                    groups
+                        .nextOrNull()
+                        ?.trimDelimiters()
+                        ?.trim()
+                        ?.let(::parseSubContent),
                 fileSystem = context.fileSystem,
             )
 

--- a/quarkdown-core/src/test/kotlin/com/quarkdown/core/AstDslTest.kt
+++ b/quarkdown-core/src/test/kotlin/com/quarkdown/core/AstDslTest.kt
@@ -102,7 +102,7 @@ class AstDslTest {
                                                         Link(
                                                             listOf(Strong(listOf(Text("alt")))),
                                                             url = "url",
-                                                            title = "title",
+                                                            title = listOf(Text("title")),
                                                             fileSystem = SimpleFileSystem(),
                                                         ),
                                                     width = null,

--- a/quarkdown-core/src/test/kotlin/com/quarkdown/core/BlockParserTest.kt
+++ b/quarkdown-core/src/test/kotlin/com/quarkdown/core/BlockParserTest.kt
@@ -237,7 +237,7 @@ class BlockParserTest {
         with(nodes.next()) {
             assertEquals("Code line 1\nCode line 2", content)
             assertEquals("text", language)
-            assertEquals("The caption", caption)
+            assertNodeEquals(listOf(Text("The caption")), caption!!)
             assertNull(referenceId)
         }
         repeat(2) {
@@ -255,8 +255,16 @@ class BlockParserTest {
         with(nodes.next()) {
             assertEquals("Code line 1\nCode line 2", content)
             assertEquals("text", language)
-            assertEquals("The caption", caption)
+            assertNodeEquals(listOf(Text("The caption")), caption!!)
             assertEquals("custom-id", referenceId)
+        }
+        with(nodes.next()) {
+            assertEquals("Code line 1\nCode line 2", content)
+            assertEquals("text", language)
+            assertNodeEquals(
+                listOf(Text("A "), Emphasis(listOf(Text("formatted caption")))),
+                caption!!,
+            )
         }
     }
 
@@ -432,23 +440,23 @@ class BlockParserTest {
             with(nodes.next()) {
                 assertEquals("label", rawText)
                 assertEquals("https://google.com", url)
-                assertEquals("Title", title)
+                assertNodeEquals(listOf(Text("Title")), title!!)
             }
         }
         with(nodes.next()) {
             assertEquals("label", rawText)
             assertEquals("https://google.com", url)
-            assertEquals("Multiline\ntitle", title)
+            assertNodeEquals(listOf(Text("Multiline\ntitle")), title!!)
         }
         with(nodes.next()) {
             assertEquals("label", rawText)
             assertEquals("https://google.com", url)
-            assertEquals("Line 1\nLine 2\nLine 3", title)
+            assertNodeEquals(listOf(Text("Line 1\nLine 2\nLine 3")), title!!)
         }
         with(nodes.next()) {
             assertEquals("label", rawText)
             assertEquals("/url", url)
-            assertEquals("Title", title)
+            assertNodeEquals(listOf(Text("Title")), title!!)
         }
     }
 
@@ -591,7 +599,7 @@ class BlockParserTest {
 
         repeat(2) {
             with(nodes.next()) {
-                assertEquals("Table caption", caption)
+                assertNodeEquals(listOf(Text("Table caption")), caption!!)
                 assertNull(referenceId)
 
                 val columns = columns.iterator()
@@ -618,8 +626,16 @@ class BlockParserTest {
         }
 
         with(nodes.next()) {
-            assertEquals("Table caption", caption)
+            assertNodeEquals(listOf(Text("Table caption")), caption!!)
             assertEquals("custom-id", referenceId)
+        }
+
+        with(nodes.next()) {
+            assertNodeEquals(
+                listOf(Text("A "), Emphasis(listOf(Text("formatted caption")))),
+                caption!!,
+            )
+            assertNull(referenceId)
         }
 
         assertFalse(nodes.hasNext())
@@ -987,7 +1003,7 @@ class BlockParserTest {
                 }.first(),
                 child,
             )
-            assertEquals("Title", caption)
+            assertNodeEquals(listOf(Text("Title")), caption!!)
         }
 
         with(nodes.next()) {
@@ -1046,6 +1062,13 @@ class BlockParserTest {
 
         with(nodes.next()) {
             assertEquals("custom-id", referenceId)
+        }
+
+        with(nodes.next()) {
+            assertNodeEquals(
+                listOf(Text("A "), Emphasis(listOf(Text("formatted caption")))),
+                caption!!,
+            )
         }
     }
 

--- a/quarkdown-core/src/test/kotlin/com/quarkdown/core/InlineParserTest.kt
+++ b/quarkdown-core/src/test/kotlin/com/quarkdown/core/InlineParserTest.kt
@@ -111,7 +111,7 @@ class InlineParserTest {
                     assertEquals("foo", text)
                 }
                 assertEquals("https://google.com", url)
-                assertEquals(title, "Title")
+                assertNodeEquals(listOf(Text("Title")), title!!)
             }
         }
 
@@ -235,7 +235,7 @@ class InlineParserTest {
                     assertEquals("foo", text)
                 }
                 assertEquals("/img", link.url)
-                assertEquals(link.title, "Title")
+                assertNodeEquals(listOf(Text("Title")), link.title!!)
 
                 assertNull(width)
                 assertNull(height)
@@ -249,7 +249,7 @@ class InlineParserTest {
                 assertEquals("foo", text)
             }
             assertEquals("/img", link.url)
-            assertEquals(link.title, "Title")
+            assertNodeEquals(listOf(Text("Title")), link.title!!)
 
             assertEquals(150.px, width)
             assertEquals(100.px, height)

--- a/quarkdown-core/src/test/resources/parsing/fencescode.md
+++ b/quarkdown-core/src/test/resources/parsing/fencescode.md
@@ -69,3 +69,8 @@ Code line 2
 Code line 1
 Code line 2
 ```
+
+```text "A *formatted caption*"
+Code line 1
+Code line 2
+```

--- a/quarkdown-core/src/test/resources/parsing/figure.md
+++ b/quarkdown-core/src/test/resources/parsing/figure.md
@@ -15,3 +15,5 @@
 !(_*10px)[Label](/url)
 
 ![Label](/url) {#custom-id}
+
+![Label](/url "A *formatted caption*")

--- a/quarkdown-core/src/test/resources/parsing/table.md
+++ b/quarkdown-core/src/test/resources/parsing/table.md
@@ -50,3 +50,8 @@ bar | baz
 | G H I | J K L |
 | M N O | P Q R |
 "Table caption" {#custom-id}
+
+| A B C | D E F |
+|-------|-------|
+| G H I | J K L |
+"A *formatted caption*"

--- a/quarkdown-html/src/main/kotlin/com/quarkdown/rendering/html/node/BaseHtmlNodeRenderer.kt
+++ b/quarkdown-html/src/main/kotlin/com/quarkdown/rendering/html/node/BaseHtmlNodeRenderer.kt
@@ -264,7 +264,7 @@ open class BaseHtmlNodeRenderer(
     private fun buildLinkTag(node: Link): HtmlTagBuilder =
         tagBuilder("a", node.label)
             .attribute("href", node.url)
-            .optionalAttribute("title", node.title)
+            .optionalAttribute("title", node.title?.toPlainText(renderer = this))
 
     override fun visit(node: Link) = buildLinkTag(node).build()
 
@@ -322,7 +322,7 @@ open class BaseHtmlNodeRenderer(
         tagBuilder("img")
             .attribute("src", node.link.getStoredMedia(context)?.path ?: node.link.getResolvedUrl(context))
             .attribute("alt", node.link.label.toPlainText(renderer = this)) // Emphasis is discarded (CommonMark 6.4)
-            .optionalAttribute("title", node.link.title)
+            .optionalAttribute("title", node.link.title?.toPlainText(renderer = this))
             .style {
                 "width" value node.width
                 "height" value node.height

--- a/quarkdown-html/src/main/kotlin/com/quarkdown/rendering/html/node/QuarkdownHtmlNodeRenderer.kt
+++ b/quarkdown-html/src/main/kotlin/com/quarkdown/rendering/html/node/QuarkdownHtmlNodeRenderer.kt
@@ -161,7 +161,7 @@ class QuarkdownHtmlNodeRenderer(
                 withLocationLabel(node)
                 withLocalizedKind(node)
 
-                node.caption?.let { +escapeCriticalContent(it) }
+                node.caption?.let { +it }
             }
         }
 

--- a/quarkdown-html/src/test/kotlin/com/quarkdown/rendering/html/HtmlNodeRendererTest.kt
+++ b/quarkdown-html/src/test/kotlin/com/quarkdown/rendering/html/HtmlNodeRendererTest.kt
@@ -143,7 +143,7 @@ class HtmlNodeRendererTest {
         )
         assertEquals(
             out.next(),
-            Link(label = listOf(Text("Foo bar baz")), url = "url", title = "Title").render(),
+            Link(label = listOf(Text("Foo bar baz")), url = "url", title = listOf(Text("Title"))).render(),
         )
     }
 
@@ -160,14 +160,14 @@ class HtmlNodeRendererTest {
         // Resolved: label matches the reference, definition is set.
         val resolved =
             ReferenceLink(label, label, fallback).also {
-                it.setDefinition(context, Link(it.label, "/url", "Title"))
+                it.setDefinition(context, Link(it.label, "/url", listOf(Text("Title"))))
             }
         assertEquals(out.next(), resolved.render(context))
 
         // Resolved: different display label, same reference label.
         val resolvedDifferentLabel =
             ReferenceLink(listOf(Text("label")), label, fallback).also {
-                it.setDefinition(context, Link(it.label, "/url", "Title"))
+                it.setDefinition(context, Link(it.label, "/url", listOf(Text("Title"))))
             }
         assertEquals(out.next(), resolvedDifferentLabel.render(context))
 
@@ -193,7 +193,7 @@ class HtmlNodeRendererTest {
         assertEquals(
             out.next(),
             Image(
-                Link(label = listOf(), url = "/url", title = "Title"),
+                Link(label = listOf(), url = "/url", title = listOf(Text("Title"))),
                 width = null,
                 height = null,
             ).render(),
@@ -209,7 +209,7 @@ class HtmlNodeRendererTest {
         assertEquals(
             out.next(),
             Image(
-                Link(label = buildInline { text("Foo bar") }, url = "/url", title = "Title"),
+                Link(label = buildInline { text("Foo bar") }, url = "/url", title = listOf(Text("Title"))),
                 width = 3.2.cm,
                 height = null,
             ).render(),
@@ -228,7 +228,7 @@ class HtmlNodeRendererTest {
 
         fun resolvedRefLink(displayLabel: InlineContent) =
             ReferenceLink(displayLabel, label, fallback).also {
-                it.setDefinition(context, Link(displayLabel, "/url", "Title"))
+                it.setDefinition(context, Link(displayLabel, "/url", listOf(Text("Title"))))
             }
 
         assertEquals(
@@ -277,7 +277,7 @@ class HtmlNodeRendererTest {
             out.next(),
             ImageFigure(
                 Image(
-                    Link(label = listOf(), url = "/url", title = ""),
+                    Link(label = listOf(), url = "/url", title = listOf(Text(""))),
                     width = null,
                     height = null,
                 ),
@@ -287,7 +287,7 @@ class HtmlNodeRendererTest {
             out.next(),
             ImageFigure(
                 Image(
-                    Link(label = listOf(), url = "/url", title = "Title"),
+                    Link(label = listOf(), url = "/url", title = listOf(Text("Title"))),
                     width = null,
                     height = null,
                 ),
@@ -297,7 +297,7 @@ class HtmlNodeRendererTest {
             out.next(),
             ImageFigure(
                 Image(
-                    Link(label = listOf(), url = "/url", title = "Title"),
+                    Link(label = listOf(), url = "/url", title = listOf(Text("Title"))),
                     width = 150.px,
                     height = 100.px,
                 ),
@@ -463,7 +463,7 @@ class HtmlNodeRendererTest {
         )
         assertEquals(
             out.next(),
-            Code("class Point {\n    ...\n}", language = "java", caption = "A Java code example.").render(),
+            Code("class Point {\n    ...\n}", language = "java", caption = listOf(Text("A Java code example."))).render(),
         )
     }
 
@@ -768,7 +768,7 @@ class HtmlNodeRendererTest {
                             ),
                     ),
                 ),
-                caption = "Table 'caption'.",
+                caption = listOf(Text("Table 'caption'.")),
             ).render(),
         )
     }

--- a/quarkdown-plaintext/src/main/kotlin/com/quarkdown/rendering/plaintext/node/PlainTextNodeRenderer.kt
+++ b/quarkdown-plaintext/src/main/kotlin/com/quarkdown/rendering/plaintext/node/PlainTextNodeRenderer.kt
@@ -295,7 +295,7 @@ class PlainTextNodeRenderer(
 
                 // If no label is available, use the caption if possible.
                 is CaptionableNode if definition.caption != null -> {
-                    definition.caption!!
+                    definition.caption!!.visitAll()
                 }
 
                 // Fallback: use the target's text if possible.

--- a/quarkdown-plaintext/src/test/kotlin/com/quarkdown/rendering/plaintext/PlainTextNodeRendererTest.kt
+++ b/quarkdown-plaintext/src/test/kotlin/com/quarkdown/rendering/plaintext/PlainTextNodeRendererTest.kt
@@ -111,7 +111,7 @@ class PlainTextNodeRendererTest {
             LinkDefinition(
                 label = buildInline { text("example") },
                 url = "https://example.com",
-                title = "Example",
+                title = listOf(Text("Example")),
             ).render(),
         )
     }

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Data.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Data.kt
@@ -2,6 +2,7 @@ package com.quarkdown.stdlib
 
 import com.github.doyaaaaaken.kotlincsv.dsl.csvReader
 import com.quarkdown.core.ast.InlineContent
+import com.quarkdown.core.ast.InlineMarkdownContent
 import com.quarkdown.core.ast.base.block.Table
 import com.quarkdown.core.ast.dsl.buildInline
 import com.quarkdown.core.context.Context
@@ -276,7 +277,7 @@ fun csv(
     @Injected context: Context,
     path: String,
     @LikelyNamed mode: CsvParsingMode = CsvParsingMode.PLAIN,
-    @LikelyNamed caption: String? = null,
+    @LikelyNamed caption: InlineMarkdownContent? = null,
     @Name("ref") referenceId: String? = null,
 ): NodeValue {
     val file = file(context, path)
@@ -308,7 +309,7 @@ fun csv(
 
     return Table(
         columns = columns.map { it.toColumn() },
-        caption = caption,
+        caption = caption?.children,
         referenceId = referenceId,
     ).wrappedAsValue()
 }

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Mermaid.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Mermaid.kt
@@ -1,5 +1,7 @@
 package com.quarkdown.stdlib
 
+import com.quarkdown.core.ast.InlineContent
+import com.quarkdown.core.ast.InlineMarkdownContent
 import com.quarkdown.core.ast.quarkdown.block.Figure
 import com.quarkdown.core.ast.quarkdown.block.MermaidDiagram
 import com.quarkdown.core.ast.quarkdown.block.SubdocumentGraph
@@ -30,7 +32,7 @@ val Mermaid: QuarkdownModule =
     )
 
 private fun mermaidFigure(
-    caption: String?,
+    caption: InlineContent?,
     referenceId: String? = null,
     code: String,
 ) = Figure<MermaidDiagram>(
@@ -64,11 +66,11 @@ private fun mermaidFigure(
  * @return a new [Figure] node
  */
 fun mermaid(
-    @LikelyNamed caption: String? = null,
+    @LikelyNamed caption: InlineMarkdownContent? = null,
     @Name("ref") referenceId: String? = null,
     @LikelyBody code: EvaluableString,
 ) = mermaidFigure(
-    caption = caption,
+    caption = caption?.children,
     referenceId = referenceId,
     code = code.content,
 )
@@ -201,7 +203,7 @@ fun xyChart(
     @Name("xtags") xAxisTags: Iterable<Value<*>>? = null,
     @Name("y") yAxisLabel: String? = null,
     @Name("yrange") yAxisRange: Range? = null,
-    @LikelyNamed caption: String? = null,
+    @LikelyNamed caption: InlineMarkdownContent? = null,
     @Name("ref") referenceId: String? = null,
     @LikelyBody values: Iterable<OutputValue<*>>,
 ): NodeValue {
@@ -229,7 +231,7 @@ fun xyChart(
         }
 
     val code = "xychart-beta\n" + content.indent("\t")
-    return mermaidFigure(caption = caption, referenceId = referenceId, code = code)
+    return mermaidFigure(caption = caption?.children, referenceId = referenceId, code = code)
 }
 
 /**

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Primitives.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Primitives.kt
@@ -88,18 +88,18 @@ fun pageBreak() = PageBreak().wrappedAsValue()
  *
  * If either [caption] or [referenceId] is set, the figure will be numbered according to the `figures` [numbering] rule.
  *
- * @param caption optional caption of the figure
+ * @param caption optional inline caption of the figure
  * @param referenceId optional ID for cross-referencing via [reference]
  * @param body content of the figure
  * @return the new [Figure] node
  */
 fun figure(
-    @LikelyNamed caption: String? = null,
+    @LikelyNamed caption: InlineMarkdownContent? = null,
     @Name("ref") referenceId: String? = null,
     @LikelyBody body: MarkdownContent,
 ): NodeValue =
     Figure<MarkdownContent>(
         body,
-        caption = caption,
+        caption = caption?.children,
         referenceId = referenceId,
     ).wrappedAsValue()

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Text.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Text.kt
@@ -113,7 +113,7 @@ fun lineBreak() = LineBreak.wrappedAsValue()
  */
 fun code(
     @Name("lang") language: String? = null,
-    @LikelyNamed caption: String? = null,
+    @LikelyNamed caption: InlineMarkdownContent? = null,
     @Name("linenumbers") showLineNumbers: Boolean = true,
     @Name("focus") focusedLines: Range? = null,
     @Name("ref") referenceId: String? = null,
@@ -124,7 +124,7 @@ fun code(
         language = language,
         showLineNumbers = showLineNumbers,
         focusedLines = focusedLines,
-        caption = caption,
+        caption = caption?.children,
         referenceId = referenceId,
     ).wrappedAsValue()
 

--- a/quarkdown-test/src/test/kotlin/com/quarkdown/test/CaptionTest.kt
+++ b/quarkdown-test/src/test/kotlin/com/quarkdown/test/CaptionTest.kt
@@ -8,6 +8,19 @@ import kotlin.test.assertEquals
  * Tests for [com.quarkdown.core.ast.quarkdown.CaptionableNode]s.
  */
 class CaptionTest {
+    companion object {
+        /**
+         * A Quarkdown source caption with inline formatting: small-caps text and emphasis.
+         */
+        private const val FORMATTED_CAPTION_SOURCE = "\'A .text {formatted} variant:{smallcaps} *caption*\'"
+
+        /**
+         * The expected HTML rendering of [FORMATTED_CAPTION_SOURCE].
+         */
+        private const val FORMATTED_CAPTION_HTML =
+            "&lsquo;A <span style=\"font-variant: small-caps;\">formatted</span> <em>caption</em>&rsquo;"
+    }
+
     @Test
     fun figure() {
         execute(
@@ -112,6 +125,106 @@ class CaptionTest {
             assertEquals(
                 "<figure><pre><code class=\"language-javascript\">console.log(&quot;Hello, world!&quot;);</code></pre>" +
                     "<figcaption class=\"caption-bottom\">Logging code</figcaption></figure>",
+                it,
+            )
+        }
+    }
+
+    @Test
+    fun `figure, formatted caption`() {
+        execute(
+            """
+            ![](https://example.com/image.png "$FORMATTED_CAPTION_SOURCE")
+            """.trimIndent(),
+        ) {
+            assertEquals(
+                "<figure><img src=\"https://example.com/image.png\" alt=\"\"" +
+                    " title=\"&lsquo;A formatted caption&rsquo;\" />" +
+                    "<figcaption class=\"caption-bottom\">$FORMATTED_CAPTION_HTML</figcaption></figure>",
+                it,
+            )
+        }
+    }
+
+    @Test
+    fun `figure via function, formatted caption`() {
+        execute(
+            """
+            .figure caption:{$FORMATTED_CAPTION_SOURCE}
+                Hello
+            """.trimIndent(),
+        ) {
+            assertEquals(
+                "<figure><p>Hello</p>" +
+                    "<figcaption class=\"caption-bottom\"><p>$FORMATTED_CAPTION_HTML</p></figcaption></figure>",
+                it,
+            )
+        }
+    }
+
+    @Test
+    fun `table, formatted caption`() {
+        execute(
+            """
+            | Header 1 | Header 2 |
+            |----------|----------|
+            | Cell 1   | Cell 2   |
+            "$FORMATTED_CAPTION_SOURCE"
+            """.trimIndent(),
+        ) {
+            assertEquals(
+                "<table><thead><tr><th>Header 1</th><th>Header 2</th></tr></thead>" +
+                    "<tbody><tr><td>Cell 1</td><td>Cell 2</td></tr></tbody>" +
+                    "<caption class=\"caption-bottom\">$FORMATTED_CAPTION_HTML</caption></table>",
+                it,
+            )
+        }
+    }
+
+    @Test
+    fun `code block, formatted caption`() {
+        execute(
+            """
+            ```javascript "$FORMATTED_CAPTION_SOURCE"
+            console.log("Hello, world!");
+            ```
+            """.trimIndent(),
+        ) {
+            assertEquals(
+                "<figure><pre><code class=\"language-javascript\">console.log(&quot;Hello, world!&quot;);</code></pre>" +
+                    "<figcaption class=\"caption-bottom\">$FORMATTED_CAPTION_HTML</figcaption></figure>",
+                it,
+            )
+        }
+    }
+
+    @Test
+    fun `code block from function, formatted caption`() {
+        execute(
+            """
+            .code lang:{javascript} caption:{$FORMATTED_CAPTION_SOURCE}
+                console.log("Hello, world!");
+            """.trimIndent(),
+        ) {
+            assertEquals(
+                "<figure><pre><code class=\"language-javascript\">console.log(&quot;Hello, world!&quot;);</code></pre>" +
+                    "<figcaption class=\"caption-bottom\"><p>$FORMATTED_CAPTION_HTML</p></figcaption></figure>",
+                it,
+            )
+        }
+    }
+
+    @Test
+    fun `mermaid, formatted caption`() {
+        execute(
+            """
+            .mermaid caption:{$FORMATTED_CAPTION_SOURCE}
+                graph TD
+            """.trimIndent(),
+        ) {
+            assertEquals(
+                "<figure><pre class=\"mermaid\">graph TD</pre>" +
+                    "<figcaption class=\"caption-bottom\"><p>$FORMATTED_CAPTION_HTML</p></figcaption></figure>",
                 it,
             )
         }


### PR DESCRIPTION
All captions now accept inline formatting rather than plain text.

```markdown
![Pi](pi.png "The symbol of *pi*, which approximately equals .pi")
```

![image.png](https://app.graphite.com/user-attachments/assets/ebaea26f-d206-455d-9ec4-00fa9e11bd05.png)

Closes #368
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/iamgio/quarkdown/pull/410" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
