### PR TITLE
Fix spelling typos across comments and tests

### DIFF
--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/function/error/ParameterAlreadyBoundException.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/function/error/ParameterAlreadyBoundException.kt
@@ -9,13 +9,13 @@ import com.quarkdown.core.function.call.asString
  * An exception thrown if a function parameter is bound more than once in a function call.
  * @param call the invalid call
  * @param parameter the parameter that was attempted to be bound again
- * @param overriddingArgument the argument that was attempted to be bound to the already bound parameter
+ * @param overridingArgument the argument that was attempted to be bound to the already bound parameter
  */
 class ParameterAlreadyBoundException(
     call: FunctionCall<*>,
     parameter: FunctionParameter<*>,
-    overriddingArgument: FunctionCallArgument,
+    overridingArgument: FunctionCallArgument,
 ) : InvalidFunctionCallException(
         call,
-        reason = "parameter '${parameter.name}' is already bound, but was attempted to be bound again to ${overriddingArgument.asString()}",
+        reason = "parameter '${parameter.name}' is already bound, but was attempted to be bound again to ${overridingArgument.asString()}",
     )

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/function/value/factory/ValueFactory.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/function/value/factory/ValueFactory.kt
@@ -584,7 +584,7 @@ object ValueFactory {
                 // The actual type is determined later.
                 is FunctionCallNode -> context.resolveUnchecked(node)
 
-                // Function existance is checked later.
+                // Function existence is checked later.
 
                 else -> throw IllegalArgumentException("Unexpected node $node in expression $raw")
             }

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/lexer/patterns/BaseMarkdownInlineTokenRegexPatterns.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/lexer/patterns/BaseMarkdownInlineTokenRegexPatterns.kt
@@ -332,10 +332,10 @@ private const val IMAGE_SIZE_DIVIDER_HELPER = "(?:[* \\t]|(?<![a-zA-Z])x)" // 1*
 /**
  * @param startDelimiter begin of the match (included)
  * @param endDelimiter end of the match (included)
- * @param strict if `true`, restrictions are applied to the delimeter checks.
+ * @param strict if `true`, restrictions are applied to the delimiter checks.
  * According to the CommonMark spec:
- * - non-strict means the start delimeter must be left-flanking and end delimeter must be right-flanking
- * - strict means any of the delimeters must not be left and right-flanking at the same time
+ * - non-strict means the start delimiter must be left-flanking and end delimiter must be right-flanking
+ * - strict means any of the delimiters must not be left and right-flanking at the same time
  *
  * @return a new regex that matches the content between [startDelimiter] and [endDelimiter]
  */

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/lexer/patterns/FunctionCallPatterns.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/lexer/patterns/FunctionCallPatterns.kt
@@ -13,7 +13,7 @@ import com.quarkdown.core.parser.walker.funcall.FunctionCallWalkerParser
 class FunctionCallPatterns {
     /**
      * Function name prefixed by '.', followed by a sequence of arguments.
-     * Can be preceeded by the beginning of the line, a whitespace or a symbol.
+     * Can be preceded by the beginning of the line, a whitespace or a symbol.
      * This is a 'flag' pattern, meaning it does not capture any content,
      * but instead detects the beginning of a function call and delegates the scanning to [FunctionCallWalkerParser].
      */

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/util/StringUtils.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/util/StringUtils.kt
@@ -21,7 +21,7 @@ fun String.removeOptionalPrefix(
  *         this string otherwise
  */
 fun String.takeUntilLastOccurrence(string: String): String {
-    // Trim trailing #s preceeded by a space
+    // Trim trailing #s preceded by a space
     val trailingIndex = lastIndexOf(string)
     return if (trailingIndex >= 0) {
         substring(0, trailingIndex)

--- a/quarkdown-core/src/test/kotlin/com/quarkdown/core/FunctionNodeExpansionTest.kt
+++ b/quarkdown-core/src/test/kotlin/com/quarkdown/core/FunctionNodeExpansionTest.kt
@@ -210,7 +210,7 @@ class FunctionNodeExpansionTest {
                 context,
                 "resourceContent",
                 listOf(
-                    FunctionCallArgument(DynamicValue("non-existant-resource")),
+                    FunctionCallArgument(DynamicValue("non-existent-resource")),
                 ),
                 isBlock = false,
             )
@@ -299,7 +299,7 @@ class FunctionNodeExpansionTest {
                 context,
                 "echoEnum",
                 listOf(
-                    FunctionCallArgument(DynamicValue("non-existant-value")),
+                    FunctionCallArgument(DynamicValue("non-existent-value")),
                 ),
                 isBlock = false,
             )

--- a/quarkdown-html/src/main/kotlin/com/quarkdown/rendering/html/node/QuarkdownHtmlNodeRenderer.kt
+++ b/quarkdown-html/src/main/kotlin/com/quarkdown/rendering/html/node/QuarkdownHtmlNodeRenderer.kt
@@ -688,7 +688,7 @@ class QuarkdownHtmlNodeRenderer(
             node.type?.asCSS?.let { type ->
                 className(type)
                 // The type is associated to a localized label
-                // only if the documant language is set and the set language is supported.
+                // only if the document language is set and the set language is supported.
                 context.localizeOrNull(key = type)?.let { localizedLabel ->
                     // The localized label is set as a CSS variable.
                     // Themes can customize label appearance and formatting.

--- a/quarkdown-html/src/main/scss/layout/latex.scss
+++ b/quarkdown-html/src/main/scss/layout/latex.scss
@@ -4,7 +4,7 @@
 @use "util/progressive-heading-sizes" as *;
 @use "util/latex-tables" as *;
 @use "util/latex-toc" as *;
-@use "../components/util/location-selectors" as location-selctors;
+@use "../components/util/location-selectors" as location-selectors;
 //noinspection CssUnknownTarget
 @import url('computermodern/index.css');
 //noinspection CssUnknownTarget
@@ -42,7 +42,7 @@
   @include latex-toc;
 
   // Numbering of headings and list items.
-  #{location-selctors.$location-heading}::before {
+  #{location-selectors.$location-heading}::before {
     padding-right: 0.85rem;
   }
 

--- a/quarkdown-html/src/main/typescript/document/quarkdown-document.ts
+++ b/quarkdown-html/src/main/typescript/document/quarkdown-document.ts
@@ -24,7 +24,7 @@ export interface QuarkdownDocument {
 
     /**
      * Initializes the document rendering process.
-     * For instance, Reveal.js inizialization in `slides` documents.
+     * For instance, Reveal.js initialization in `slides` documents.
      */
     initializeRendering(): void;
 

--- a/quarkdown-quarkdoc/src/main/kotlin/com/quarkdown/quarkdoc/dokka/kdoc/DocumentationReferencesTransformer.kt
+++ b/quarkdown-quarkdoc/src/main/kotlin/com/quarkdown/quarkdoc/dokka/kdoc/DocumentationReferencesTransformer.kt
@@ -37,7 +37,7 @@ interface DocumentationReferencesTransformer {
     /**
      * Transforms references within a KDoc documentation.
      * @param documentation the original documentation
-     * @param parameters the list of arameters to be looked up from `@param` references
+     * @param parameters the list of parameters to be looked up from `@param` references
      * @return the transformed documentation
      */
     fun transformReferences(

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Data.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Data.kt
@@ -47,20 +47,20 @@ val Data: QuarkdownModule =
 
 /**
  * @param path path of the file, relative or absolute (with extension)
- * @param requireExistance whether the corresponding file must exist
+ * @param requireExistence whether the corresponding file must exist
  * @return a [File] instance of the file located in [path].
  *         If the path is relative, the location is determined by the working directory of the pipeline.
- * @throws IllegalArgumentException if the file does not exist and [requireExistance] is `true`
+ * @throws IllegalArgumentException if the file does not exist and [requireExistence] is `true`
  */
 internal fun file(
     context: Context,
     path: String,
-    requireExistance: Boolean = true,
+    requireExistence: Boolean = true,
 ): File {
     val file = context.fileSystem.resolve(path)
     context.requireReadPermission(file)
 
-    if (requireExistance && !file.exists()) {
+    if (requireExistence && !file.exists()) {
         throw IllegalArgumentException("File $file does not exist.")
     }
 

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Document.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Document.kt
@@ -127,7 +127,7 @@ private fun <T> MutableContext.modifyOrEchoDocumentInfo(
  * .doctype {paged}
  * ```
  *
- * If it's unset, the lowecase name of the current document type is returned.
+ * If it's unset, the lowercase name of the current document type is returned.
  *
  * ```
  * The current document type is .doctype


### PR DESCRIPTION
Fixes #473

## Summary
This PR fixes a small set of spelling mistakes across Kotlin comments/KDoc, TypeScript docs, tests, and one SCSS alias/identifier.

These changes are intended to be behavior-neutral.

## Validation
- Ran `./gradlew --no-daemon test`

## Notes
- I have read the contributing guidelines.
- I did not update `docs/` or `CHANGELOG.md` because this is a typo-only cleanup.
- The tracking issue exists, but this change has not been discussed with maintainers yet.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/iamgio/quarkdown/pull/474" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
