### PR TITLE
fix: allow inline code inside compact footnote definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased]
 
+### Fixed
+
+&nbsp;
+
+#### Fixed inline code inside compact footnote definitions
+
+Compact footnotes like `` [^: text with `code`] `` were incorrectly parsed as plain text instead of footnotes. The definition pattern now allows backtick-enclosed spans inside the footnote body.
+
+Thanks @Shreyansh-Kushwaha!
+
 ## [2.0.1] - 2026-05-04
 
 ### Added

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/lexer/patterns/BaseMarkdownInlineTokenRegexPatterns.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/lexer/patterns/BaseMarkdownInlineTokenRegexPatterns.kt
@@ -173,7 +173,7 @@ open class BaseMarkdownInlineTokenRegexPatterns {
             regex =
                 RegexBuilder("\\[\\^(label)definition\\]")
                     .withReference("label", LABEL_HELPER)
-                    .withReference("definition", "(?::[ \\t]*([^\\[\\]\\\\`]+?))?")
+                    .withReference("definition", "(?::[ \\t]*((?:`[^`]*`|[^\\[\\]\\\\`])+?))?")
                     .build(),
         )
     }

--- a/quarkdown-core/src/test/kotlin/com/quarkdown/core/InlineParserTest.kt
+++ b/quarkdown-core/src/test/kotlin/com/quarkdown/core/InlineParserTest.kt
@@ -209,6 +209,20 @@ class InlineParserTest {
             )
             assertEquals("this is an anonymous definition!", definition.toPlainText())
         }
+        with(nodes.next()) {
+            assertEquals("code", label)
+            assertEquals("some inline code here", definition.toPlainText())
+        }
+        with(nodes.next()) {
+            assertEquals(
+                label.length,
+                UUID
+                    .randomUUID()
+                    .toString()
+                    .length,
+            )
+            assertEquals("anonymous with code", definition.toPlainText())
+        }
     }
 
     @Test

--- a/quarkdown-core/src/test/resources/parsing/inline/reffootnote-all-in-one.md
+++ b/quarkdown-core/src/test/resources/parsing/inline/reffootnote-all-in-one.md
@@ -1,3 +1,7 @@
 [^abc: this is a definition!]
 
 [^: this is an *anonymous* definition!]
+
+[^code: some `inline code` here]
+
+[^: anonymous with `code`]

--- a/quarkdown-test/src/test/kotlin/com/quarkdown/test/FootnoteTest.kt
+++ b/quarkdown-test/src/test/kotlin/com/quarkdown/test/FootnoteTest.kt
@@ -279,6 +279,45 @@ class FootnoteTest {
     }
 
     @Test
+    fun `all-in-one definition with inline code`() {
+        execute("text[^x: see `foo()` for details]") {
+            assertEquals(
+                "<p>text" +
+                    referenceHtml("x", "1") +
+                    definitionHtml(
+                        label = "x",
+                        index = 0,
+                        content = "see <span class=\"codespan-content\"><code>foo()</code></span> for details",
+                    ) +
+                    "</p>",
+                it,
+            )
+        }
+    }
+
+    @Test
+    fun `all-in-one anonymous definition with inline code`() {
+        var uuid = 0
+        val firstUuid = "2"
+        execute(
+            "text[^: use `bar` here]",
+            options = DEFAULT_OPTIONS.copy(uuidSupplier = { (++uuid * 2).toString() }),
+        ) {
+            assertEquals(
+                "<p>text" +
+                    referenceHtml(firstUuid, "1") +
+                    definitionHtml(
+                        label = firstUuid,
+                        index = 0,
+                        content = "use <span class=\"codespan-content\"><code>bar</code></span> here",
+                    ) +
+                    "</p>",
+                it,
+            )
+        }
+    }
+
+    @Test
     fun numbered() {
         execute(
             """


### PR DESCRIPTION
Fixes #488 

The `definition` regex in `referenceFootnote` excluded backticks entirely, causing compact footnotes like ``[^: text with `code`]`` to fall back to plain text instead of being parsed as footnotes.

Updated the pattern to allow balanced backtick spans (inline code) inside the definition, mirroring the approach already used in `LABEL_HELPER` for the label portion.

### Tests added

* **Parser-level**:

  * Added two new cases in `reffootnote-all-in-one.md`
  * Added assertions in `InlineParserTest`

* **Integration**:

  * Added two new tests in `FootnoteTest` covering named and anonymous compact footnotes containing inline code


- [X] I have read the [contributing guidelines](https://github.com/iamgio/quarkdown/blob/main/CONTRIBUTING.md).
- [X] I have tested the changes locally.
- [X] An issue for this change exists, and it was discussed with maintainers. This is required for new features and non-trivial changes. If present, append `Closes #488 ` at the end of this PR description.
- [ ] (Optional) I have added necessary documentation to [`docs`](https://github.com/iamgio/quarkdown/tree/main/docs) and [`CHANGELOG.md`](https://github.com/iamgio/quarkdown/blob/main/CHANGELOG.md)

