### PR TITLE
feat(function): support bash-style line continuations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,17 @@ quarkdown c main.qd --allow global-read --deny native-content
 
 Available permissions: `project-read` (default), `global-read`, `network`, `native-content` (default), `all`. See the wiki page for more details.
 
+#### [Line continuation in function calls](https://quarkdown.com/wiki/syntax-of-a-function-call#line-continuation)
+
+A backslash (`\`) at the end of a line lets you split a function call's arguments across multiple lines.
+This improves readability for calls with many parameters:
+
+```markdown
+.container alignment:{center} \
+           background:{red} \
+           padding:{1px}
+```
+
 ### Changed
 
 #### Changed default output directory to `./quarkdown-output` (breaking change)

--- a/docs/syntax-of-a-function-call.qd
+++ b/docs/syntax-of-a-function-call.qd
@@ -47,6 +47,20 @@ Arguments can span over multiple lines. Indentation is optional and arbitrary.
         .sum {2} {1}
     }
 
+## Line continuation
+
+When a function call has many arguments, a backslash (`\`) at the end of a line continues the argument list on the next line.
+
+```markdown
+.container alignment:{center} \
+           background:{red} \
+           padding:{1px}
+```
+
+The backslash and the newline are consumed by the compiler, and optional leading whitespace on the continuation line is ignored. You can use as many continuation lines as you need.
+
+Line continuation is supported in both block and inline function calls.
+
 ## Nested function calls
 
 Function calls can be nested in arguments, allowing you to compose complex expressions.

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/lexer/patterns/FunctionCallPatterns.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/lexer/patterns/FunctionCallPatterns.kt
@@ -6,7 +6,6 @@ import com.quarkdown.core.lexer.regex.pattern.WalkedToken
 import com.quarkdown.core.lexer.tokens.FunctionCallToken
 import com.quarkdown.core.parser.walker.funcall.FunctionCallGrammar
 import com.quarkdown.core.parser.walker.funcall.FunctionCallWalkerParser
-import com.quarkdown.core.util.isBlankUntilEndOfLine
 
 /**
  * Patterns for block and inline function calls.
@@ -63,7 +62,7 @@ class FunctionCallPatterns {
             walker = { data, remaining ->
                 val result = FunctionCallWalkerParser(remaining, allowsBody = true).parse()
                 // The function call is block-level only if it spans the entire header line.
-                val isBlock = remaining.isBlankUntilEndOfLine(result.endIndex)
+                val isBlock = remaining.isBlankAfterFunctionCall(result.endIndex)
                 if (!isBlock) return@TokenRegexPattern null
 
                 WalkedToken(
@@ -100,3 +99,18 @@ class FunctionCallPatterns {
  * Accepted pattern before a function call.
  */
 const val FUNCTION_CALL_PATTERN_BEFORE = "^|\\s|[^a-zA-Z0-9.\\\\]"
+
+/**
+ * Whether a function call that was parsed from [this] source ends cleanly, with no trailing content
+ * on the same line as the call's last argument. This determines whether the call is block-level.
+ *
+ * @param endIndex the index where the walker stopped parsing
+ * @return `true` if the call is block-level (no trailing content on the last line)
+ */
+private fun CharSequence.isBlankAfterFunctionCall(endIndex: Int): Boolean {
+    // If the walker stopped at a line boundary (e.g. after body arguments), the call's content ended cleanly.
+    if (endIndex >= length || this[endIndex - 1] == '\n') return true
+    // Otherwise, check if the rest of the line after endIndex is blank.
+    val lineEnd = indexOf('\n', endIndex).let { if (it < 0) length else it }
+    return substring(endIndex, lineEnd).isBlank()
+}

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/parser/walker/funcall/FunctionCallGrammar.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/parser/walker/funcall/FunctionCallGrammar.kt
@@ -2,6 +2,7 @@ package com.quarkdown.core.parser.walker.funcall
 
 import com.github.h0tk3y.betterParse.combinators.and
 import com.github.h0tk3y.betterParse.combinators.map
+import com.github.h0tk3y.betterParse.combinators.oneOrMore
 import com.github.h0tk3y.betterParse.combinators.optional
 import com.github.h0tk3y.betterParse.combinators.or
 import com.github.h0tk3y.betterParse.combinators.unaryMinus
@@ -82,6 +83,11 @@ class FunctionCallGrammar(
          * The character that separates chained function calls.
          */
         const val CHAIN_SEPARATOR = "::"
+
+        /**
+         * The character that, at the end of a line, continues parsing arguments on the next line.
+         */
+        const val LINE_CONTINUATION = '\\'
     }
 
     /**
@@ -120,6 +126,40 @@ class FunctionCallGrammar(
      * Token that matches whitespace, ignored between arguments
      */
     private val whitespace by regexToken("[ \\t]+")
+
+    /**
+     * Token that matches a line continuation: a backslash followed by a newline,
+     * optionally followed by leading whitespace on the next line.
+     * This allows function call arguments to span multiple lines.
+     *
+     * For example:
+     * ```
+     * .container alignment:{center} \
+     *            padding:{1px}
+     * ```
+     */
+    private val lineContinuation by token { string, position ->
+        if (inArg) return@token 0
+
+        val isLineContinuation =
+            string.getOrNull(position) == LINE_CONTINUATION &&
+                string.getOrNull(position + 1) == '\n'
+
+        if (!isLineContinuation) return@token 0
+
+        // Consume `\`, `\n`, and optional leading whitespace on the next line.
+        var length = 2 // LINE_CONTINUATION + newline
+        while (string.getOrNull(position + length)?.let { it == ' ' || it == '\t' } == true) {
+            length++
+        }
+        length
+    }
+
+    /**
+     * Combinator that matches one or more whitespace or line continuation tokens.
+     * Used as a separator between arguments, allowing arguments to span multiple lines.
+     */
+    private val argumentSeparator = oneOrMore(whitespace or lineContinuation)
 
     /**
      * Token that matches the beginning of an inline argument.
@@ -210,7 +250,7 @@ class FunctionCallGrammar(
      */
     private val argumentParser =
         (
-            -optional(whitespace) and
+            -optional(argumentSeparator) and
                 // Optional named argument.
                 optional(identifier and -argumentNameDelimiter) and
                 argumentBegin and
@@ -251,7 +291,7 @@ class FunctionCallGrammar(
                 // Inline arguments.
                 zeroOrMore(argumentParser) and
                 // Body argument.
-                optional(-optional(whitespace) and bodyArgumentParser)
+                optional(-optional(argumentSeparator) and bodyArgumentParser)
         ) map { (id, args, body) ->
             WalkedFunctionCall(
                 id.text,
@@ -265,7 +305,7 @@ class FunctionCallGrammar(
      * The result is an ordered linked list of [WalkedFunctionCall]s, and the first of them is returned.
      */
     private val chainCallParser =
-        callParser and zeroOrMore(-chainSeparator and callParser) map { (first, rest) ->
+        callParser and zeroOrMore(-optional(argumentSeparator) and -chainSeparator and callParser) map { (first, rest) ->
             var current = first
             for (next in rest) {
                 current.next = next

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/parser/walker/funcall/FunctionCallGrammar.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/parser/walker/funcall/FunctionCallGrammar.kt
@@ -315,10 +315,18 @@ class FunctionCallGrammar(
         }
 
     /**
+     * Consumes an optional trailing line continuation (`\` + newline) at the end of a function call,
+     * even when no arguments follow on the next line.
+     * This extends the call's parsed range so that tools like the LSP can locate
+     * the call from positions on the blank continuation line.
+     */
+    private val trailingLineContinuation = optional(optional(whitespace) and lineContinuation)
+
+    /**
      * Entry point of the grammar.
      * Parses the whole chain of function calls.
      */
     override val rootParser =
-        (-begin and chainCallParser) or
+        (-begin and chainCallParser and -trailingLineContinuation) or
             (-argumentBegin and -begin and chainCallParser and -argumentEnd)
 }

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/util/StringUtils.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/util/StringUtils.kt
@@ -110,17 +110,6 @@ fun StringBuilder.replace(
 fun String.sanitizeFileName(replacement: String) = this.replace("^\\.|\\.$|[^a-zA-Z0-9\\-_.@]+".toRegex(), replacement)
 
 /**
- * Whether the content of [this] string between [startIndex] and the end of the first line is blank.
- * If [startIndex] is beyond the first line, this returns `true`.
- * @param startIndex index to start checking from
- * @return `true` if the remainder of the first line after [startIndex] is blank or [startIndex] is past the first line
- */
-fun CharSequence.isBlankUntilEndOfLine(startIndex: Int): Boolean {
-    val firstLineEnd = indexOf('\n').let { if (it < 0) length else it }
-    return startIndex > firstLineEnd || substring(startIndex, firstLineEnd).isBlank()
-}
-
-/**
  * @return [this] string with line separators replaced with `\n`,
  *         or the string itself if `\n` is already the line separator
  */

--- a/quarkdown-core/src/test/kotlin/com/quarkdown/core/LexerTest.kt
+++ b/quarkdown-core/src/test/kotlin/com/quarkdown/core/LexerTest.kt
@@ -675,6 +675,102 @@ class LexerTest {
     }
 
     /**
+     * Verifies that backslash line continuation works in block function calls.
+     */
+    @Test
+    fun lineContinuation() {
+        fun walk(source: CharSequence) = FunctionCallWalkerParser(source, allowsBody = true).parse()
+
+        // Basic continuation: two args across two lines.
+        with(walk(".function {x} \\\n{y}")) {
+            assertEquals("function", value.name)
+            assertEquals(2, value.arguments.size)
+            assertEquals("x", value.arguments[0].value)
+            assertEquals("y", value.arguments[1].value)
+        }
+
+        // Continuation with named arg on next line.
+        with(walk(".function {x} \\\nname:{y}")) {
+            assertEquals("function", value.name)
+            assertEquals(2, value.arguments.size)
+            assertEquals("x", value.arguments[0].value)
+            with(value.arguments[1]) {
+                assertEquals("name", name)
+                assertEquals("y", value)
+            }
+        }
+
+        // Continuation with leading whitespace on next line (consumed).
+        with(walk(".function {x} \\\n    name:{y}")) {
+            assertEquals("function", value.name)
+            assertEquals(2, value.arguments.size)
+            assertEquals("x", value.arguments[0].value)
+            with(value.arguments[1]) {
+                assertEquals("name", name)
+                assertEquals("y", value)
+            }
+        }
+
+        // Multiple continuations across three lines.
+        with(walk(".function {x} \\\n{y} \\\n{z}")) {
+            assertEquals("function", value.name)
+            assertEquals(3, value.arguments.size)
+            assertEquals("x", value.arguments[0].value)
+            assertEquals("y", value.arguments[1].value)
+            assertEquals("z", value.arguments[2].value)
+        }
+
+        // Continuation followed by a body argument.
+        with(
+            walk(
+                """
+                .function {x} \
+                {y}
+                  Body
+                """.trimIndent(),
+            ),
+        ) {
+            assertEquals("function", value.name)
+            assertEquals(2, value.arguments.size)
+            assertEquals("x", value.arguments[0].value)
+            assertEquals("y", value.arguments[1].value)
+            assertEquals("Body", value.bodyArgument?.value)
+        }
+
+        // Continuation before chaining separator.
+        with(walk(".foo {a} \\\n::bar {b}")) {
+            assertEquals("foo", value.name)
+            assertEquals(1, value.arguments.size)
+            assertEquals("a", value.arguments[0].value)
+            assertEquals("bar", value.next!!.name)
+            assertEquals(1, value.next!!.arguments.size)
+            assertEquals("b", value.next!!.arguments[0].value)
+        }
+
+        // Line continuation also works for inline function calls (allowsBody=false).
+        with(FunctionCallWalkerParser(".function {x} \\\n{y}", allowsBody = false).parse()) {
+            assertEquals("function", value.name)
+            assertEquals(2, value.arguments.size)
+            assertEquals("x", value.arguments[0].value)
+            assertEquals("y", value.arguments[1].value)
+        }
+
+        // Bare backslash at end of source (no newline) is not continuation.
+        with(walk(".function {x} \\")) {
+            assertEquals("function", value.name)
+            assertEquals(1, value.arguments.size)
+            assertEquals("x", value.arguments[0].value)
+        }
+
+        // Backslash inside argument content is literal, not continuation.
+        with(walk(".function {a\\\nb}")) {
+            assertEquals("function", value.name)
+            assertEquals(1, value.arguments.size)
+            assertEquals("a\\\nb", value.arguments[0].value)
+        }
+    }
+
+    /**
      * Verifies that escaped function calls are not tokenized as [FunctionCallToken]s.
      */
     @Test

--- a/quarkdown-lsp/src/main/kotlin/com/quarkdown/lsp/completion/function/parameter/FunctionParameterNameCompletionSupplier.kt
+++ b/quarkdown-lsp/src/main/kotlin/com/quarkdown/lsp/completion/function/parameter/FunctionParameterNameCompletionSupplier.kt
@@ -4,6 +4,7 @@ import com.quarkdown.lsp.cache.DocumentedFunction
 import com.quarkdown.lsp.completion.function.AbstractFunctionCompletionSupplier
 import com.quarkdown.lsp.completion.toCompletionItem
 import com.quarkdown.lsp.tokenizer.FunctionCall
+import com.quarkdown.lsp.tokenizer.FunctionCallToken
 import com.quarkdown.lsp.tokenizer.getTokenAtSourceIndex
 import com.quarkdown.lsp.util.remainderUntilIndex
 import org.eclipse.lsp4j.CompletionItem
@@ -38,7 +39,9 @@ class FunctionParameterNameCompletionSupplier(
     ): List<CompletionItem> {
         if (function == null) return emptyList()
         // Parameter names are only completed when the parameter name is being typed, so it's not yet part of the function call.
-        if (call.getTokenAtSourceIndex(originalCursorIndex) != null) return emptyList()
+        // A line continuation token is allowed: the cursor is on a blank continuation line, ready for a new parameter.
+        val tokenAtCursor = call.getTokenAtSourceIndex(originalCursorIndex)
+        if (tokenAtCursor != null && tokenAtCursor.type != FunctionCallToken.Type.LINE_CONTINUATION) return emptyList()
 
         // The remainder of the function call before the cursor position.
         // For example, if the function call being completed is `.function param`,

--- a/quarkdown-lsp/src/main/kotlin/com/quarkdown/lsp/highlight/function/FunctionCallTokensSupplier.kt
+++ b/quarkdown-lsp/src/main/kotlin/com/quarkdown/lsp/highlight/function/FunctionCallTokensSupplier.kt
@@ -13,6 +13,7 @@ import com.quarkdown.lsp.tokenizer.FunctionCallToken.Type.FUNCTION_NAME
 import com.quarkdown.lsp.tokenizer.FunctionCallToken.Type.INLINE_ARGUMENT_BEGIN
 import com.quarkdown.lsp.tokenizer.FunctionCallToken.Type.INLINE_ARGUMENT_END
 import com.quarkdown.lsp.tokenizer.FunctionCallToken.Type.INLINE_ARGUMENT_VALUE
+import com.quarkdown.lsp.tokenizer.FunctionCallToken.Type.LINE_CONTINUATION
 import com.quarkdown.lsp.tokenizer.FunctionCallToken.Type.NAMED_PARAMETER_DELIMITER
 import com.quarkdown.lsp.tokenizer.FunctionCallToken.Type.PARAMETER_NAME
 import org.eclipse.lsp4j.SemanticTokensParams
@@ -39,23 +40,33 @@ class FunctionCallTokensSupplier : SemanticTokensSupplier {
     private fun FunctionCallToken.toSimpleTokenData(): SimpleTokenData? {
         val type: TokenType? =
             when (type) {
-                BEGIN, FUNCTION_NAME ->
+                BEGIN, FUNCTION_NAME -> {
                     TokenType.FUNCTION_CALL_IDENTIFIER
+                }
 
-                CHAINING_SEPARATOR ->
+                CHAINING_SEPARATOR -> {
                     TokenType.FUNCTION_CALL_CHAINING_SEPARATOR
+                }
 
-                PARAMETER_NAME, NAMED_PARAMETER_DELIMITER ->
+                PARAMETER_NAME, NAMED_PARAMETER_DELIMITER -> {
                     TokenType.FUNCTION_CALL_NAMED_PARAMETER
+                }
 
-                INLINE_ARGUMENT_BEGIN, INLINE_ARGUMENT_END ->
+                INLINE_ARGUMENT_BEGIN, INLINE_ARGUMENT_END -> {
                     TokenType.FUNCTION_CALL_INLINE_ARGUMENT_DELIMITER
+                }
 
-                INLINE_ARGUMENT_VALUE ->
+                INLINE_ARGUMENT_VALUE -> {
                     ValueQualifier.getTokenType(lexeme.trim())
+                }
 
-                BODY_ARGUMENT ->
+                LINE_CONTINUATION -> {
+                    TokenType.FUNCTION_CALL_INLINE_ARGUMENT_DELIMITER
+                }
+
+                BODY_ARGUMENT -> {
                     null
+                }
             }
         return SimpleTokenData(
             type = type ?: return null,

--- a/quarkdown-lsp/src/main/kotlin/com/quarkdown/lsp/ontype/LineContinuationAutoIndentOnTypeFormattingEditSupplier.kt
+++ b/quarkdown-lsp/src/main/kotlin/com/quarkdown/lsp/ontype/LineContinuationAutoIndentOnTypeFormattingEditSupplier.kt
@@ -1,0 +1,92 @@
+package com.quarkdown.lsp.ontype
+
+import com.quarkdown.core.parser.walker.funcall.FunctionCallGrammar
+import com.quarkdown.lsp.TextDocument
+import com.quarkdown.lsp.cache.functionCalls
+import com.quarkdown.lsp.tokenizer.FunctionCall
+import com.quarkdown.lsp.tokenizer.FunctionCallToken
+import com.quarkdown.lsp.tokenizer.getAtSourceIndex
+import com.quarkdown.lsp.util.getLine
+import com.quarkdown.lsp.util.toOffset
+import org.eclipse.lsp4j.DocumentOnTypeFormattingParams
+import org.eclipse.lsp4j.Position
+import org.eclipse.lsp4j.Range
+import org.eclipse.lsp4j.TextEdit
+
+/**
+ * Formatter that, when the user presses Enter after a line ending with `\` (line continuation)
+ * inside a function call, inserts indentation on the new line to align with the first argument.
+ *
+ * For example, given:
+ * ```
+ * .container alignment:{center} \
+ * ```
+ * After pressing Enter, the new line is indented to:
+ * ```
+ * .container alignment:{center} \
+ *            <cursor here>
+ * ```
+ */
+class LineContinuationAutoIndentOnTypeFormattingEditSupplier : OnTypeFormattingEditSupplier {
+    override fun getEdits(
+        params: DocumentOnTypeFormattingParams,
+        document: TextDocument,
+    ): List<TextEdit> {
+        val text = document.text
+        val previousLineNum = params.position.line - 1
+        val previousLine = text.getLine(previousLineNum) ?: return emptyList()
+
+        if (!previousLine.trimEnd().endsWith(FunctionCallGrammar.LINE_CONTINUATION)) {
+            return emptyList()
+        }
+
+        // Only act on the first continuation line. Subsequent ones are already indented by the editor's built-in auto-indent.
+        val lineBeforePrevious = text.getLine(previousLineNum - 1)
+        if (lineBeforePrevious?.trimEnd()?.endsWith(FunctionCallGrammar.LINE_CONTINUATION) == true) {
+            return emptyList()
+        }
+
+        // Look up the function call before the `\`, since the `\` itself may fall outside
+        // the parsed call range when the next line has no content yet.
+        val searchColumn =
+            previousLine
+                .trimEnd()
+                .dropLast(1)
+                .trimEnd()
+                .length - 1
+        if (searchColumn < 0) return emptyList()
+
+        val call: FunctionCall =
+            document.functionCalls
+                .getAtSourceIndex(Position(previousLineNum, searchColumn).toOffset(text))
+                ?: return emptyList()
+
+        val indentation = call.argumentStartColumn(text)
+
+        return listOf(
+            TextEdit(
+                Range(
+                    Position(params.position.line, 0),
+                    Position(params.position.line, 0),
+                ),
+                " ".repeat(indentation),
+            ),
+        )
+    }
+
+    /**
+     * @return the column where arguments begin, i.e. right after `.functionname `.
+     */
+    private fun FunctionCall.argumentStartColumn(text: String): Int {
+        val callStartOffset = range.first
+        val lineStartOffset = text.lastIndexOf('\n', callStartOffset - 1) + 1
+        val callColumn = callStartOffset - lineStartOffset
+
+        val prefixLength =
+            tokens
+                .takeWhile { it.type == FunctionCallToken.Type.BEGIN || it.type == FunctionCallToken.Type.FUNCTION_NAME }
+                .sumOf { it.lexeme.length }
+
+        return callColumn + prefixLength + 1 // +1 for the space after the function name.
+    }
+}

--- a/quarkdown-lsp/src/main/kotlin/com/quarkdown/lsp/ontype/OnTypeFormattingSuppliersFactory.kt
+++ b/quarkdown-lsp/src/main/kotlin/com/quarkdown/lsp/ontype/OnTypeFormattingSuppliersFactory.kt
@@ -4,5 +4,9 @@ package com.quarkdown.lsp.ontype
  * Factory for creating [OnTypeFormattingEditSupplier]s.
  */
 object OnTypeFormattingSuppliersFactory {
-    fun default(): List<OnTypeFormattingEditSupplier> = listOf(TrailingSpacesRemoverOnTypeFormattingEditSupplier())
+    fun default(): List<OnTypeFormattingEditSupplier> =
+        listOf(
+            TrailingSpacesRemoverOnTypeFormattingEditSupplier(),
+            LineContinuationAutoIndentOnTypeFormattingEditSupplier(),
+        )
 }

--- a/quarkdown-lsp/src/main/kotlin/com/quarkdown/lsp/tokenizer/FunctionCall.kt
+++ b/quarkdown-lsp/src/main/kotlin/com/quarkdown/lsp/tokenizer/FunctionCall.kt
@@ -66,6 +66,9 @@ data class FunctionCallToken(
 
         /** A body argument. */
         BODY_ARGUMENT,
+
+        /** A line continuation (backslash at end of line). */
+        LINE_CONTINUATION,
     }
 }
 

--- a/quarkdown-lsp/src/main/kotlin/com/quarkdown/lsp/tokenizer/FunctionCallTokenizer.kt
+++ b/quarkdown-lsp/src/main/kotlin/com/quarkdown/lsp/tokenizer/FunctionCallTokenizer.kt
@@ -14,6 +14,7 @@ private const val FUNCTION_CALL_ARGUMENT_CONTENT_TOKEN_NAME = "argContent"
 private const val FUNCTION_CALL_INLINE_ARGUMENT_BEGIN_TOKEN_NAME = "argumentBegin"
 private const val FUNCTION_CALL_INLINE_ARGUMENT_END_TOKEN_NAME = "argumentEnd"
 private const val FUNCTION_CALL_INLINE_ARGUMENT_CONTENT_TOKEN_NAME = "argContent"
+private const val FUNCTION_CALL_LINE_CONTINUATION_TOKEN_NAME = "lineContinuation"
 
 /**
  * Tokenizes function calls in text content.
@@ -167,6 +168,12 @@ class FunctionCallTokenizer {
             //            ^^^
             FUNCTION_CALL_INLINE_ARGUMENT_CONTENT_TOKEN_NAME -> {
                 FunctionCallToken.Type.INLINE_ARGUMENT_VALUE
+            }
+
+            // .function {x} \
+            //               ^
+            FUNCTION_CALL_LINE_CONTINUATION_TOKEN_NAME -> {
+                FunctionCallToken.Type.LINE_CONTINUATION
             }
 
             else -> {

--- a/quarkdown-lsp/src/test/kotlin/com/quarkdown/lsp/FunctionCallTokenizerTest.kt
+++ b/quarkdown-lsp/src/test/kotlin/com/quarkdown/lsp/FunctionCallTokenizerTest.kt
@@ -237,6 +237,27 @@ class FunctionCallTokenizerTest {
     }
 
     @Test
+    fun `function call with line continuation`() {
+        val text = ".function {arg1} \\\n  name:{arg2}"
+        val calls = tokenizer.getFunctionCalls(text)
+
+        assertEquals(1, calls.size)
+
+        val call = calls.first()
+        val tokens = call.tokens
+
+        // Verify line continuation token is present.
+        val continuationToken = tokens.find { it.type == FunctionCallToken.Type.LINE_CONTINUATION }
+        assertNotNull(continuationToken)
+        assertEquals("\\", continuationToken.lexeme.take(1))
+
+        // Verify the named parameter after the continuation is still tokenized.
+        val paramNameToken = tokens.find { it.type == FunctionCallToken.Type.PARAMETER_NAME }
+        assertNotNull(paramNameToken)
+        assertEquals("name", paramNameToken.lexeme)
+    }
+
+    @Test
     fun `wrapped function call with named parameter`() {
         val text = "{.function param:{value}}"
         val calls = tokenizer.getFunctionCalls(text)

--- a/quarkdown-lsp/src/test/kotlin/com/quarkdown/lsp/FunctionCallTokensSupplierTest.kt
+++ b/quarkdown-lsp/src/test/kotlin/com/quarkdown/lsp/FunctionCallTokensSupplierTest.kt
@@ -365,6 +365,28 @@ class FunctionCallTokensSupplierTest {
         }
     }
 
+    // Line continuation
+
+    @Test
+    fun `function call with line continuation`() {
+        tokenize(
+            ".func {arg1} \\\n  name:{arg2}".normalizeLineSeparators().toString(),
+        ) {
+            assertNext(TYPE_BEGIN, 0..1)
+            assertNext(TYPE_NAME, 1..5)
+            assertNext(TYPE_INLINE_ARGUMENT_DELIMITER, 6..7)
+            assertNext(TokenType.ENUM, 7..11)
+            assertNext(TYPE_INLINE_ARGUMENT_DELIMITER, 11..12)
+            // Line continuation is highlighted as punctuation.
+            assertNext(TYPE_INLINE_ARGUMENT_DELIMITER, 13..17) // `\` + `\n` + `  `
+            assertNext(TYPE_NAMED_PARAMETER, 17..21) // name
+            assertNext(TYPE_NAMED_PARAMETER_SEPARATOR, 21..22) // :
+            assertNext(TYPE_INLINE_ARGUMENT_DELIMITER, 22..23) // {
+            assertNext(TokenType.ENUM, 23..27) // arg2
+            assertNext(TYPE_INLINE_ARGUMENT_DELIMITER, 27..28) // }
+        }
+    }
+
     // Wrapped (tight) function calls
 
     @Test

--- a/quarkdown-lsp/src/test/kotlin/com/quarkdown/lsp/FunctionCompletionSupplierTest.kt
+++ b/quarkdown-lsp/src/test/kotlin/com/quarkdown/lsp/FunctionCompletionSupplierTest.kt
@@ -22,6 +22,8 @@ private const val LAYOUT_MODULE = "Layout"
 private const val DATA_MODULE = "Data"
 
 private const val ALIGNMENT_PARAMETER = "alignment"
+private const val CROSS_PARAMETER = "cross"
+private const val GAP_PARAMETER = "gap"
 private const val BODY_PARAMETER = "body"
 private const val CAPTION_PARAMETER = "caption"
 
@@ -204,6 +206,51 @@ class FunctionCompletionSupplierTest {
         val completions = getCompletions(text, position).map { it.label }
 
         assertContains(completions, ALIGNMENT_PARAMETER)
+    }
+
+    @Test
+    fun `parameter completions on blank line continuation`() {
+        val text = ".$ALIGN_FUNCTION \\\n"
+        val position = Position(1, 0)
+        val completions = getCompletions(text, position).map { it.label }
+
+        assertContains(completions, ALIGNMENT_PARAMETER)
+        assertContains(completions, BODY_PARAMETER)
+    }
+
+    @Test
+    fun `parameter completions on line continuation with some parameters specified`() {
+        val text = ".$ALIGN_FUNCTION $ALIGNMENT_PARAMETER:{center} \\\n"
+        val position = Position(1, 0)
+        val completions = getCompletions(text, position).map { it.label }
+
+        assertFalse(ALIGNMENT_PARAMETER in completions)
+        assertEquals(BODY_PARAMETER, completions.single())
+    }
+
+    @Test
+    fun `parameter completions on non-blank continuation line`() {
+        val text = ".$COLUMN_FUNCTION $ALIGNMENT_PARAMETER:{center} \\\n        $GAP_PARAMETER:{1px} "
+        val position = Position(1, text.lines()[1].length)
+        val completions = getCompletions(text, position).map { it.label }
+
+        assertContains(completions, CROSS_PARAMETER)
+        assertContains(completions, BODY_PARAMETER)
+        assertFalse(ALIGNMENT_PARAMETER in completions)
+        assertFalse(GAP_PARAMETER in completions)
+    }
+
+    @Test
+    fun `parameter completions on blank line among non-blank continuations`() {
+        // .column alignment:{center} \
+        //        <cursor here> \
+        //        gap:{1px}
+        val text = ".$COLUMN_FUNCTION $ALIGNMENT_PARAMETER:{center} \\\n \\\n        $GAP_PARAMETER:{1px}"
+        val position = Position(1, 1)
+        val completions = getCompletions(text, position).map { it.label }
+
+        assertContains(completions, CROSS_PARAMETER)
+        assertContains(completions, BODY_PARAMETER)
     }
 
     @Test

--- a/quarkdown-lsp/src/test/kotlin/com/quarkdown/lsp/LineContinuationAutoIndentOnTypeFormattingEditSupplierTest.kt
+++ b/quarkdown-lsp/src/test/kotlin/com/quarkdown/lsp/LineContinuationAutoIndentOnTypeFormattingEditSupplierTest.kt
@@ -1,0 +1,105 @@
+package com.quarkdown.lsp
+
+import com.quarkdown.core.util.normalizeLineSeparators
+import com.quarkdown.lsp.ontype.LineContinuationAutoIndentOnTypeFormattingEditSupplier
+import org.eclipse.lsp4j.DocumentOnTypeFormattingParams
+import org.eclipse.lsp4j.FormattingOptions
+import org.eclipse.lsp4j.Position
+import org.eclipse.lsp4j.TextDocumentIdentifier
+import org.eclipse.lsp4j.TextEdit
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Tests for [LineContinuationAutoIndentOnTypeFormattingEditSupplier].
+ */
+class LineContinuationAutoIndentOnTypeFormattingEditSupplierTest {
+    private val supplier = LineContinuationAutoIndentOnTypeFormattingEditSupplier()
+
+    private fun getEdits(
+        text: String,
+        atLine: Int,
+    ): List<TextEdit> {
+        val doc = TextDocument(text.normalizeLineSeparators().toString())
+        val options = FormattingOptions(2, true)
+        val params =
+            DocumentOnTypeFormattingParams(TextDocumentIdentifier("mem://test.qd"), options, Position(atLine, 0), "\n")
+        return supplier.getEdits(params, doc)
+    }
+
+    @Test
+    fun `indents after line continuation in function call`() {
+        // .container alignment:{center} \
+        // <cursor here>
+        val text = ".container alignment:{center} \\\n"
+        val edits = getEdits(text, 1)
+        assertEquals(1, edits.size)
+        val edit = edits.single()
+        // Inserts indentation to align with the first argument (after `.container `).
+        assertEquals(1, edit.range.start.line)
+        assertEquals(0, edit.range.start.character)
+        assertEquals(" ".repeat(".container ".length), edit.newText)
+    }
+
+    @Test
+    fun `indents after line continuation with existing args`() {
+        // .func {arg1} \
+        // <cursor here>
+        val text = ".func {arg1} \\\n"
+        val edits = getEdits(text, 1)
+        assertEquals(1, edits.size)
+        assertEquals(" ".repeat(".func ".length), edits.single().newText)
+    }
+
+    @Test
+    fun `indents after line continuation with no args`() {
+        // .func \
+        // <cursor here>
+        val text = ".func \\\n"
+        val edits = getEdits(text, 1)
+        assertEquals(1, edits.size)
+        assertEquals(" ".repeat(".func ".length), edits.single().newText)
+    }
+
+    @Test
+    fun `indents after line continuation in inline function preceded by other content`() {
+        // Hello .func {arg1} \
+        // <cursor here>
+        val text = "Hello .func {arg1} \\\n"
+        val edits = getEdits(text, 1)
+        assertEquals(1, edits.size)
+        assertEquals(" ".repeat("Hello .func ".length), edits.single().newText)
+    }
+
+    @Test
+    fun `no indentation when previous line does not end with backslash`() {
+        val text = ".func {arg1}\n"
+        val edits = getEdits(text, 1)
+        assertTrue(edits.isEmpty())
+    }
+
+    @Test
+    fun `no indentation for non-function-call line`() {
+        val text = "Hello world \\\n"
+        val edits = getEdits(text, 1)
+        assertTrue(edits.isEmpty())
+    }
+
+    @Test
+    fun `no indentation on subsequent continuation lines`() {
+        // .container alignment:{center} \
+        //            padding:{1px} \
+        // <cursor here>
+        // The editor's built-in auto-indent preserves the previous line's indentation.
+        val text = ".container alignment:{center} \\\n           padding:{1px} \\\n"
+        assertTrue(getEdits(text, 2).isEmpty())
+    }
+
+    @Test
+    fun `no indentation on third continuation line`() {
+        val indent = " ".repeat(".container ".length)
+        val text = ".container alignment:{center} \\\n${indent}padding:{1px} \\\n${indent}margin:{2px} \\\n"
+        assertTrue(getEdits(text, 3).isEmpty())
+    }
+}

--- a/quarkdown-quarkdoc/src/main/kotlin/com/quarkdown/quarkdoc/dokka/signature/LineBreakingStrategy.kt
+++ b/quarkdown-quarkdoc/src/main/kotlin/com/quarkdown/quarkdoc/dokka/signature/LineBreakingStrategy.kt
@@ -1,5 +1,6 @@
 package com.quarkdown.quarkdoc.dokka.signature
 
+import com.quarkdown.core.parser.walker.funcall.FunctionCallGrammar
 import org.jetbrains.dokka.base.translators.documentables.PageContentBuilder
 import org.jetbrains.dokka.model.DFunction
 import org.jetbrains.dokka.model.DParameter
@@ -83,8 +84,8 @@ private class SplitLineBreakingStrategy(
     /**
      * Result:
      * ```
-     * .func abcd:{Int}
-     *         ef:{String}
+     * .func abcd:{Int} \
+     *         ef:{String} \
      *     ghijkl:{Int}
      * ```
      */
@@ -101,11 +102,16 @@ private class SplitLineBreakingStrategy(
             return
         }
 
-        breakLine()
+        lineContinuation()
         pad(supplementPad + firstParameterNameLength - parameterNameLength)
     }
 
     override fun PageContentBuilder.DocumentableContentBuilder.beforeReturn() {
+        lineContinuation()
+    }
+
+    private fun PageContentBuilder.DocumentableContentBuilder.lineContinuation() {
+        punctuation(" " + FunctionCallGrammar.LINE_CONTINUATION)
         breakLine()
     }
 }

--- a/quarkdown-quarkdoc/src/test/kotlin/com/quarkdown/quarkdoc/dokka/QuarkdownSignatureTest.kt
+++ b/quarkdown-quarkdoc/src/test/kotlin/com/quarkdown/quarkdoc/dokka/QuarkdownSignatureTest.kt
@@ -73,9 +73,9 @@ class QuarkdownSignatureTest :
         testSignature("fun func(a: Int, b: Int, c: Int) = VoidValue") {
             assertEquals(
                 """
-                .func a:{Int}
-                      b:{Int}
-                      c:{Int}
+                .func a:{Int} \
+                      b:{Int} \
+                      c:{Int} \
                 -> Void
                 """.trimIndent(),
                 it,
@@ -88,9 +88,9 @@ class QuarkdownSignatureTest :
         testSignature("fun func(abcd: Int, ef: String, ghijkl: Int) = VoidValue") {
             assertEquals(
                 """
-                .func abcd:{Int}
-                        ef:{String}
-                    ghijkl:{Int}
+                .func abcd:{Int} \
+                        ef:{String} \
+                    ghijkl:{Int} \
                 -> Void
                 """.trimIndent(),
                 it,
@@ -103,9 +103,9 @@ class QuarkdownSignatureTest :
         testSignature("fun func(abcd: Int, ef: String, ghijklmnopqrst: Int) = VoidValue") {
             assertEquals(
                 """
-                .func      abcd:{Int}
-                             ef:{String}
-                 ghijklmnopqrst:{Int}
+                .func      abcd:{Int} \
+                             ef:{String} \
+                 ghijklmnopqrst:{Int} \
                 -> Void
                 """.trimIndent(),
                 it,

--- a/quarkdown-test/src/test/kotlin/com/quarkdown/test/FunctionCallTest.kt
+++ b/quarkdown-test/src/test/kotlin/com/quarkdown/test/FunctionCallTest.kt
@@ -129,6 +129,16 @@ class FunctionCallTest {
                 it,
             )
         }
+
+        // Trailing content after args on a continuation line is inline, not block.
+        execute(
+            """
+            .sum {1} \
+                 {2} hello
+            """.trimIndent(),
+        ) {
+            assertEquals("<p>3 hello</p>", it)
+        }
     }
 
     @Test

--- a/quarkdown-test/src/test/kotlin/com/quarkdown/test/FunctionCallTest.kt
+++ b/quarkdown-test/src/test/kotlin/com/quarkdown/test/FunctionCallTest.kt
@@ -95,6 +95,43 @@ class FunctionCallTest {
     }
 
     @Test
+    fun `line continuation`() {
+        // Basic: inline args across lines.
+        execute(".sum {3} \\\n{4}") {
+            assertEquals("<p>7</p>", it)
+        }
+
+        // Named args across lines.
+        execute(".multiply {3} \\\nby:{6}") {
+            assertEquals("<p>18</p>", it)
+        }
+
+        // Multiple continuations.
+        execute(
+            """
+            .sum {.sum {1} {2}} \
+            {4}
+            """.trimIndent(),
+        ) {
+            assertEquals("<p>7</p>", it)
+        }
+
+        // Continuation + body argument.
+        execute(
+            """
+            .code \
+            lang:{txt}
+                hello
+            """.trimIndent(),
+        ) {
+            assertEquals(
+                "<pre><code class=\"language-txt\">hello</code></pre>",
+                it,
+            )
+        }
+    }
+
+    @Test
     fun `wrapped inline function call (loose)`() {
         execute("hello {.sum {1} {2}} hello") {
             assertEquals("<p>hello 3 hello</p>", it)


### PR DESCRIPTION
```markdown
.func first:{x} \
      second:{y} \
      third:{z}
```

also supported by lsp
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/iamgio/quarkdown/pull/449" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
