### PR TITLE
fix(quarkdoc): fix trailing line continuation at the end of multiline signatures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,14 @@ Thanks @emsspree!
 
 When creating a `docs` project, `quarkdown create` now links the top-left title to the root document, for easier navigation back to the home page.
 
+&nbsp;
+
+### Fixed
+
+#### Fixed trailing `\` in Quarkdoc multiline signatures
+
+When a function signature in Quarkdoc was long enough to split across multiple lines, the last parameter line incorrectly displayed a trailing `\` before the return type. 
+
 ## [2.0.0] - 2026-04-23
 
 ### Added

--- a/quarkdown-quarkdoc/src/main/kotlin/com/quarkdown/quarkdoc/dokka/signature/LineBreakingStrategy.kt
+++ b/quarkdown-quarkdoc/src/main/kotlin/com/quarkdown/quarkdoc/dokka/signature/LineBreakingStrategy.kt
@@ -107,7 +107,7 @@ private class SplitLineBreakingStrategy(
     }
 
     override fun PageContentBuilder.DocumentableContentBuilder.beforeReturn() {
-        lineContinuation()
+        breakLine()
     }
 
     private fun PageContentBuilder.DocumentableContentBuilder.lineContinuation() {

--- a/quarkdown-quarkdoc/src/test/kotlin/com/quarkdown/quarkdoc/dokka/QuarkdownSignatureTest.kt
+++ b/quarkdown-quarkdoc/src/test/kotlin/com/quarkdown/quarkdoc/dokka/QuarkdownSignatureTest.kt
@@ -75,7 +75,7 @@ class QuarkdownSignatureTest :
                 """
                 .func a:{Int} \
                       b:{Int} \
-                      c:{Int} \
+                      c:{Int}
                 -> Void
                 """.trimIndent(),
                 it,
@@ -90,7 +90,7 @@ class QuarkdownSignatureTest :
                 """
                 .func abcd:{Int} \
                         ef:{String} \
-                    ghijkl:{Int} \
+                    ghijkl:{Int}
                 -> Void
                 """.trimIndent(),
                 it,
@@ -105,7 +105,7 @@ class QuarkdownSignatureTest :
                 """
                 .func      abcd:{Int} \
                              ef:{String} \
-                 ghijklmnopqrst:{Int} \
+                 ghijklmnopqrst:{Int}
                 -> Void
                 """.trimIndent(),
                 it,


### PR DESCRIPTION
- [X] I have read the [contributing guidelines](https://github.com/iamgio/quarkdown/blob/main/CONTRIBUTING.md).
- [X] I have tested the changes locally.
- [ ] An issue for this change exists, and it was discussed with maintainers. This is required for new features and non-trivial changes. If present, append `Closes #ISSUE_NUMBER` at the end of this PR description.
- [x] (Optional) I have added necessary documentation to [`docs`](https://github.com/iamgio/quarkdown/tree/main/docs) and [`CHANGELOG.md`](https://github.com/iamgio/quarkdown/blob/main/CHANGELOG.md)

