### PR TITLE
fix(preview): use static output name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,11 @@ As before, opt-in libraries, such as Mermaid and KaTeX, are still only included 
 
 Rendering now runs in parallel across sibling elements, improving performance on large documents.
 
+#### Static preview output file name (breaking change)
+
+When launching with `--preview` (without `--out-name`), the output directory name no longer matches `.docname`, because its dynamic nature may easily break the preview. Instead, it's now `preview-<mainfile>-<hash>`.  
+In order to get the `.docname`-based output name, consider compiling without `--preview`.
+
 ### Fixed
 
 #### Fixed broken wiki links in Quarkdoc

--- a/quarkdown-cli/src/main/kotlin/com/quarkdown/cli/exec/ExecuteCommand.kt
+++ b/quarkdown-cli/src/main/kotlin/com/quarkdown/cli/exec/ExecuteCommand.kt
@@ -203,12 +203,37 @@ abstract class ExecuteCommand(
         ).let(::finalizeCliOptions)
 
     /**
+     * When preview is enabled, the output resource name must be fixed
+     * so that changing the document title doesn't break the live preview.
+     * If the user explicitly set [resourceName], that value is used as-is.
+     * Otherwise, if preview is enabled, the resource name is derived from a hash of the source file path.
+     * @param cliOptions finalized CLI options
+     * @return the resolved resource name, or `null` to let the pipeline decide
+     */
+    private fun resolveResourceName(cliOptions: CliOptions): String? =
+        when {
+            resourceName != null -> {
+                resourceName
+            }
+
+            preview -> {
+                cliOptions.source
+                    ?.let { it.nameWithoutExtension to it.absolutePath.hashCode().toUInt() }
+                    ?.let { (name, hash) -> "preview-$name-$hash" }
+            }
+
+            else -> {
+                null
+            }
+        }
+
+    /**
      * @param cliOptions finalized CLI options
      * @return pipeline options based on the command's properties
      */
     fun createPipelineOptions(cliOptions: CliOptions) =
         PipelineOptions(
-            resourceName = resourceName,
+            resourceName = resolveResourceName(cliOptions),
             prettyOutput = prettyOutput,
             wrapOutput = !noWrap,
             workingDirectory = cliOptions.source?.absoluteFile?.parentFile,

--- a/quarkdown-cli/src/test/kotlin/com/quarkdown/cli/CompileCommandTest.kt
+++ b/quarkdown-cli/src/test/kotlin/com/quarkdown/cli/CompileCommandTest.kt
@@ -404,6 +404,56 @@ class CompileCommandTest : TempDirectory() {
         checkPdf()
     }
 
+    /**
+     * Runs the command with `--preview --pipe` to test preview resource name resolution
+     * without triggering server communication (`--pipe` causes an early return in `postExecute`).
+     * @return the pipeline options after parsing
+     */
+    private fun testPreviewResourceName(vararg additionalArgs: String): PipelineOptions {
+        val pipeStdout = java.io.ByteArrayOutputStream()
+        val originalOut = System.out
+        try {
+            System.setOut(java.io.PrintStream(pipeStdout))
+            command.test(
+                main.absolutePath,
+                "-o",
+                outputDirectory.absolutePath,
+                "--preview",
+                "--pipe",
+                *additionalArgs,
+            )
+        } finally {
+            System.setOut(originalOut)
+        }
+        return command.createPipelineOptions(command.createCliOptions())
+    }
+
+    @Test
+    fun `preview uses deterministic resource name`() {
+        val pipelineOptions = testPreviewResourceName()
+        val expectedHash = main.absolutePath.hashCode().toUInt()
+        assertEquals("preview-main-$expectedHash", pipelineOptions.resourceName)
+    }
+
+    @Test
+    fun `preview resource name is stable across runs`() {
+        val first = testPreviewResourceName()
+        val second = testPreviewResourceName()
+        assertEquals(first.resourceName, second.resourceName)
+    }
+
+    @Test
+    fun `preview with explicit output name uses explicit name`() {
+        val pipelineOptions = testPreviewResourceName("--out-name", "Custom")
+        assertEquals("Custom", pipelineOptions.resourceName)
+    }
+
+    @Test
+    fun `no preview uses null resource name`() {
+        val (_, pipelineOptions) = test()
+        assertEquals(null, pipelineOptions.resourceName)
+    }
+
     @Test
     fun `plaintext, single subdocument`() {
         val (_, _, _) = test("--render", "text")


### PR DESCRIPTION
When launching with `--preview` without `--out-name`, use a static output dir name to avoid breaking the preview on docname changes