### PR TITLE
(docs) fix reference syntax in example of "Primitives - Cross-referencing"

### DIFF
--- a/docs/primitives.qd
+++ b/docs/primitives.qd
@@ -47,7 +47,7 @@ The `ref` parameter assigns an ID that can be used with [cross-references](cross
 ```markdown
 .image {diagram.png} label:{Architecture diagram} title:{System overview} ref:{arch-diagram} width:{400px}
 
-See .reference {arch-diagram} for more details.
+See .ref {arch-diagram} for more details.
 ```
 
 ### Media storage opt-out


### PR DESCRIPTION
- [X] I confirm an issue for this change exists, and it was discussed with maintainers.
- [X] I have read the [contributing guidelines](https://github.com/iamgio/quarkdown/blob/main/CONTRIBUTING.md).
- [X] I have tested the changes locally.
- [ ] (Optional) I have added necessary documentation to [`docs`](https://github.com/iamgio/quarkdown/tree/main/docs) and [CHANGELOG.md](https://github.com/iamgio/quarkdown/blob/main/CHANGELOG.md)


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/iamgio/quarkdown/pull/476" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
