### PR TITLE
chore: move ContextOptions to context.options

### DIFF
--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/context/BaseContext.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/context/BaseContext.kt
@@ -6,6 +6,8 @@ import com.quarkdown.core.context.file.FileSystem
 import com.quarkdown.core.context.file.RootGranularity
 import com.quarkdown.core.context.file.SimpleFileSystem
 import com.quarkdown.core.context.file.getRootFileSystem
+import com.quarkdown.core.context.options.ContextOptions
+import com.quarkdown.core.context.options.MutableContextOptions
 import com.quarkdown.core.context.subdocument.SubdocumentsData
 import com.quarkdown.core.document.DocumentInfo
 import com.quarkdown.core.document.sub.Subdocument

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/context/Context.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/context/Context.kt
@@ -3,6 +3,7 @@ package com.quarkdown.core.context
 import com.quarkdown.core.ast.attributes.AstAttributes
 import com.quarkdown.core.ast.quarkdown.FunctionCallNode
 import com.quarkdown.core.context.file.FileSystem
+import com.quarkdown.core.context.options.ContextOptions
 import com.quarkdown.core.context.subdocument.SubdocumentsData
 import com.quarkdown.core.document.DocumentInfo
 import com.quarkdown.core.document.sub.Subdocument

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/context/MutableContext.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/context/MutableContext.kt
@@ -2,6 +2,7 @@ package com.quarkdown.core.context
 
 import com.quarkdown.core.ast.attributes.MutableAstAttributes
 import com.quarkdown.core.ast.quarkdown.FunctionCallNode
+import com.quarkdown.core.context.options.MutableContextOptions
 import com.quarkdown.core.document.DocumentInfo
 import com.quarkdown.core.document.sub.Subdocument
 import com.quarkdown.core.flavor.MarkdownFlavor

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/context/options/ContextOptions.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/context/options/ContextOptions.kt
@@ -1,9 +1,8 @@
-package com.quarkdown.core.context
+package com.quarkdown.core.context.options
 
 import com.quarkdown.core.ast.base.block.Heading
+import com.quarkdown.core.context.Context
 import com.quarkdown.core.media.storage.options.MediaStorageOptions
-
-private val DEFAULT_SUBDOCUMENT_URL_SUFFIXES = setOf(".qd", ".md")
 
 /**
  * Read-only properties that affect several behaviors of the document generation process,
@@ -36,7 +35,6 @@ interface ContextOptions : MediaStorageOptions {
      * @see com.quarkdown.core.ast.base.inline.SubdocumentLink
      */
     val subdocumentUrlSuffixes: Set<String>
-        get() = DEFAULT_SUBDOCUMENT_URL_SUFFIXES
 
     /**
      * Supplier of unique identifiers (UUIDs). For instance, UUIDs are generated for anonymous footnotes.
@@ -59,30 +57,3 @@ fun Context.shouldAutoPageBreak(heading: Heading) =
  * @see com.quarkdown.core.ast.base.inline.SubdocumentLink
  */
 fun Context.isSubdocumentUrl(url: String): Boolean = options.subdocumentUrlSuffixes.any { url.endsWith(it, ignoreCase = true) }
-
-/**
- * Mutable [ContextOptions] implementation.
- */
-data class MutableContextOptions(
-    override var autoPageBreakHeadingMaxDepth: Int = 1,
-    override var enableAutomaticIdentifiers: Boolean = true,
-    override var enableLocationAwareness: Boolean = true,
-    override var subdocumentUrlSuffixes: Set<String> = DEFAULT_SUBDOCUMENT_URL_SUFFIXES,
-    override var uuidSupplier: () -> String = {
-        java.util.UUID
-            .randomUUID()
-            .toString()
-    },
-    override var enableRemoteMediaStorage: Boolean = false,
-    override var enableLocalMediaStorage: Boolean = false,
-) : ContextOptions {
-    /**
-     * Mutates this instance by merging the current media storage rules with the given [options].
-     * An option is overridden and merged only if its value from [options] is set, i.e. not `null`.
-     * @param options options to merge this instance with
-     */
-    fun mergeMediaStorageOptions(options: MediaStorageOptions) {
-        options.enableRemoteMediaStorage?.let { enableRemoteMediaStorage = it }
-        options.enableLocalMediaStorage?.let { enableLocalMediaStorage = it }
-    }
-}

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/context/options/MutableContextOptions.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/context/options/MutableContextOptions.kt
@@ -1,0 +1,33 @@
+package com.quarkdown.core.context.options
+
+import com.quarkdown.core.media.storage.options.MediaStorageOptions
+import java.util.UUID
+
+private val DEFAULT_SUBDOCUMENT_URL_SUFFIXES = setOf(".qd", ".md")
+
+/**
+ * Mutable [ContextOptions] implementation.
+ */
+data class MutableContextOptions(
+    override var autoPageBreakHeadingMaxDepth: Int = 1,
+    override var enableAutomaticIdentifiers: Boolean = true,
+    override var enableLocationAwareness: Boolean = true,
+    override var subdocumentUrlSuffixes: Set<String> = DEFAULT_SUBDOCUMENT_URL_SUFFIXES,
+    override var uuidSupplier: () -> String = {
+        UUID
+            .randomUUID()
+            .toString()
+    },
+    override var enableRemoteMediaStorage: Boolean = false,
+    override var enableLocalMediaStorage: Boolean = false,
+) : ContextOptions {
+    /**
+     * Mutates this instance by merging the current media storage rules with the given [options].
+     * An option is overridden and merged only if its value from [options] is set, i.e. not `null`.
+     * @param options options to merge this instance with
+     */
+    fun mergeMediaStorageOptions(options: MediaStorageOptions) {
+        options.enableRemoteMediaStorage?.let { enableRemoteMediaStorage = it }
+        options.enableLocalMediaStorage?.let { enableLocalMediaStorage = it }
+    }
+}

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/media/storage/options/MediaStorageOptions.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/media/storage/options/MediaStorageOptions.kt
@@ -2,7 +2,7 @@ package com.quarkdown.core.media.storage.options
 
 /**
  * Read-only options that affect the rules of a context's media storage.
- * @see com.quarkdown.core.context.MutableContextOptions for an implementation
+ * @see com.quarkdown.core.context.options.MutableContextOptions for an implementation
  */
 interface MediaStorageOptions {
     /**

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/parser/InlineTokenParser.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/parser/InlineTokenParser.kt
@@ -22,7 +22,7 @@ import com.quarkdown.core.ast.base.inline.Text
 import com.quarkdown.core.ast.quarkdown.inline.MathSpan
 import com.quarkdown.core.ast.quarkdown.inline.TextSymbol
 import com.quarkdown.core.context.MutableContext
-import com.quarkdown.core.context.isSubdocumentUrl
+import com.quarkdown.core.context.options.isSubdocumentUrl
 import com.quarkdown.core.document.size.Size
 import com.quarkdown.core.flavor.InlineLexerVariant
 import com.quarkdown.core.function.value.factory.IllegalRawValueException

--- a/quarkdown-html/src/main/kotlin/com/quarkdown/rendering/html/node/QuarkdownHtmlNodeRenderer.kt
+++ b/quarkdown-html/src/main/kotlin/com/quarkdown/rendering/html/node/QuarkdownHtmlNodeRenderer.kt
@@ -62,7 +62,7 @@ import com.quarkdown.core.ast.quarkdown.reference.CrossReference
 import com.quarkdown.core.ast.quarkdown.reference.CrossReferenceableNode
 import com.quarkdown.core.context.Context
 import com.quarkdown.core.context.localization.localizeOrNull
-import com.quarkdown.core.context.shouldAutoPageBreak
+import com.quarkdown.core.context.options.shouldAutoPageBreak
 import com.quarkdown.core.context.subdocument.subdocumentGraph
 import com.quarkdown.core.document.layout.caption.CaptionPosition
 import com.quarkdown.core.document.layout.caption.CaptionPositionInfo

--- a/quarkdown-html/src/test/kotlin/com/quarkdown/rendering/html/HtmlNodeRendererTest.kt
+++ b/quarkdown-html/src/test/kotlin/com/quarkdown/rendering/html/HtmlNodeRendererTest.kt
@@ -62,7 +62,7 @@ import com.quarkdown.core.bibliography.style.BibliographyEntryLabelProviderStrat
 import com.quarkdown.core.bibliography.style.BibliographyStyle
 import com.quarkdown.core.context.Context
 import com.quarkdown.core.context.MutableContext
-import com.quarkdown.core.context.MutableContextOptions
+import com.quarkdown.core.context.options.MutableContextOptions
 import com.quarkdown.core.document.size.Sizes
 import com.quarkdown.core.document.size.cm
 import com.quarkdown.core.document.size.inch

--- a/quarkdown-test/src/test/kotlin/com/quarkdown/test/util/Launcher.kt
+++ b/quarkdown-test/src/test/kotlin/com/quarkdown/test/util/Launcher.kt
@@ -2,7 +2,7 @@ package com.quarkdown.test.util
 
 import com.quarkdown.core.context.Context
 import com.quarkdown.core.context.MutableContext
-import com.quarkdown.core.context.MutableContextOptions
+import com.quarkdown.core.context.options.MutableContextOptions
 import com.quarkdown.core.context.subdocument.subdocumentGraph
 import com.quarkdown.core.document.sub.Subdocument
 import com.quarkdown.core.document.sub.SubdocumentOutputNaming


### PR DESCRIPTION
- [x] I confirm an issue for this change exists, and it was discussed with maintainers.
- [x] I have read the [contributing guidelines](https://github.com/iamgio/quarkdown/blob/main/CONTRIBUTING.md).
- [x] I have tested the changes locally.
- [ ] (Optional) I have added necessary documentation to [`docs`](https://github.com/iamgio/quarkdown/tree/main/docs) and [CHANGELOG.md](https://github.com/iamgio/quarkdown/blob/main/CHANGELOG.md)