### PR TITLE
fix(ui): apply flexbox layout to headings

### DIFF
--- a/quarkdown-html/src/main/scss/components/_heading.scss
+++ b/quarkdown-html/src/main/scss/components/_heading.scss
@@ -11,6 +11,8 @@
     color: var(--qd-heading-color);
     margin: var(--qd-heading-margin);
     text-transform: none !important;
+    display: flex;
+    align-items: flex-start;
     @include font.global-font-family-with-main-fallback($kind: "heading");
   }
 

--- a/quarkdown-html/src/test/e2e/headings/multiline-alignment/main.qd
+++ b/quarkdown-html/src/test/e2e/headings/multiline-alignment/main.qd
@@ -1,0 +1,4 @@
+.doctype {paged}
+.pageformat width:{10cm} height:{5cm} margin:{1cm}
+
+# A multiline title

--- a/quarkdown-html/src/test/e2e/headings/multiline-alignment/multiline-alignment.spec.ts
+++ b/quarkdown-html/src/test/e2e/headings/multiline-alignment/multiline-alignment.spec.ts
@@ -1,0 +1,8 @@
+import {suite} from "../../quarkdown";
+
+const {test, expect} = suite(__dirname);
+
+test("multiline headings are aligned to the left", async (page) => {
+    const heading = page.locator("h1").first();
+    await expect(heading).toHaveCSS("display", "flex");
+});


### PR DESCRIPTION
- [X] I confirm an issue for this change exists.
- [X] I have read the [contributing guidelines](https://github.com/iamgio/quarkdown/blob/main/CONTRIBUTING.md).
- [X] I have tested the changes locally.
- [ ] (Optional) I have added necessary documentation to [`docs`](https://github.com/iamgio/quarkdown/tree/main/docs) and [CHANGELOG.md](https://github.com/iamgio/quarkdown/blob/main/CHANGELOG.md)

Closes #433.

In Playwright tests I tried to verify that the bounding boxes of the `::before` pseudo-element and the inner text did not overlap, but I was unsuccessful as the browser does not appear to expose the `::before` element.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/iamgio/quarkdown/pull/434" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
