### PR TITLE
Fix Docker build and default PDF export setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,10 @@
 build/
+**/build/
+.git/
+.github/
+.run/
+demo/
+docs/
+mock/
+*.md
+.typos.toml

--- a/.github/workflows/docker-image-test.yml
+++ b/.github/workflows/docker-image-test.yml
@@ -1,0 +1,51 @@
+name: Docker image test
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  smoke-test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Build Docker image
+      run: docker build -t quarkdown:test .
+
+    - name: Install PDF inspection tools
+      run: sudo apt-get update && sudo apt-get install -y --no-install-recommends poppler-utils
+
+    - name: Test HTML output
+      run: |
+        workdir="$(mktemp -d)"
+        chmod 777 "$workdir"
+        cat <<'EOF' > "$workdir/main.qd"
+        .docname {test}
+
+        QuarkdownHtmlSmokeCheck
+        EOF
+
+        docker run --rm -v "$workdir:/work" -w /work quarkdown:test c main.qd -o output
+
+        test -f "$workdir/output/test/index.html"
+        test -s "$workdir/output/test/index.html"
+        grep -F "QuarkdownHtmlSmokeCheck" "$workdir/output/test/index.html"
+
+    - name: Test PDF output
+      run: |
+        workdir="$(mktemp -d)"
+        chmod 777 "$workdir"
+        cat <<'EOF' > "$workdir/main.qd"
+        .docname {test}
+
+        QuarkdownPdfSmokeCheck
+        EOF
+
+        docker run --rm -v "$workdir:/work" -w /work quarkdown:test c main.qd -o output --pdf
+
+        test -f "$workdir/output/test.pdf"
+        test -s "$workdir/output/test.pdf"
+        pdftotext "$workdir/output/test.pdf" - | tee "$workdir/test.txt"
+        grep -F "QuarkdownPdfSmokeCheck" "$workdir/test.txt"

--- a/.github/workflows/docker-image-test.yml
+++ b/.github/workflows/docker-image-test.yml
@@ -2,7 +2,18 @@ name: Docker image test
 
 on:
   pull_request:
+    paths:
+      - 'Dockerfile'
+      - 'quarkdown-html/**'
+      - '.github/workflows/docker-image-test.yml'
+      - 'build.gradle.kts'
+      - 'settings.gradle.kts'
+      - 'gradle/**'
   workflow_dispatch:
+
+concurrency:
+  group: docker-image-test-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   smoke-test:

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,10 @@
 FROM gradle:8.14.3-jdk17 AS builder
 
 USER root
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends nodejs npm \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 RUN mkdir -p /app && chown -R gradle:gradle /app
 
 USER gradle

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,6 @@
 FROM gradle:8.14.3-jdk17 AS builder
 
 USER root
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends nodejs npm \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
 RUN mkdir -p /app && chown -R gradle:gradle /app
 
 USER gradle

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,15 @@
 # Build stage via Gradle
 FROM gradle:8.14.3-jdk17 AS builder
 
-COPY . /app
+USER root
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends nodejs npm \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /app
+
+COPY . /app
 
 # Build the distribution zip
 RUN gradle --no-daemon distZip
@@ -17,9 +24,12 @@ RUN unzip quarkdown.zip && rm quarkdown.zip
 # Run stage
 FROM ghcr.io/puppeteer/puppeteer:24.15.0 AS runner
 
-# Install JDK
+ENV QD_NPM_PREFIX="/home/pptruser" \
+    NODE_PATH="/home/pptruser/node_modules"
+
 USER root
-RUN apt-get update && apt-get install -y openjdk-17-jdk \
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends openjdk-17-jre-headless \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,13 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends nodejs npm \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
+RUN mkdir -p /app && chown -R gradle:gradle /app
+
+USER gradle
 
 WORKDIR /app
 
-COPY . /app
+COPY --chown=gradle:gradle . /app
 
 # Build the distribution zip
 RUN gradle --no-daemon distZip

--- a/quarkdown-html/build.gradle.kts
+++ b/quarkdown-html/build.gradle.kts
@@ -9,11 +9,6 @@ plugins {
     id("io.miret.etienne.sass") version "1.6.0"
 }
 
-node {
-    download.set(true)
-    version.set("22.22.2")
-}
-
 dependencies {
     testImplementation(kotlin("test"))
     testImplementation(testFixtures(project(":quarkdown-core")))

--- a/quarkdown-html/build.gradle.kts
+++ b/quarkdown-html/build.gradle.kts
@@ -9,6 +9,11 @@ plugins {
     id("io.miret.etienne.sass") version "1.6.0"
 }
 
+node {
+    download.set(true)
+    version.set("22.22.2")
+}
+
 dependencies {
     testImplementation(kotlin("test"))
     testImplementation(testFixtures(project(":quarkdown-core")))


### PR DESCRIPTION
Fixes #477

## Summary
This PR applies a minimal Docker-focused fix so the repository image can be built successfully and PDF export works by default in the produced container.

The change intentionally keeps the existing runtime base image (`ghcr.io/puppeteer/puppeteer:24.15.0`) and only fixes the missing pieces around it.

## Problems addressed
1. The builder stage used `gradle:8.14.3-jdk17`, but `distZip` triggers `:quarkdown-html:npmInstall`, and the builder image did not provide `npm`.
2. The runtime image contains the Puppeteer stack, but Quarkdown could not locate the `puppeteer` module automatically, so `quarkdown c <file> --pdf` failed unless `QD_NPM_PREFIX` was set manually.
3. The runtime stage installed a full JDK even though only a JRE is needed to run Quarkdown.
4. The Docker build context was larger than necessary.

## Changes
- Install `nodejs` and `npm` in the builder stage.
- Keep the existing `distZip` + unzip flow to minimize behavior changes.
- Set `QD_NPM_PREFIX=/home/pptruser` and `NODE_PATH=/home/pptruser/node_modules` in the runtime image so Quarkdown can find the `puppeteer` module already present in the base image.
- Replace `openjdk-17-jdk` with `openjdk-17-jre-headless` in the runtime stage.
- Expand `.dockerignore` to reduce the build context size.

## Validation
Built the image locally:
```bash
docker build -t quarkdown:min .
```

Validated PDF export from the built image with a minimal paged document:
```bash
docker run --rm -v "$TMPDIR:/work" -w /work quarkdown:min c main.qd --pdf
```

Validation result:
- image build succeeded
- PDF export succeeded
- extracted text from the produced PDF matched the expected Chinese content

## Notes
- I have read the contributing guidelines.
- I have tested the changes locally.
- I did not update `docs/` or `CHANGELOG.md` because this is a Docker/runtime fix.
- The issue exists, but this change has not been discussed with maintainers yet.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/iamgio/quarkdown/pull/478" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
