### PR TITLE
feat: add nameless identity function

### DIFF
--- a/docs/syntax-of-a-function-call.qd
+++ b/docs/syntax-of-a-function-call.qd
@@ -98,6 +98,18 @@ You can append additional arguments to any function in the chain. Just keep in m
 
 Many core functions are designed to be called in a chain, for example [`None` operations](none.qd#examples).
 
+### Identity function
+
+A nameless function call uses the syntax `.{value}`, omitting the function name entirely. It acts as an identity function, passing its argument through unchanged. This is especially useful as a starting point for a chain when you want to begin with a literal value:
+
+.examplemirror
+    .{30}::multiply {2}
+
+.examplemirror
+    .{Hello}::text variant:{smallcaps}
+
+Without the nameless call, you would need to either use a variable or nest the calls manually.
+
 ## Tight function calls
 
 A function call must normally be surrounded by whitespace, a symbol, or the beginning or end of a line. This means that a call directly adjacent to a word character is not recognized:

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/lexer/patterns/FunctionCallPatterns.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/lexer/patterns/FunctionCallPatterns.kt
@@ -24,9 +24,10 @@ class FunctionCallPatterns {
             wrap = { error("Inline function call tokens are constructed by the walker") },
             // The name of the function prefixed by a dot.
             regex =
-                RegexBuilder("(?:(?<=before)(?=call))|(?:(?=wrapcall))")
+                RegexBuilder("(?:(?<=before)(?=call))|(?:(?<=before)(?=beginarg))|(?:(?=wrapcall))|(?:(?=wrapbeginarg))")
                     .withReference("before", FUNCTION_CALL_PATTERN_BEFORE)
                     .withReference("call", "begin(name)")
+                    .withReference("beginarg", "begin" + Regex.escape(FunctionCallGrammar.ARGUMENT_BEGIN.toString()))
                     .withReference("wrap", Regex.escape(FunctionCallGrammar.ARGUMENT_BEGIN.toString()))
                     .withReference("begin", Regex.escape(FunctionCallGrammar.BEGIN.toString()))
                     .withReference("name", FunctionCallGrammar.IDENTIFIER_PATTERN)

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/parser/walker/funcall/FunctionCallGrammar.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/parser/walker/funcall/FunctionCallGrammar.kt
@@ -241,31 +241,41 @@ class FunctionCallGrammar(
         }
 
     /**
-     * Parses a single function call.
-     * A function call consists of a function name, inline arguments and an optional body argument.
+     * Parses the arguments and optional body of a function call, shared by both [namedCallParser] and [namelessCallParser].
      */
-    private val callParser =
-        (
-            // Function name.
-            identifier and
-                // Inline arguments.
-                zeroOrMore(argumentParser) and
-                // Body argument.
-                optional(-optional(whitespace) and bodyArgumentParser)
-        ) map { (id, args, body) ->
-            WalkedFunctionCall(
-                id.text,
-                args,
-                body,
-            )
+    private val argumentsParser =
+        // Inline arguments.
+        zeroOrMore(argumentParser) and
+            // Body argument.
+            optional(-optional(whitespace) and bodyArgumentParser)
+
+    /**
+     * Parses a named function call, where the function name is required.
+     * This is used for chained calls (after `::`) where a name is mandatory.
+     */
+    private val namedCallParser =
+        (identifier and argumentsParser) map { (id, argsAndBody) ->
+            val (args, body) = argsAndBody
+            WalkedFunctionCall(id.text, args, body)
+        }
+
+    /**
+     * Parses a nameless (identity) function call, where the function name is omitted (e.g. `.{value}`).
+     * This is only allowed as the first call in a chain, not after `::`.
+     */
+    private val namelessCallParser =
+        argumentsParser map { (args, body) ->
+            WalkedFunctionCall("", args, body)
         }
 
     /**
      * Parses a chain of function calls, separated by [chainSeparator].
+     * The first call in the chain may be nameless (e.g. `.{value}::bar`),
+     * but subsequent calls after `::` must have a name.
      * The result is an ordered linked list of [WalkedFunctionCall]s, and the first of them is returned.
      */
     private val chainCallParser =
-        callParser and zeroOrMore(-chainSeparator and callParser) map { (first, rest) ->
+        (namedCallParser or namelessCallParser) and zeroOrMore(-chainSeparator and namedCallParser) map { (first, rest) ->
             var current = first
             for (next in rest) {
                 current.next = next

--- a/quarkdown-core/src/test/kotlin/com/quarkdown/core/BlockParserTest.kt
+++ b/quarkdown-core/src/test/kotlin/com/quarkdown/core/BlockParserTest.kt
@@ -1222,6 +1222,21 @@ class BlockParserTest {
                 )
             }
         }
+
+        // Nameless (identity) function calls.
+
+        with(nodes.next()) {
+            assertEquals("", name)
+            assertEquals(1, arguments.size)
+            assertEquals("hello", arguments[0].value.unwrappedValue)
+        }
+
+        with(nodes.next()) {
+            assertEquals("", name)
+            assertEquals(2, arguments.size)
+            assertEquals("arg1", arguments[0].value.unwrappedValue)
+            assertEquals("arg2", arguments[1].value.unwrappedValue)
+        }
     }
 
     /**
@@ -1314,6 +1329,50 @@ class BlockParserTest {
             assertEquals("bar", (arguments.first().expression as UncheckedFunctionCall<*>).name)
         }
 
+        // .{x}::bar {y}
+        with(nodes.next()) {
+            assertEquals("bar", name)
+            assertEquals(2, arguments.size)
+            assertEquals("", (arguments.first().expression as UncheckedFunctionCall<*>).name)
+            assertEquals("y", arguments[1].value.unwrappedValue)
+        }
+
+        // .{10}::multiply {2}::sum {5}
+        with(nodes.next()) {
+            assertEquals("sum", name)
+            assertEquals(2, arguments.size)
+            assertEquals("5", arguments[1].value.unwrappedValue)
+            val multiply = arguments.first().expression as UncheckedFunctionCall<*>
+            assertEquals("multiply", multiply.name)
+        }
+
         assertFalse(nodes.hasNext())
+    }
+
+    /**
+     * Verifies that nameless (identity) function calls are parsed correctly
+     * as inline function calls within paragraphs.
+     */
+    @Test
+    fun namelessInlineFunctionCall() {
+        // Nameless call between text.
+        with(blocksIterator<Paragraph>("hello .{x} world").next()) {
+            val children = children.iterator()
+            assertEquals("hello ", assertIs<Text>(children.next()).text)
+            with(assertIs<FunctionCallNode>(children.next())) {
+                assertEquals("", name)
+                assertEquals(1, arguments.size)
+                assertEquals("x", arguments[0].value.unwrappedValue)
+            }
+            assertEquals(" world", assertIs<Text>(children.next()).text)
+            assertFalse(children.hasNext())
+        }
+
+        // Wrapped nameless call.
+        with(blocksIterator<FunctionCallNode>("{.{x}}").next()) {
+            assertEquals("", name)
+            assertEquals(1, arguments.size)
+            assertEquals("x", arguments[0].value.unwrappedValue)
+        }
     }
 }

--- a/quarkdown-core/src/test/kotlin/com/quarkdown/core/LexerTest.kt
+++ b/quarkdown-core/src/test/kotlin/com/quarkdown/core/LexerTest.kt
@@ -672,6 +672,50 @@ class LexerTest {
             assertEquals("bar", value.next!!.name)
             assertEquals(1, value.next!!.arguments.size)
         }
+
+        // Nameless (identity) function calls.
+
+        with(walk(".{x}")) {
+            assertEquals("", value.name)
+            assertEquals(".{x}".length, endIndex)
+            with(value.arguments.single()) {
+                assertEquals("x", value)
+                assertNull(name)
+            }
+        }
+
+        with(walk(".{x} {y}")) {
+            assertEquals("", value.name)
+            assertEquals("x", value.arguments[0].value)
+            assertEquals("y", value.arguments[1].value)
+        }
+
+        with(walk(".{x}::bar {y}")) {
+            assertEquals("", value.name)
+            assertEquals(1, value.arguments.size)
+            assertEquals("bar", value.next!!.name)
+            assertEquals(1, value.next!!.arguments.size)
+        }
+
+        // Trailing `::` should not produce a nameless chained call.
+        with(walk(".foo::")) {
+            assertEquals("foo", value.name)
+            assertNull(value.next)
+            // The `::` is not consumed: the walker stops at the end of the named call.
+            assertEquals(".foo".length, endIndex)
+        }
+
+        with(walk(".{x}::bar {y}::baz {z}")) {
+            assertEquals("", value.name)
+            assertEquals("bar", value.next!!.name)
+            assertEquals("baz", value.next!!.next!!.name)
+        }
+
+        with(walk("{.{x}}")) {
+            assertEquals("", value.name)
+            assertEquals("{.{x}}".length, endIndex)
+            assertEquals("x", value.arguments.single().value)
+        }
     }
 
     /**
@@ -850,5 +894,51 @@ class LexerTest {
         assertEquals("first", tokens[0].walkerResult.value.name)
         assertEquals("second", tokens[1].walkerResult.value.name)
         assertEquals("third", tokens[2].walkerResult.value.name)
+    }
+
+    /**
+     * Verifies that nameless (identity) function calls are tokenized correctly at the inline level.
+     */
+    @Test
+    fun namelessInlineFunctionCall() {
+        with(inlineLex(".{x}")) {
+            assertIs<FunctionCallToken>(next())
+            assertFalse(hasNext())
+        }
+
+        with(inlineLex("hello .{x} world")) {
+            assertIs<PlainTextToken>(next())
+            assertIs<FunctionCallToken>(next())
+            assertIs<PlainTextToken>(next())
+            assertFalse(hasNext())
+        }
+
+        with(inlineLex("{.{x}}")) {
+            assertIs<FunctionCallToken>(next())
+            assertFalse(hasNext())
+        }
+    }
+
+    /**
+     * Verifies that nameless (identity) function calls are tokenized correctly at the block level.
+     */
+    @Test
+    fun namelessBlockFunctionCall() {
+        val tokens =
+            blockLexer(".{hello}")
+                .tokenize()
+                .filterIsInstance<FunctionCallToken>()
+                .toList()
+
+        assertEquals(1, tokens.size)
+        with(tokens.single()) {
+            assertEquals("", walkerResult.value.name)
+            assertEquals(
+                "hello",
+                walkerResult.value.arguments
+                    .single()
+                    .value,
+            )
+        }
     }
 }

--- a/quarkdown-core/src/test/resources/parsing/functioncall-chain.md
+++ b/quarkdown-core/src/test/resources/parsing/functioncall-chain.md
@@ -3,3 +3,7 @@
 .foo {x}::bar name:{y}
 
 .foo {x}::bar {y}::baz {z}
+
+.{x}::bar {y}
+
+.{10}::multiply {2}::sum {5}

--- a/quarkdown-core/src/test/resources/parsing/functioncall.md
+++ b/quarkdown-core/src/test/resources/parsing/functioncall.md
@@ -43,3 +43,7 @@ not body
 
 .function {arg{1} arg} { { arg2 } }
     body content
+
+.{hello}
+
+.{arg1} {arg2}

--- a/quarkdown-lsp/src/main/kotlin/com/quarkdown/lsp/cache/CacheableFunctionCatalogue.kt
+++ b/quarkdown-lsp/src/main/kotlin/com/quarkdown/lsp/cache/CacheableFunctionCatalogue.kt
@@ -63,5 +63,5 @@ object CacheableFunctionCatalogue {
         nameQuery: String,
     ): Sequence<DocumentedFunction> =
         getCatalogue(docsDirectory)
-            .filter { it.data.name.startsWith(nameQuery, ignoreCase = true) }
+            .filter { it.data.name.isNotEmpty() && it.data.name.startsWith(nameQuery, ignoreCase = true) }
 }

--- a/quarkdown-lsp/src/test/kotlin/com/quarkdown/lsp/FunctionCallTokenizerTest.kt
+++ b/quarkdown-lsp/src/test/kotlin/com/quarkdown/lsp/FunctionCallTokenizerTest.kt
@@ -249,4 +249,86 @@ class FunctionCallTokenizerTest {
         assertNotNull(paramNameToken)
         assertEquals("param", paramNameToken.lexeme)
     }
+
+    @Test
+    fun `nameless function call`() {
+        val text = ".{hello}"
+        val calls = tokenizer.getFunctionCalls(text)
+
+        assertEquals(1, calls.size)
+
+        val call = calls.first()
+        assertEquals(0..text.length, call.range)
+
+        // No FUNCTION_NAME token should be present.
+        val nameToken = call.tokens.find { it.type == FunctionCallToken.Type.FUNCTION_NAME }
+        assertEquals(null, nameToken)
+
+        // The BEGIN token is still present.
+        val beginToken = call.tokens.find { it.type == FunctionCallToken.Type.BEGIN }
+        assertNotNull(beginToken)
+        assertEquals(0..1, beginToken.range)
+
+        // The argument is tokenized normally.
+        val argValueToken = call.tokens.find { it.type == FunctionCallToken.Type.INLINE_ARGUMENT_VALUE }
+        assertNotNull(argValueToken)
+        assertEquals("hello", argValueToken.lexeme)
+    }
+
+    @Test
+    fun `nameless function call with chaining`() {
+        val text = ".{x}::bar {y}"
+        val calls = tokenizer.getFunctionCalls(text)
+
+        assertEquals(1, calls.size)
+
+        val call = calls.first()
+        val tokens = call.tokens.iterator()
+
+        assertEquals(FunctionCallToken.Type.BEGIN, tokens.next().type)
+        // No FUNCTION_NAME for the nameless part — argument follows directly.
+        assertEquals(FunctionCallToken.Type.INLINE_ARGUMENT_BEGIN, tokens.next().type)
+        assertEquals(FunctionCallToken.Type.INLINE_ARGUMENT_VALUE, tokens.next().type)
+        assertEquals(FunctionCallToken.Type.INLINE_ARGUMENT_END, tokens.next().type)
+        assertEquals(FunctionCallToken.Type.CHAINING_SEPARATOR, tokens.next().type)
+        // The chained function has a name.
+        with(tokens.next()) {
+            assertEquals(FunctionCallToken.Type.FUNCTION_NAME, type)
+            assertEquals("bar", lexeme)
+        }
+        assertEquals(FunctionCallToken.Type.INLINE_ARGUMENT_BEGIN, tokens.next().type)
+        assertEquals(FunctionCallToken.Type.INLINE_ARGUMENT_VALUE, tokens.next().type)
+        assertEquals(FunctionCallToken.Type.INLINE_ARGUMENT_END, tokens.next().type)
+        assertFalse(tokens.hasNext())
+    }
+
+    @Test
+    fun `nameless function call in text`() {
+        val text = "hello .{world} goodbye"
+        val calls = tokenizer.getFunctionCalls(text)
+
+        assertEquals(1, calls.size)
+
+        val call = calls.first()
+        val nameToken = call.tokens.find { it.type == FunctionCallToken.Type.FUNCTION_NAME }
+        assertEquals(null, nameToken)
+
+        val argValueToken = call.tokens.find { it.type == FunctionCallToken.Type.INLINE_ARGUMENT_VALUE }
+        assertNotNull(argValueToken)
+        assertEquals("world", argValueToken.lexeme)
+    }
+
+    @Test
+    fun `wrapped nameless function call`() {
+        val text = "{.{x}}"
+        val calls = tokenizer.getFunctionCalls(text)
+
+        assertEquals(1, calls.size)
+
+        val call = calls.first()
+        assertEquals(0..text.length, call.range)
+
+        val nameToken = call.tokens.find { it.type == FunctionCallToken.Type.FUNCTION_NAME }
+        assertEquals(null, nameToken)
+    }
 }

--- a/quarkdown-lsp/src/test/kotlin/com/quarkdown/lsp/FunctionCallTokensSupplierTest.kt
+++ b/quarkdown-lsp/src/test/kotlin/com/quarkdown/lsp/FunctionCallTokensSupplierTest.kt
@@ -414,4 +414,54 @@ class FunctionCallTokensSupplierTest {
             assertNext(TYPE_INLINE_ARGUMENT_DELIMITER, 14..15) // Wrap close
         }
     }
+
+    // Nameless (identity) function calls
+
+    @Test
+    fun `nameless function call with one positional argument`() {
+        tokenize(".{hello}") {
+            assertNext(TYPE_BEGIN, 0..1) // '.'
+            // No name token — argument follows directly.
+            assertNext(TYPE_INLINE_ARGUMENT_DELIMITER, 1..2) // '{'
+            assertNext(TokenType.ENUM, 2..7) // 'hello'
+            assertNext(TYPE_INLINE_ARGUMENT_DELIMITER, 7..8) // '}'
+        }
+    }
+
+    @Test
+    fun `nameless function call in surrounding text`() {
+        tokenize("text .{42} text") {
+            assertNext(TYPE_BEGIN, 5..6) // '.'
+            assertNext(TYPE_INLINE_ARGUMENT_DELIMITER, 6..7) // '{'
+            assertNext(TokenType.NUMBER, 7..9) // '42'
+            assertNext(TYPE_INLINE_ARGUMENT_DELIMITER, 9..10) // '}'
+        }
+    }
+
+    @Test
+    fun `nameless function call chained with named function`() {
+        tokenize(".{10}::multiply {2}") {
+            assertNext(TYPE_BEGIN, 0..1) // '.'
+            assertNext(TYPE_INLINE_ARGUMENT_DELIMITER, 1..2) // '{'
+            assertNext(TokenType.NUMBER, 2..4) // '10'
+            assertNext(TYPE_INLINE_ARGUMENT_DELIMITER, 4..5) // '}'
+            assertNext(TYPE_CHAINING_SEPARATOR, 5..7) // '::'
+            assertNext(TYPE_NAME, 7..15) // 'multiply'
+            assertNext(TYPE_INLINE_ARGUMENT_DELIMITER, 16..17) // '{'
+            assertNext(TokenType.NUMBER, 17..18) // '2'
+            assertNext(TYPE_INLINE_ARGUMENT_DELIMITER, 18..19) // '}'
+        }
+    }
+
+    @Test
+    fun `wrapped nameless function call`() {
+        tokenize("{.{x}}") {
+            assertNext(TYPE_INLINE_ARGUMENT_DELIMITER, 0..1) // Wrap open '{'
+            assertNext(TYPE_BEGIN, 1..2) // '.'
+            assertNext(TYPE_INLINE_ARGUMENT_DELIMITER, 2..3) // '{'
+            assertNext(TokenType.ENUM, 3..4) // 'x'
+            assertNext(TYPE_INLINE_ARGUMENT_DELIMITER, 4..5) // '}'
+            assertNext(TYPE_INLINE_ARGUMENT_DELIMITER, 5..6) // Wrap close '}'
+        }
+    }
 }

--- a/quarkdown-lsp/src/test/kotlin/com/quarkdown/lsp/FunctionCompletionSupplierTest.kt
+++ b/quarkdown-lsp/src/test/kotlin/com/quarkdown/lsp/FunctionCompletionSupplierTest.kt
@@ -18,6 +18,12 @@ private const val CLIP_FUNCTION = "clip"
 private const val COLUMN_FUNCTION = "column"
 private const val CSV_FUNCTION = "csv"
 
+/**
+ * Total number of named documented functions in the test resources.
+ * The identity function (empty name) is excluded from completions.
+ */
+private const val NAMED_FUNCTION_COUNT = 4
+
 private const val LAYOUT_MODULE = "Layout"
 private const val DATA_MODULE = "Data"
 
@@ -69,10 +75,11 @@ class FunctionCompletionSupplierTest {
     fun `completions at beginning of function call`() {
         val text = "hello ."
         val completions = getCompletions(text, Position(0, text.length))
-        assertEquals(4, completions.size)
+        assertEquals(NAMED_FUNCTION_COUNT, completions.size)
 
-        // Verifies the expected function names are present.
+        // Verifies the expected function names are present and the identity function is excluded.
         val labels = completions.map { it.label }.toSet()
+        assertFalse("" in labels)
         assertContains(labels, ALIGN_FUNCTION)
         assertContains(labels, CLIP_FUNCTION)
         assertContains(labels, COLUMN_FUNCTION)
@@ -125,14 +132,14 @@ class FunctionCompletionSupplierTest {
     fun `name completion in chain for empty name`() {
         val text = "hello .$ALIGN_FUNCTION::"
         val completions = getCompletions(text, Position(0, text.length))
-        assertEquals(4, completions.size)
+        assertEquals(NAMED_FUNCTION_COUNT, completions.size)
     }
 
     @Test
     fun `name completion in chain with args`() {
         val text = "hello .$ALIGN_FUNCTION {arg}::"
         val completions = getCompletions(text, Position(0, text.length))
-        assertEquals(4, completions.size)
+        assertEquals(NAMED_FUNCTION_COUNT, completions.size)
     }
 
     @Test
@@ -151,7 +158,7 @@ class FunctionCompletionSupplierTest {
         val suffix = " abc"
         val text = "hello .$ALIGN_FUNCTION::$suffix"
         val completions = getCompletions(text, Position(0, text.length - suffix.length))
-        assertEquals(4, completions.size)
+        assertEquals(NAMED_FUNCTION_COUNT, completions.size)
     }
 
     @Test
@@ -304,7 +311,7 @@ class FunctionCompletionSupplierTest {
     fun `name completions in wrapped function call`() {
         val text = "hello{."
         val completions = getCompletions(text, Position(0, text.length))
-        assertEquals(4, completions.size)
+        assertEquals(NAMED_FUNCTION_COUNT, completions.size)
     }
 
     @Test

--- a/quarkdown-lsp/src/test/kotlin/com/quarkdown/lsp/FunctionDocumentationHoverSupplierTest.kt
+++ b/quarkdown-lsp/src/test/kotlin/com/quarkdown/lsp/FunctionDocumentationHoverSupplierTest.kt
@@ -121,4 +121,37 @@ class FunctionDocumentationHoverSupplierTest {
         // Position on "hello" before the wrap.
         assertNull(getHover(text, Position(0, 2)))
     }
+
+    // Nameless (identity) function calls
+
+    @Test
+    fun `hover over nameless function call shows identity documentation`() {
+        val text = "hello .{world} bye"
+        val position = Position(0, text.indexOf("{"))
+
+        val hover = getHover(text, position)
+        assertNotNull(hover)
+        assertContains(hover.contents.right.value, ". value:{")
+    }
+
+    @Test
+    fun `hover over named function chained after nameless call`() {
+        val text = ".{center}::$ALIGN_FUNCTION"
+        val position = Position(0, text.indexOf(ALIGN_FUNCTION) + ALIGN_FUNCTION.length / 2)
+
+        val hover = getHover(text, position)
+        assertNotNull(hover)
+        assertContains(hover.contents.right.value, ALIGN_FUNCTION)
+    }
+
+    @Test
+    fun `hover over nameless part of chained call falls back to last chain name`() {
+        // Hovering over the nameless `.{...}` part: no FUNCTION_NAME token is found.
+        val text = ".{center}::$ALIGN_FUNCTION"
+        val position = Position(0, 1) // Over the '{' of the nameless call.
+
+        val hover = getHover(text, position)
+        assertNotNull(hover)
+        assertContains(hover.contents.right.value, ALIGN_FUNCTION)
+    }
 }

--- a/quarkdown-lsp/src/test/resources/docs/com.quarkdown.stdlib.module.Flow/--root--.html
+++ b/quarkdown-lsp/src/test/resources/docs/com.quarkdown.stdlib.module.Flow/--root--.html
@@ -1,0 +1,116 @@
+<!doctype html>
+<html class="no-js">
+<head>
+    <meta name="viewport" content="width=device-width, initial-scale=1" charset="UTF-8">
+    <title></title>
+<link href="../../images/logo-icon.svg" rel="icon" type="image/svg">    <script>var pathToRoot = "../../";</script>
+    <script>document.documentElement.classList.replace("no-js","js");</script>
+    <script>const storage = localStorage.getItem("dokka-dark-mode")
+    if (storage == null) {
+        const osDarkSchemePreferred = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches
+        if (osDarkSchemePreferred === true) {
+            document.getElementsByTagName("html")[0].classList.add("theme-dark")
+        }
+    } else {
+        const savedDarkMode = JSON.parse(storage)
+        if(savedDarkMode === true) {
+            document.getElementsByTagName("html")[0].classList.add("theme-dark")
+        }
+    }
+    </script>
+<script type="text/javascript" src="https://unpkg.com/kotlin-playground@1/dist/playground.min.js" async></script>
+<script type="text/javascript" src="../../scripts/sourceset_dependencies.js" async></script>
+<link href="../../styles/style.css" rel="Stylesheet">
+<link href="../../styles/main.css" rel="Stylesheet">
+<link href="../../styles/prism.css" rel="Stylesheet">
+<link href="../../styles/logo-styles.css" rel="Stylesheet">
+<link href="../../styles/font-jb-sans-auto.css" rel="Stylesheet">
+<link href="../../ui-kit/ui-kit.min.css" rel="Stylesheet">
+<script type="text/javascript" src="../../scripts/clipboard.js" async></script>
+<script type="text/javascript" src="../../scripts/navigation-loader.js" async></script>
+<script type="text/javascript" src="../../scripts/platform-content-handler.js" async></script>
+<script type="text/javascript" src="../../scripts/main.js" defer></script>
+<script type="text/javascript" src="../../scripts/prism.js" async></script>
+<script type="text/javascript" src="../../ui-kit/ui-kit.min.js" defer></script>
+<script type="text/javascript" src="../../scripts/symbol-parameters-wrapper_deferred.js" defer></script>
+<link href="../../images/logo-icon.svg">
+<link href="../../styles/stylesheet.css" rel="Stylesheet"></head>
+<body>
+    <div class="root">
+    <nav class="navigation theme-dark" id="navigation-wrapper">
+<a class="library-name--link" href="../../index.html">
+                    quarkdown
+            </a>        <button class="navigation-controls--btn navigation-controls--btn_toc ui-kit_mobile-only" id="toc-toggle" type="button">Toggle table of contents
+        </button>
+        <div class="navigation-controls--break ui-kit_mobile-only"></div>
+        <div class="library-version" id="library-version">1.14.1
+        </div>
+        <div class="navigation-controls">
+        <div class="filter-section filter-section_loading" id="filter-section">
+                <button class="platform-tag platform-selector jvm-like" data-active="" data-filter=":quarkdown-stdlib/main">jvm</button>
+            <div class="dropdown filter-section--dropdown" data-role="dropdown" id="filter-section-dropdown">
+                <button class="button button_dropdown filter-section--dropdown-toggle" role="combobox" data-role="dropdown-toggle" aria-controls="platform-tags-listbox" aria-haspopup="listbox" aria-expanded="false" aria-label="Toggle source sets"></button>
+                <ul role="listbox" id="platform-tags-listbox" class="dropdown--list" data-role="dropdown-listbox">
+                    <div class="dropdown--header"><span>Platform filter</span>
+                        <button class="button" data-role="dropdown-toggle" aria-label="Close platform filter">
+                            <i class="ui-kit-icon ui-kit-icon_cross"></i>
+                        </button>
+                    </div>
+                        <li role="option" class="dropdown--option platform-selector-option jvm-like" tabindex="0">
+                            <label class="checkbox">
+                                <input type="checkbox" class="checkbox--input" id=":quarkdown-stdlib/main" data-filter=":quarkdown-stdlib/main">
+                                <span class="checkbox--icon"></span>
+                                jvm
+                            </label>
+                        </li>
+                </ul>
+                <div class="dropdown--overlay"></div>
+            </div>
+        </div>
+            <button class="navigation-controls--btn navigation-controls--btn_theme" id="theme-toggle-button" type="button">Switch theme
+            </button>
+            <div class="navigation-controls--btn navigation-controls--btn_search" id="searchBar" role="button">Search in
+                API
+            </div>
+        </div>
+    </nav>
+        <div id="container">
+            <div class="sidebar" id="leftColumn">
+                <div class="dropdown theme-dark_mobile" data-role="dropdown" id="toc-dropdown">
+                    <ul role="listbox" id="toc-listbox" class="dropdown--list dropdown--list_toc-list" data-role="dropdown-listbox">
+                        <div class="dropdown--header">
+                            <span>
+                                    quarkdown
+                            </span>
+                            <button class="button" data-role="dropdown-toggle" aria-label="Close table of contents">
+                                <i class="ui-kit-icon ui-kit-icon_cross"></i>
+                            </button>
+                        </div>
+                        <div class="sidebar--inner" id="sideMenu"></div>
+                    </ul>
+                    <div class="dropdown--overlay"></div>
+                </div>
+            </div>
+            <div id="main">
+<div class="main-content" data-page-type="member" id="content" pageids="quarkdown-stdlib::com.quarkdown.stdlib//identity/#com.quarkdown.core.function.value.DynamicValue/PointingToDeclaration//742850071">
+  <div class="breadcrumbs"><a href="../index.html">quarkdown-stdlib</a><span class="delimiter">/</span><a href="index.html">com.quarkdown.stdlib.module.Flow</a><span class="delimiter">/</span><span class="current"></span></div>
+  <div class="cover ">
+    <h1 class="cover"></h1>
+  </div>
+  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":quarkdown-stdlib/main"><div class="sample-container"><pre><code class="block lang-kotlin" theme="idea"><span class="token punctuation">.</span><span class="token function"></span><span class="token punctuation"> </span><span class="token constant">value</span><span class="token operator">:</span><span class="token punctuation">{</span><span data-unresolved-link="com.quarkdown.core.function.value/Dynamic///PointingToDeclaration/">Dynamic</span><span class="token punctuation">}</span><span class="token punctuation"> </span><span class="token operator">-&gt; </span><span data-unresolved-link="com.quarkdown.core.function.value/Dynamic///PointingToDeclaration/">Dynamic</span></code></pre><span class="top-right-position"><span class="copy-icon"></span><div class="copy-popup-wrapper popup-to-left"><span class="copy-popup-icon"></span><span>Content copied to clipboard</span></div></span></div><p class="paragraph">Returns the given value unchanged. This is the identity function, invoked via the nameless syntax <code class="lang-kotlin">.{value}</code>. It is useful as a starting point for chained calls:</p><div class="sample-container"><pre><code class="block lang-kotlin" theme="idea">.{10}::multiply {2}::sum {5}</code></pre><span class="top-right-position"><span class="copy-icon"></span><div class="copy-popup-wrapper popup-to-left"><span class="copy-popup-icon"></span><span>Content copied to clipboard</span></div></span></div><p class="paragraph">Result: <code class="lang-kotlin">25</code></p><span class="kdoc-tag"><h4 class="">Return</h4><p class="paragraph">the same value, unchanged</p></span><h4 class="">Parameters</h4><div class="table"><div class="table-row" data-filterable-current=":quarkdown-stdlib/main" data-filterable-set=":quarkdown-stdlib/main"><div class="main-subrow keyValue "><div class=""><span class="inline-flex"><div><u><span><span>value</span></span></u></div></span></div><div><div class="title"><p class="paragraph">value to pass through</p></div></div></div></div></div></div></div>
+</div>
+    <div class="footer">
+        <a href="#content" id="go-to-top-link" class="footer--button footer--button_go-to-top"></a>
+        <span>© 2026 Quarkdown</span>
+        <span class="pull-right">
+            <span>Generated by </span>
+            <a class="footer--link footer--link_external" href="https://github.com/Kotlin/dokka">
+                <span>dokka</span>
+            </a>
+        </span>
+    </div>
+            </div>
+        </div>
+    </div>
+</body>
+</html>

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Flow.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Flow.kt
@@ -31,6 +31,7 @@ import com.quarkdown.core.function.value.wrappedAsValue
  */
 val Flow: QuarkdownModule =
     moduleOf(
+        ::identity,
         ::`if`,
         ::ifNot,
         ::forEach,
@@ -437,6 +438,22 @@ fun let(
     value: DynamicValue,
     @LikelyBody body: Lambda,
 ): OutputValue<*> = body.invokeDynamic(value)
+
+/**
+ * Returns the given value unchanged.
+ * This is the identity function, invoked via the nameless syntax `.{value}`.
+ * It is useful as a starting point for chained calls:
+ *
+ * ```
+ * .{10}::multiply {2}::sum {5}
+ * ```
+ * Result: `25`
+ *
+ * @param value value to pass through
+ * @return the same value, unchanged
+ */
+@Name("")
+fun identity(value: DynamicValue): DynamicValue = value
 
 /**
  * Creates a null invisible node that forces the expression it lies in to be evaluated as Markdown content.

--- a/quarkdown-test/src/test/kotlin/com/quarkdown/test/FunctionCallTest.kt
+++ b/quarkdown-test/src/test/kotlin/com/quarkdown/test/FunctionCallTest.kt
@@ -137,4 +137,25 @@ class FunctionCallTest {
             assertEquals("<p>hello{3</p>", it)
         }
     }
+
+    @Test
+    fun `identity function`() {
+        execute(".{hello}") {
+            assertEquals("<p>hello</p>", it)
+        }
+    }
+
+    @Test
+    fun `identity function chain`() {
+        execute(".{10}::multiply {2}::sum {5}") {
+            assertEquals("<p>25</p>", it)
+        }
+    }
+
+    @Test
+    fun `wrapped identity function`() {
+        execute("hello{.{world}}hello") {
+            assertEquals("<p>helloworldhello</p>", it)
+        }
+    }
 }

--- a/quarkdown-test/src/test/kotlin/com/quarkdown/test/FunctionCallTest.kt
+++ b/quarkdown-test/src/test/kotlin/com/quarkdown/test/FunctionCallTest.kt
@@ -146,6 +146,13 @@ class FunctionCallTest {
     }
 
     @Test
+    fun `malformed nameless function does not parse`() {
+        execute(".") { assertEquals("<p>.</p>", it) }
+        execute("abc . def") { assertEquals("<p>abc . def</p>", it) }
+        execute(". {def}") { assertEquals("<p>. {def}</p>", it) }
+    }
+
+    @Test
     fun `identity function chain`() {
         execute(".{10}::multiply {2}::sum {5}") {
             assertEquals("<p>25</p>", it)

--- a/quarkdown-test/src/test/kotlin/com/quarkdown/test/TextTest.kt
+++ b/quarkdown-test/src/test/kotlin/com/quarkdown/test/TextTest.kt
@@ -113,6 +113,16 @@ class TextTest {
     }
 
     @Test
+    fun `advanced text formatting with identity function`() {
+        execute("This is a .{small text}::text size:{tiny} variant:{smallcaps}") {
+            assertEquals(
+                "<p>This is a <span class=\"size-tiny\" style=\"font-variant: small-caps;\">small text</span></p>",
+                it,
+            )
+        }
+    }
+
+    @Test
     fun `subscript and superscript`() {
         execute("H{.text {2} script:{sub}}O is water. E = mc{.text {2} script:{sup}}") {
             assertEquals(


### PR DESCRIPTION
This PR adds:
- support for unnamed function calls.
- an identity function with an empty name.

The identity function allows for function call chaining from a static value: this call is now valid: `.{10}::multiply {5}`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/iamgio/quarkdown/pull/415" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
