### PR TITLE
feat(postrenderer): add checksum invalidation to resource copying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ The default output directory (`--out`) was changed from `./output` to `./quarkdo
 
 HTML documents now render entirely offline. Assets such as fonts, opt-in libraries and code highlighting themes, are now bundled in the Quarkdown installation and copied to each generated document. Previously, the output relied on CDNs and Google Fonts, which meant that opening a document without an internet connection could lead to broken styling and missing features.
 
-With this change, compilation is slightly slower and the output directory size is larger, but it comes with more predictable rendering and significantly faster page loads.
+With this change, output directory size is larger, but it comes with more predictable rendering and significantly faster page loads. First-time compilations may take slightly longer due to the additional copying step, but subsequent compilation times should be unaffected thanks to checksum validation.
 
 As before, opt-in libraries, such as Mermaid and KaTeX, are still only included if used in the document, so they don't affect performance or output size if not needed.
 

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/pipeline/output/FileReferenceOutputArtifact.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/pipeline/output/FileReferenceOutputArtifact.kt
@@ -7,10 +7,13 @@ import java.io.File
  * Instead of holding content in memory, it references a [file] that is efficiently copied to the output location.
  * @param name the output file name (with extension, since the original file name is used as-is)
  * @param file the source file (or directory) to copy
+ * @param useChecksumInvalidation whether to also create a checksum file for this artifact, used for incremental builds
+ *                                to determine whether the artifact has changed since the last build and should be recreated.
  */
 data class FileReferenceOutputArtifact(
     override val name: String,
     val file: File,
+    val useChecksumInvalidation: Boolean = false,
 ) : OutputResource {
     override fun <T> accept(visitor: OutputResourceVisitor<T>): T = visitor.visit(this)
 }

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/pipeline/output/OutputResource.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/pipeline/output/OutputResource.kt
@@ -2,7 +2,7 @@ package com.quarkdown.core.pipeline.output
 
 /**
  * Abstraction of an output entity produced by the pipeline.
- * A resource is saved to file via a [FileResourceExporter].
+ * A resource is saved to file via a [com.quarkdown.core.pipeline.output.visitor.FileResourceExporter].
  */
 interface OutputResource {
     /**

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/pipeline/output/visitor/FileResourceExporter.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/pipeline/output/visitor/FileResourceExporter.kt
@@ -105,7 +105,7 @@ class FileResourceExporter(
                 val currentChecksum = IOUtils.computeChecksum(artifact.file)
                 val storedChecksum = checksumFile.takeIf { it.isFile }?.readText()
 
-                if (currentChecksum == storedChecksum) {
+                if (currentChecksum == storedChecksum && target.exists()) {
                     Log.debug { "Skipping '${artifact.name}': checksum unchanged ($currentChecksum)" }
                     return@also
                 }

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/pipeline/output/visitor/FileResourceExporter.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/pipeline/output/visitor/FileResourceExporter.kt
@@ -1,5 +1,6 @@
 package com.quarkdown.core.pipeline.output.visitor
 
+import com.quarkdown.core.log.Log
 import com.quarkdown.core.pipeline.output.ArtifactType
 import com.quarkdown.core.pipeline.output.BinaryOutputArtifact
 import com.quarkdown.core.pipeline.output.FileReferenceOutputArtifact
@@ -10,12 +11,14 @@ import com.quarkdown.core.pipeline.output.OutputResourceVisitor
 import com.quarkdown.core.pipeline.output.TextOutputArtifact
 import com.quarkdown.core.pipeline.output.visitor.FileResourceExporter.NameProvider.fileNameWithoutExtension
 import com.quarkdown.core.pipeline.output.visitor.FileResourceExporter.NameProvider.fullFileName
+import com.quarkdown.core.util.IOUtils
 import com.quarkdown.core.util.sanitizeFileName
 import java.io.File
 
 /**
  * A visitor that saves each type of [OutputResource] to a file and returns it.
  * @param location directory to save the resources to
+ * @param write whether to actually write to the file system (if `false`, the visitor only returns the corresponding file paths without creating them)
  */
 class FileResourceExporter(
     private val location: File,
@@ -83,19 +86,51 @@ class FileResourceExporter(
     /**
      * Copies a [FileReferenceOutputArtifact] to the output location.
      * If the source is a directory, it is copied recursively.
+     *
+     * When [FileReferenceOutputArtifact.useChecksumInvalidation] is enabled, a sibling
+     * `.checksum` file is maintained next to the output. If the checksum of the source
+     * matches the stored value, the copy is skipped entirely. This avoids redundant I/O
+     * for large assets (fonts, third-party libraries) that rarely change between builds.
+     *
      * @return the copied file or directory
      */
     override fun visit(artifact: FileReferenceOutputArtifact) =
-        File(location, artifact.name).also {
-            if (write) {
-                it.parentFile?.mkdirs()
-                if (artifact.file.isDirectory) {
-                    artifact.file.copyRecursively(it, overwrite = true)
-                } else {
-                    artifact.file.copyTo(it, overwrite = true)
+        File(location, artifact.name).also { target ->
+            if (!write) return@also
+
+            target.parentFile?.mkdirs()
+
+            if (artifact.useChecksumInvalidation) {
+                val checksumFile = target.resolveSibling("${target.name}.checksum")
+                val currentChecksum = IOUtils.computeChecksum(artifact.file)
+                val storedChecksum = checksumFile.takeIf { it.isFile }?.readText()
+
+                if (currentChecksum == storedChecksum) {
+                    Log.debug { "Skipping '${artifact.name}': checksum unchanged ($currentChecksum)" }
+                    return@also
                 }
+
+                Log.debug {
+                    "Copying '${artifact.name}': checksum changed " +
+                        "(stored=${storedChecksum ?: "<none>"}, current=$currentChecksum)"
+                }
+                copyFileOrDirectory(artifact.file, target)
+                checksumFile.writeText(currentChecksum)
+            } else {
+                copyFileOrDirectory(artifact.file, target)
             }
         }
+
+    private fun copyFileOrDirectory(
+        source: File,
+        target: File,
+    ) {
+        if (source.isDirectory) {
+            source.copyRecursively(target, overwrite = true)
+        } else {
+            source.copyTo(target, overwrite = true)
+        }
+    }
 
     /**
      * Saves an [OutputResourceGroup] to a directory which contains its nested files.

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/util/IOUtils.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/util/IOUtils.kt
@@ -45,7 +45,7 @@ object IOUtils {
     }
 
     /**
-     * Computes a SHA-256 digest that represents the current state of [file].
+     * Computes an SHA-256 digest that represents the current state of [file].
      * - For a regular file, the digest covers its content.
      * - For a directory, the digest covers the sorted list of relative paths and file sizes,
      *   which is fast (metadata only) and catches additions, deletions, and size changes.
@@ -61,7 +61,9 @@ object IOUtils {
                 .sortedBy { it.relativeTo(file).path }
                 .forEach {
                     digest.update(it.relativeTo(file).path.toByteArray())
+                    digest.update(0)
                     digest.update(it.length().toString().toByteArray())
+                    digest.update(0)
                 }
         }
         return digest.digest().joinToString("") { "%02x".format(it) }

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/util/IOUtils.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/util/IOUtils.kt
@@ -3,6 +3,7 @@ package com.quarkdown.core.util
 import java.io.File
 import java.io.IOException
 import java.nio.file.Path
+import java.security.MessageDigest
 import kotlin.io.path.Path
 
 /**
@@ -41,6 +42,29 @@ object IOUtils {
         val parentPath = parent.toPath().resolveReal()
         val childPath = child.toPath().resolveReal()
         return childPath.startsWith(parentPath)
+    }
+
+    /**
+     * Computes a SHA-256 digest that represents the current state of [file].
+     * - For a regular file, the digest covers its content.
+     * - For a directory, the digest covers the sorted list of relative paths and file sizes,
+     *   which is fast (metadata only) and catches additions, deletions, and size changes.
+     */
+    fun computeChecksum(file: File): String {
+        val digest = MessageDigest.getInstance("SHA-256")
+        if (file.isFile) {
+            digest.update(file.readBytes())
+        } else {
+            file
+                .walkTopDown()
+                .filter { it.isFile }
+                .sortedBy { it.relativeTo(file).path }
+                .forEach {
+                    digest.update(it.relativeTo(file).path.toByteArray())
+                    digest.update(it.length().toString().toByteArray())
+                }
+        }
+        return digest.digest().joinToString("") { "%02x".format(it) }
     }
 
     /**

--- a/quarkdown-core/src/test/kotlin/com/quarkdown/core/FileResourceExporterTest.kt
+++ b/quarkdown-core/src/test/kotlin/com/quarkdown/core/FileResourceExporterTest.kt
@@ -1,0 +1,230 @@
+package com.quarkdown.core
+
+import com.quarkdown.core.pipeline.output.ArtifactType
+import com.quarkdown.core.pipeline.output.BinaryOutputArtifact
+import com.quarkdown.core.pipeline.output.FileReferenceOutputArtifact
+import com.quarkdown.core.pipeline.output.OutputResourceGroup
+import com.quarkdown.core.pipeline.output.TextOutputArtifact
+import com.quarkdown.core.pipeline.output.visitor.FileResourceExporter
+import java.io.File
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Tests for [FileResourceExporter] writing resources to disk.
+ */
+class FileResourceExporterTest {
+    private fun withTempDir(block: (File) -> Unit) {
+        val dir = Files.createTempDirectory("exporterTest").toFile()
+        try {
+            block(dir)
+        } finally {
+            dir.deleteRecursively()
+        }
+    }
+
+    // Text artifacts
+
+    @Test
+    fun `text artifact is written with correct extension`() =
+        withTempDir { dir ->
+            val artifact = TextOutputArtifact(name = "index", content = "<h1>hello</h1>", type = ArtifactType.HTML)
+            val result = artifact.accept(FileResourceExporter(dir))
+
+            assertEquals("index.html", result.name)
+            assertEquals("<h1>hello</h1>", result.readText())
+        }
+
+    @Test
+    fun `auto artifact preserves original name`() =
+        withTempDir { dir ->
+            val artifact = TextOutputArtifact(name = "data.csv", content = "a,b", type = ArtifactType.AUTO)
+            val result = artifact.accept(FileResourceExporter(dir))
+
+            assertEquals("data.csv", result.name)
+            assertEquals("a,b", result.readText())
+        }
+
+    // Binary artifacts
+
+    @Test
+    fun `binary artifact is written`() =
+        withTempDir { dir ->
+            val bytes = listOf<Byte>(0x00, 0x01, 0x02)
+            val artifact = BinaryOutputArtifact(name = "out", content = bytes, type = ArtifactType.AUTO)
+            val result = artifact.accept(FileResourceExporter(dir))
+
+            assertEquals(bytes, result.readBytes().toList())
+        }
+
+    // File reference artifacts
+
+    @Test
+    fun `file reference copies a single file`() =
+        withTempDir { dir ->
+            val source = File(dir, "src").also { it.mkdir() }
+            val sourceFile = File(source, "style.css").also { it.writeText("body {}") }
+
+            val output = File(dir, "out").also { it.mkdir() }
+            val artifact = FileReferenceOutputArtifact(name = "style.css", file = sourceFile)
+            val result = artifact.accept(FileResourceExporter(output))
+
+            assertEquals("style.css", result.name)
+            assertEquals("body {}", result.readText())
+        }
+
+    @Test
+    fun `file reference copies a directory recursively`() =
+        withTempDir { dir ->
+            val source = File(dir, "lib").also { it.mkdir() }
+            File(source, "a.js").writeText("var a;")
+            File(source, "sub").mkdir()
+            File(source, "sub/b.js").writeText("var b;")
+
+            val output = File(dir, "out").also { it.mkdir() }
+            val artifact = FileReferenceOutputArtifact(name = "lib", file = source)
+            val result = artifact.accept(FileResourceExporter(output))
+
+            assertTrue(result.isDirectory)
+            assertEquals("var a;", File(result, "a.js").readText())
+            assertEquals("var b;", File(result, "sub/b.js").readText())
+        }
+
+    // Resource groups
+
+    @Test
+    fun `group creates a subdirectory with nested resources`() =
+        withTempDir { dir ->
+            val group =
+                OutputResourceGroup(
+                    name = "theme",
+                    resources =
+                        setOf(
+                            TextOutputArtifact(name = "global", content = "* {}", type = ArtifactType.CSS),
+                            TextOutputArtifact(name = "dark", content = ".dark {}", type = ArtifactType.CSS),
+                        ),
+                )
+            val result = group.accept(FileResourceExporter(dir))
+
+            assertTrue(result.isDirectory)
+            assertEquals("theme", result.name)
+            assertEquals("* {}", File(result, "global.css").readText())
+            assertEquals(".dark {}", File(result, "dark.css").readText())
+        }
+
+    @Test
+    fun `empty group does not create directory`() =
+        withTempDir { dir ->
+            val group = OutputResourceGroup(name = "empty", resources = emptySet())
+            val result = group.accept(FileResourceExporter(dir))
+
+            assertFalse(result.exists())
+        }
+
+    // write = false
+
+    @Test
+    fun `write false returns paths without creating files`() =
+        withTempDir { dir ->
+            val artifact = TextOutputArtifact(name = "ghost", content = "boo", type = ArtifactType.HTML)
+            val result = artifact.accept(FileResourceExporter(dir, write = false))
+
+            assertEquals("ghost.html", result.name)
+            assertFalse(result.exists())
+        }
+
+    // Checksum invalidation
+
+    @Test
+    fun `checksum skips copy when source unchanged`() =
+        withTempDir { dir ->
+            val source = File(dir, "src").also { it.mkdir() }
+            File(source, "lib.js").writeText("console.log('v1');")
+
+            val output = File(dir, "out").also { it.mkdir() }
+            val artifact = FileReferenceOutputArtifact(name = "lib.js", file = File(source, "lib.js"), useChecksumInvalidation = true)
+
+            // First export: file is copied, checksum is written.
+            artifact.accept(FileResourceExporter(output))
+            val copied = File(output, "lib.js")
+            val checksumFile = File(output, "lib.js.checksum")
+            assertTrue(copied.isFile)
+            assertTrue(checksumFile.isFile)
+            val firstChecksum = checksumFile.readText()
+
+            // Modify the output to detect whether a second export overwrites it.
+            copied.writeText("TAMPERED")
+
+            // Second export: source unchanged, checksum matches -> copy is skipped.
+            artifact.accept(FileResourceExporter(output))
+            assertEquals("TAMPERED", copied.readText(), "File should not have been overwritten")
+            assertEquals(firstChecksum, checksumFile.readText())
+        }
+
+    @Test
+    fun `checksum re-copies when source changes`() =
+        withTempDir { dir ->
+            val source = File(dir, "src").also { it.mkdir() }
+            val sourceFile = File(source, "lib.js").also { it.writeText("v1") }
+
+            val output = File(dir, "out").also { it.mkdir() }
+            val artifact = FileReferenceOutputArtifact(name = "lib.js", file = sourceFile, useChecksumInvalidation = true)
+
+            // First export.
+            artifact.accept(FileResourceExporter(output))
+            val firstChecksum = File(output, "lib.js.checksum").readText()
+
+            // Modify source.
+            sourceFile.writeText("v2")
+
+            // Second export: checksum differs -> file is re-copied.
+            artifact.accept(FileResourceExporter(output))
+            assertEquals("v2", File(output, "lib.js").readText())
+
+            val secondChecksum = File(output, "lib.js.checksum").readText()
+            assertTrue(firstChecksum != secondChecksum)
+        }
+
+    @Test
+    fun `checksum works for directories`() =
+        withTempDir { dir ->
+            val source = File(dir, "fonts").also { it.mkdir() }
+            File(source, "a.woff2").writeText("font-a")
+
+            val output = File(dir, "out").also { it.mkdir() }
+            val artifact = FileReferenceOutputArtifact(name = "fonts", file = source, useChecksumInvalidation = true)
+
+            // First export.
+            artifact.accept(FileResourceExporter(output))
+            assertTrue(File(output, "fonts/a.woff2").isFile)
+            assertTrue(File(output, "fonts.checksum").isFile)
+            val firstChecksum = File(output, "fonts.checksum").readText()
+
+            // Add a file to source.
+            File(source, "b.woff2").writeText("font-b")
+
+            // Second export: checksum differs -> directory is re-copied.
+            artifact.accept(FileResourceExporter(output))
+            assertTrue(File(output, "fonts/b.woff2").isFile)
+
+            val secondChecksum = File(output, "fonts.checksum").readText()
+            assertTrue(firstChecksum != secondChecksum)
+        }
+
+    @Test
+    fun `no checksum file when invalidation is disabled`() =
+        withTempDir { dir ->
+            val source = File(dir, "src").also { it.mkdir() }
+            File(source, "lib.js").writeText("hello")
+
+            val output = File(dir, "out").also { it.mkdir() }
+            val artifact = FileReferenceOutputArtifact(name = "lib.js", file = File(source, "lib.js"))
+
+            artifact.accept(FileResourceExporter(output))
+            assertTrue(File(output, "lib.js").isFile)
+            assertFalse(File(output, "lib.js.checksum").exists())
+        }
+}

--- a/quarkdown-core/src/test/kotlin/com/quarkdown/core/FileResourceExporterTest.kt
+++ b/quarkdown-core/src/test/kotlin/com/quarkdown/core/FileResourceExporterTest.kt
@@ -215,6 +215,29 @@ class FileResourceExporterTest {
         }
 
     @Test
+    fun `checksum re-copies when target deleted but checksum file survives`() =
+        withTempDir { dir ->
+            val source = File(dir, "src").also { it.mkdir() }
+            val sourceFile = File(source, "lib.js").also { it.writeText("content") }
+
+            val output = File(dir, "out").also { it.mkdir() }
+            val artifact = FileReferenceOutputArtifact(name = "lib.js", file = sourceFile, useChecksumInvalidation = true)
+
+            // First export.
+            artifact.accept(FileResourceExporter(output))
+            assertTrue(File(output, "lib.js").isFile)
+
+            // Delete the target but leave the checksum file.
+            File(output, "lib.js").delete()
+            assertTrue(File(output, "lib.js.checksum").isFile)
+
+            // Second export: checksum matches but target is missing -> must re-copy.
+            artifact.accept(FileResourceExporter(output))
+            assertTrue(File(output, "lib.js").isFile)
+            assertEquals("content", File(output, "lib.js").readText())
+        }
+
+    @Test
     fun `no checksum file when invalidation is disabled`() =
         withTempDir { dir ->
             val source = File(dir, "src").also { it.mkdir() }

--- a/quarkdown-core/src/test/kotlin/com/quarkdown/core/IOUtilsTest.kt
+++ b/quarkdown-core/src/test/kotlin/com/quarkdown/core/IOUtilsTest.kt
@@ -7,6 +7,7 @@ import kotlin.io.path.createDirectories
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
 import kotlin.test.assertTrue
 
 /**
@@ -63,5 +64,70 @@ class IOUtilsTest {
     fun `resolvePath resolves relative path as-is when working directory is null`() {
         val result = IOUtils.resolvePath("relative/file.txt", workingDirectory = null)
         assertEquals(File("relative/file.txt"), result)
+    }
+
+    // Checksum
+
+    @Test
+    fun `checksum is stable for the same file`() {
+        val file = Files.createTempFile("checksum", ".txt").toFile()
+        try {
+            file.writeText("hello")
+            assertEquals(IOUtils.computeChecksum(file), IOUtils.computeChecksum(file))
+        } finally {
+            file.delete()
+        }
+    }
+
+    @Test
+    fun `checksum changes when file content changes`() {
+        val file = Files.createTempFile("checksum", ".txt").toFile()
+        try {
+            file.writeText("hello")
+            val first = IOUtils.computeChecksum(file)
+            file.writeText("world")
+            assertNotEquals(first, IOUtils.computeChecksum(file))
+        } finally {
+            file.delete()
+        }
+    }
+
+    @Test
+    fun `checksum is stable for the same directory`() {
+        val dir = Files.createTempDirectory("checksumDir").toFile()
+        try {
+            dir.resolve("a.txt").writeText("aaa")
+            dir.resolve("sub").mkdir()
+            dir.resolve("sub/b.txt").writeText("bbb")
+            assertEquals(IOUtils.computeChecksum(dir), IOUtils.computeChecksum(dir))
+        } finally {
+            dir.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `directory checksum changes when a file is added`() {
+        val dir = Files.createTempDirectory("checksumDir").toFile()
+        try {
+            dir.resolve("a.txt").writeText("aaa")
+            val first = IOUtils.computeChecksum(dir)
+            dir.resolve("b.txt").writeText("bbb")
+            assertNotEquals(first, IOUtils.computeChecksum(dir))
+        } finally {
+            dir.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `directory checksum changes when a file size changes`() {
+        val dir = Files.createTempDirectory("checksumDir").toFile()
+        try {
+            dir.resolve("a.txt").writeText("short")
+            val first = IOUtils.computeChecksum(dir)
+            dir.resolve("a.txt").writeText("much longer content")
+            assertNotEquals(first, IOUtils.computeChecksum(dir))
+        } finally {
+            dir.deleteRecursively()
+        }
     }
 }

--- a/quarkdown-html/src/main/kotlin/com/quarkdown/rendering/html/post/resources/ThemePostRendererResource.kt
+++ b/quarkdown-html/src/main/kotlin/com/quarkdown/rendering/html/post/resources/ThemePostRendererResource.kt
@@ -95,7 +95,13 @@ class ThemePostRendererResource(
      */
     private fun buildArtifacts(components: List<Component>): Set<OutputResource> =
         buildSet {
-            components.mapTo(this) { FileReferenceOutputArtifact(name = it.name, file = it.source) }
+            components.mapTo(this) {
+                FileReferenceOutputArtifact(
+                    name = it.name,
+                    file = it.source,
+                    useChecksumInvalidation = true,
+                )
+            }
             add(
                 TextOutputArtifact(
                     name = MANIFEST_NAME,

--- a/quarkdown-install-layout-navigator/src/main/kotlin/com/quarkdown/installlayout/InstallLayoutEntry.kt
+++ b/quarkdown-install-layout-navigator/src/main/kotlin/com/quarkdown/installlayout/InstallLayoutEntry.kt
@@ -25,7 +25,7 @@ interface InstallLayoutEntry {
     fun resolveDirectory(relativePath: String): InstallLayoutDirectory = InstallLayoutDirectory(file.resolve(relativePath))
 
     /** Wraps this entry as an [OutputResource] for the pipeline to output. */
-    fun asOutputResource(): OutputResource = FileReferenceOutputArtifact(name, file)
+    fun asOutputResource(): OutputResource = FileReferenceOutputArtifact(name, file, useChecksumInvalidation = true)
 }
 
 /**


### PR DESCRIPTION
Resource exporter now relies on checksums to determine whether to copy HTML resources.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/iamgio/quarkdown/pull/452" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
