### PR TITLE
perf(rendering): make rendering parallel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+### Changed
+
+#### Parallel rendering
+
+Rendering now runs in parallel across sibling elements, improving performance on large documents.
+
 ## [1.15.1] - 2026-03-31
 
 ### Changed

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/Node.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/Node.kt
@@ -1,5 +1,6 @@
 package com.quarkdown.core.ast
 
+import com.quarkdown.core.util.mapParallel
 import com.quarkdown.core.visitor.node.NodeVisitor
 
 /**
@@ -37,3 +38,23 @@ interface SingleChildNestableNode<T : Node> : NestableNode {
     override val children: List<Node>
         get() = listOf(child)
 }
+
+/**
+ * Accepts a visitor for each node sequentially.
+ * @param visitor the visitor to accept
+ * @return the list of results from each visit, preserving order
+ */
+fun <T> List<Node>.acceptAll(visitor: NodeVisitor<T>): List<T> = map { it.accept(visitor) }
+
+/**
+ * Accepts a visitor for each node, executing visits in parallel when beneficial.
+ * Falls back to sequential execution for small lists.
+ * @param visitor the visitor to accept
+ * @param minItems minimum number of nodes required for parallel execution
+ * @return the list of results from each visit, preserving order
+ * @see mapParallel
+ */
+fun <T> List<Node>.parallelAcceptAll(
+    visitor: NodeVisitor<T>,
+    minItems: Int = 50,
+): List<T> = mapParallel(minItems) { it.accept(visitor) }

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/attributes/reference/CitationLabelProperty.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/attributes/reference/CitationLabelProperty.kt
@@ -1,0 +1,41 @@
+package com.quarkdown.core.ast.attributes.reference
+
+import com.quarkdown.core.ast.quarkdown.bibliography.BibliographyCitation
+import com.quarkdown.core.context.Context
+import com.quarkdown.core.context.MutableContext
+import com.quarkdown.core.property.Property
+
+/**
+ * Pre-computed citation label for a [BibliographyCitation] node.
+ *
+ * Labels are computed eagerly in document order during the
+ * [com.quarkdown.core.context.hooks.reference.BibliographyCitationResolverHook] phase,
+ * so that parallel rendering can read them without depending on visit order.
+ * @param value the formatted citation label (e.g. `"[1]"`, `"[1, 2]"`)
+ */
+data class CitationLabelProperty(
+    override val value: String,
+) : Property<String> {
+    companion object : Property.Key<String>
+
+    override val key = CitationLabelProperty
+}
+
+/**
+ * Retrieves the pre-computed citation label for this node.
+ * @param context context where the property is stored
+ * @return the citation label, or `null` if not pre-computed
+ */
+fun BibliographyCitation.getCitationLabel(context: Context): String? = context.attributes.of(this)[CitationLabelProperty]
+
+/**
+ * Stores a pre-computed citation label on this node.
+ * @param context context where the property is stored
+ * @param label the citation label to store
+ */
+fun BibliographyCitation.setCitationLabel(
+    context: MutableContext,
+    label: String,
+) {
+    context.attributes.of(this) += CitationLabelProperty(label)
+}

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/context/hooks/reference/BibliographyCitationResolverHook.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/context/hooks/reference/BibliographyCitationResolverHook.kt
@@ -1,5 +1,7 @@
 package com.quarkdown.core.context.hooks.reference
 
+import com.quarkdown.core.ast.attributes.reference.ReferenceNode
+import com.quarkdown.core.ast.attributes.reference.setCitationLabel
 import com.quarkdown.core.ast.iterator.ObservableAstIterator
 import com.quarkdown.core.ast.quarkdown.bibliography.BibliographyCitation
 import com.quarkdown.core.ast.quarkdown.bibliography.BibliographyView
@@ -11,6 +13,10 @@ import com.quarkdown.core.context.MutableContext
  * Hook that associates bibliography entries to each [BibliographyCitation]
  * that can be linked to entries of a [Bibliography]
  * within a [BibliographyView].
+ *
+ * After each citation is resolved, this hook pre-computes its citation label in document order
+ * and stores it as a [com.quarkdown.core.ast.attributes.reference.CitationLabelProperty] on the node,
+ * so that parallel rendering can safely read it without depending on visit order.
  */
 class BibliographyCitationResolverHook(
     context: MutableContext,
@@ -32,4 +38,13 @@ class BibliographyCitationResolverHook(
                     }
                 bibliography to (entries to bibliography)
             }
+
+    override fun onResolved(
+        reference: ReferenceNode<BibliographyCitation, Pair<List<BibliographyEntry>, BibliographyView>>,
+        definition: Pair<List<BibliographyEntry>, BibliographyView>,
+    ) {
+        val (entries, view) = definition
+        val label = view.style.labelProvider.getCitationLabel(entries)
+        reference.reference.setCitationLabel(context, label)
+    }
 }

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/context/hooks/reference/ReferenceDefinitionResolverHook.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/context/hooks/reference/ReferenceDefinitionResolverHook.kt
@@ -26,7 +26,9 @@ abstract class ReferenceDefinitionResolverHook<R, DN : Node, D>(
             indexReferences(references).forEach { (index, reference) ->
                 val definition = findDefinitionPair(reference.reference, definitions, index)
                 definition?.let {
-                    reference.setDefinition(context, transformDefinitionPair(it))
+                    val transformed = transformDefinitionPair(it)
+                    reference.setDefinition(context, transformed)
+                    onResolved(reference, transformed)
                 }
             }
         }
@@ -71,4 +73,15 @@ abstract class ReferenceDefinitionResolverHook<R, DN : Node, D>(
      * @return the definition to be associated with the reference
      */
     protected open fun transformDefinitionPair(definition: Pair<DN, D>): D = definition.second
+
+    /**
+     * Called after a reference has been successfully resolved and associated with its definition.
+     * Subclasses can override this to perform additional processing per resolved pair.
+     * @param reference the resolved reference node
+     * @param definition the definition associated with the reference
+     */
+    protected open fun onResolved(
+        reference: ReferenceNode<R, D>,
+        definition: D,
+    ) {}
 }

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/property/AssociatedProperties.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/property/AssociatedProperties.kt
@@ -1,5 +1,8 @@
 package com.quarkdown.core.property
 
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.ConcurrentMap
+
 /**
  * Associations between a key of type [T] and a [PropertyContainer].
  *
@@ -30,7 +33,7 @@ interface AssociatedProperties<T, V> {
  * Mutable implementation of [AssociatedProperties].
  */
 class MutableAssociatedProperties<T, V> : AssociatedProperties<T, V> {
-    private val properties: MutableMap<T, MutablePropertyContainer<V>> = mutableMapOf()
+    private val properties: ConcurrentMap<T, MutablePropertyContainer<V>> = ConcurrentHashMap()
 
-    override fun of(key: T): MutablePropertyContainer<V> = properties.getOrPut(key) { MutablePropertyContainer() }
+    override fun of(key: T): MutablePropertyContainer<V> = properties.computeIfAbsent(key) { MutablePropertyContainer() }
 }

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/rendering/tag/TagBuilder.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/rendering/tag/TagBuilder.kt
@@ -1,6 +1,7 @@
 package com.quarkdown.core.rendering.tag
 
 import com.quarkdown.core.ast.Node
+import com.quarkdown.core.ast.parallelAcceptAll
 
 /**
  * A builder of a generic output code wrapped within tags (of any kind) which can be unlimitedly nested.
@@ -63,12 +64,12 @@ abstract class TagBuilder(
     }
 
     /**
-     * Appends a sequence of nodes to this tag's content.
+     * Appends a sequence of nodes to this tag's content, rendering in parallel when beneficial.
      * Their string representation is given by this [TagBuilder]'s [renderer].
      * Usage: `+someNode.children`
      */
     operator fun List<Node>.unaryPlus() {
-        forEach { +it }
+        parallelAcceptAll(renderer).forEach { +it }
     }
 }
 

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/util/ConcurrencyUtils.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/util/ConcurrencyUtils.kt
@@ -1,0 +1,33 @@
+package com.quarkdown.core.util
+
+import java.util.stream.Collectors
+
+/**
+ * Default minimum number of items required for parallel execution to be worthwhile.
+ * Below this threshold, the overhead of thread scheduling exceeds the benefit.
+ */
+private const val DEFAULT_MIN_ITEMS_FOR_PARALLELISM = 4
+
+/**
+ * Maps each element of this list using [transform], executing transformations in parallel
+ * when the list is large enough to benefit from concurrency.
+ * Falls back to sequential mapping for small lists where parallelism overhead exceeds benefit.
+ *
+ * Uses [java.util.stream.Stream.parallel] with the common [java.util.concurrent.ForkJoinPool],
+ * which handles nested parallelism via work-stealing without risking deadlocks.
+ *
+ * Results are returned in the same order as the input list.
+ * @param minItems minimum number of items required for parallel execution.
+ *                 Lists smaller than this are mapped sequentially
+ * @param transform the transformation to apply to each element
+ * @return the list of transformed results, preserving input order
+ */
+fun <T, R> List<T>.mapParallel(
+    minItems: Int = DEFAULT_MIN_ITEMS_FOR_PARALLELISM,
+    transform: (T) -> R,
+): List<R> {
+    if (size < minItems) {
+        return map(transform)
+    }
+    return parallelStream().map(transform).collect(Collectors.toList())
+}

--- a/quarkdown-core/src/test/kotlin/com/quarkdown/core/util/MapParallelTest.kt
+++ b/quarkdown-core/src/test/kotlin/com/quarkdown/core/util/MapParallelTest.kt
@@ -1,0 +1,91 @@
+package com.quarkdown.core.util
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class MapParallelTest {
+    @Test
+    fun `empty list`() {
+        val result = emptyList<Int>().mapParallel { it * 2 }
+        assertEquals(emptyList(), result)
+    }
+
+    @Test
+    fun `below threshold is sequential`() {
+        val result = listOf(1, 2, 3).mapParallel { it * 2 }
+        assertEquals(listOf(2, 4, 6), result)
+    }
+
+    @Test
+    fun `at threshold is parallel`() {
+        val result = listOf(1, 2, 3, 4).mapParallel { it * 2 }
+        assertEquals(listOf(2, 4, 6, 8), result)
+    }
+
+    @Test
+    fun `above threshold preserves order`() {
+        val result =
+            (1..100).toList().mapParallel { element ->
+                Thread.sleep(10 - (element % 10).toLong()) // Varying delay to provoke reordering
+                element * 3
+            }
+        assertEquals((1..100).map { it * 3 }, result)
+    }
+
+    @Test
+    fun `nested calls do not deadlock`() {
+        // Outer list triggers parallelism, each inner list also exceeds the threshold.
+        val result =
+            (1..8).toList().mapParallel { outer ->
+                (1..8).toList().mapParallel { inner ->
+                    outer * 10 + inner
+                }
+            }
+        val expected = (1..8).map { outer -> (1..8).map { inner -> outer * 10 + inner } }
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `triple nesting does not deadlock`() {
+        val result =
+            (1..4).toList().mapParallel { a ->
+                (1..4).toList().mapParallel { b ->
+                    (1..4).toList().mapParallel { c ->
+                        a * 100 + b * 10 + c
+                    }
+                }
+            }
+        val expected =
+            (1..4).map { a ->
+                (1..4).map { b ->
+                    (1..4).map { c -> a * 100 + b * 10 + c }
+                }
+            }
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `exception propagation`() {
+        assertFailsWith<IllegalStateException> {
+            (1..10).toList().mapParallel { element ->
+                if (element == 5) error("fail")
+                element
+            }
+        }
+    }
+
+    @Test
+    fun `runs concurrently above threshold`() {
+        val threads =
+            java.util.concurrent.ConcurrentHashMap
+                .newKeySet<String>()
+        (1..8).toList().mapParallel {
+            threads += Thread.currentThread().name
+            Thread.sleep(50)
+            it
+        }
+        assertTrue(threads.size > 1, "Expected multiple threads, got: $threads")
+    }
+}

--- a/quarkdown-html/src/main/kotlin/com/quarkdown/rendering/html/node/QuarkdownHtmlNodeRenderer.kt
+++ b/quarkdown-html/src/main/kotlin/com/quarkdown/rendering/html/node/QuarkdownHtmlNodeRenderer.kt
@@ -7,6 +7,7 @@ import com.quarkdown.core.ast.attributes.id.getId
 import com.quarkdown.core.ast.attributes.localization.LocalizedKind
 import com.quarkdown.core.ast.attributes.location.LocationTrackableNode
 import com.quarkdown.core.ast.attributes.location.getLocationLabel
+import com.quarkdown.core.ast.attributes.reference.getCitationLabel
 import com.quarkdown.core.ast.attributes.reference.getDefinition
 import com.quarkdown.core.ast.base.TextNode
 import com.quarkdown.core.ast.base.block.BlockQuote
@@ -59,7 +60,6 @@ import com.quarkdown.core.ast.quarkdown.invisible.PageNumberReset
 import com.quarkdown.core.ast.quarkdown.invisible.SlidesConfigurationInitializer
 import com.quarkdown.core.ast.quarkdown.reference.CrossReference
 import com.quarkdown.core.ast.quarkdown.reference.CrossReferenceableNode
-import com.quarkdown.core.bibliography.BibliographyEntry
 import com.quarkdown.core.context.Context
 import com.quarkdown.core.context.localization.localizeOrNull
 import com.quarkdown.core.context.shouldAutoPageBreak
@@ -477,10 +477,7 @@ class QuarkdownHtmlNodeRenderer(
     }
 
     override fun visit(node: BibliographyCitation): CharSequence {
-        val (entries: List<BibliographyEntry>, view: BibliographyView) =
-            node.getDefinition(context) ?: return Text("[???]").accept(this)
-
-        val label = view.style.labelProvider.getCitationLabel(entries)
+        val label = node.getCitationLabel(context) ?: return Text("[???]").accept(this)
         return Text(label).accept(this)
     }
 

--- a/quarkdown-plaintext/src/main/kotlin/com/quarkdown/rendering/plaintext/node/PlainTextNodeRenderer.kt
+++ b/quarkdown-plaintext/src/main/kotlin/com/quarkdown/rendering/plaintext/node/PlainTextNodeRenderer.kt
@@ -6,6 +6,7 @@ import com.quarkdown.core.ast.NestableNode
 import com.quarkdown.core.ast.attributes.localization.LocalizedKind
 import com.quarkdown.core.ast.attributes.location.LocationTrackableNode
 import com.quarkdown.core.ast.attributes.location.getLocationLabel
+import com.quarkdown.core.ast.attributes.reference.getCitationLabel
 import com.quarkdown.core.ast.attributes.reference.getDefinition
 import com.quarkdown.core.ast.base.TextNode
 import com.quarkdown.core.ast.base.block.BlankNode
@@ -39,6 +40,7 @@ import com.quarkdown.core.ast.base.inline.StrongEmphasis
 import com.quarkdown.core.ast.base.inline.SubdocumentLink
 import com.quarkdown.core.ast.base.inline.Text
 import com.quarkdown.core.ast.dsl.buildBlock
+import com.quarkdown.core.ast.parallelAcceptAll
 import com.quarkdown.core.ast.quarkdown.CaptionableNode
 import com.quarkdown.core.ast.quarkdown.FunctionCallNode
 import com.quarkdown.core.ast.quarkdown.bibliography.BibliographyCitation
@@ -76,7 +78,6 @@ import com.quarkdown.core.ast.quarkdown.invisible.PageNumberReset
 import com.quarkdown.core.ast.quarkdown.invisible.SlidesConfigurationInitializer
 import com.quarkdown.core.ast.quarkdown.reference.CrossReference
 import com.quarkdown.core.ast.quarkdown.reference.CrossReferenceableNode
-import com.quarkdown.core.bibliography.BibliographyEntry
 import com.quarkdown.core.context.Context
 import com.quarkdown.core.context.localization.localizeOrNull
 import com.quarkdown.core.rendering.NodeRenderer
@@ -91,7 +92,7 @@ class PlainTextNodeRenderer(
 ) : NodeRenderer {
     private fun NestableNode.visitChildren() = children.visitAll()
 
-    private fun InlineContent.visitAll() = joinToString(separator = "") { it.accept(this@PlainTextNodeRenderer) }
+    private fun InlineContent.visitAll() = parallelAcceptAll(this@PlainTextNodeRenderer).joinToString(separator = "")
 
     private val String.blockNode: String
         get() =
@@ -338,12 +339,7 @@ class PlainTextNodeRenderer(
         return builder.toString()
     }
 
-    override fun visit(node: BibliographyCitation): CharSequence {
-        val (entries: List<BibliographyEntry>, view: BibliographyView) =
-            node.getDefinition(context) ?: return "[???]"
-
-        return view.style.labelProvider.getCitationLabel(entries)
-    }
+    override fun visit(node: BibliographyCitation): CharSequence = node.getCitationLabel(context) ?: "[???]"
 
     override fun visit(node: SlidesFragment) = ""
 

--- a/quarkdown-test/src/test/kotlin/com/quarkdown/test/ParallelRenderingTest.kt
+++ b/quarkdown-test/src/test/kotlin/com/quarkdown/test/ParallelRenderingTest.kt
@@ -1,0 +1,89 @@
+package com.quarkdown.test
+
+import com.quarkdown.rendering.plaintext.extension.plainText
+import com.quarkdown.test.util.execute
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Tests that parallel rendering produces deterministic output identical to sequential rendering.
+ * These tests exercise documents with enough nodes to trigger parallelism (50+ sibling nodes),
+ * ensuring that order-sensitive rendering operations remain correct under concurrency.
+ */
+class ParallelRenderingTest {
+    /**
+     * A document with many top-level blocks that exceed the parallel threshold.
+     * Verifies that sibling block rendering order is preserved.
+     */
+    @Test
+    fun `many paragraphs`() {
+        val source = (1..60).joinToString("\n\n") { "Paragraph $it with **bold** and *italic* text." }
+
+        execute(source) { result ->
+            val expected =
+                (1..60).joinToString("") {
+                    "<p>Paragraph $it with <strong>bold</strong> and <em>italic</em> text.</p>"
+                }
+            assertEquals(expected, result)
+        }
+    }
+
+    /**
+     * A document with headings and paragraphs interleaved, producing enough top-level nodes
+     * to trigger parallelism. Tests that the block order is preserved.
+     */
+    @Test
+    fun `interleaved headings and paragraphs`() {
+        val source =
+            (1..30).joinToString("\n\n") { i ->
+                "## Section $i\n\nContent of section $i."
+            }
+
+        execute(source) { result ->
+            val expected =
+                (1..30).joinToString("") { i ->
+                    "<h2>Section $i</h2><p>Content of section $i.</p>"
+                }
+            assertEquals(expected, result)
+        }
+    }
+
+    /**
+     * Plaintext rendering with many blocks.
+     * Verifies that the plaintext renderer's parallel `visitAll` preserves order.
+     */
+    @Test
+    fun `plaintext rendering order`() {
+        val source = (1..60).joinToString("\n\n") { "Paragraph $it." }
+
+        execute(
+            source,
+            renderer = { rendererFactory, ctx -> rendererFactory.plainText(ctx) },
+        ) { result ->
+            val expected = (1..60).joinToString("") { "Paragraph $it.\n\n" }
+            assertEquals(expected, result)
+        }
+    }
+
+    /**
+     * Repeated runs of the same document to detect non-deterministic ordering.
+     * If parallelism introduces randomness, at least one run out of many would produce different output.
+     */
+    @Test
+    fun `repeated rendering is deterministic`() {
+        val source =
+            (1..30).joinToString("\n\n") { i ->
+                "## Heading $i\n\nParagraph with **bold $i** and *italic $i*."
+            }
+
+        val results = mutableListOf<String>()
+        repeat(10) {
+            execute(source) { result -> results += result.toString() }
+        }
+
+        val first = results.first()
+        results.forEachIndexed { index, result ->
+            assertEquals(first, result, "Run $index produced different output")
+        }
+    }
+}


### PR DESCRIPTION
This PR makes rendering of trees fully parallel

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/iamgio/quarkdown/pull/440" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
