### PR TITLE
fix(html): drop screen-only paged backdrop and shadow in print

### DIFF
--- a/.run/CLI_ Mock.run.xml
+++ b/.run/CLI_ Mock.run.xml
@@ -1,0 +1,17 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="CLI: Mock" type="JetRunConfigurationType">
+    <envs>
+      <env name="NODE_PATH" value="/opt/homebrew/Cellar/quarkdown/2.0.1/libexec/lib/node_modules" />
+      <env name="PUPPETEER_CACHE_DIR" value="$USER_HOME$/Library/Caches/Homebrew/puppeteer" />
+      <env name="QD_NPM_PREFIX" value="/opt/homebrew/Cellar/quarkdown/2.0.1/libexec/lib" />
+    </envs>
+    <option name="MAIN_CLASS_NAME" value="com.quarkdown.cli.QuarkdownCliKt" />
+    <module name="quarkdown.quarkdown-cli.main" />
+    <option name="PROGRAM_PARAMETERS" value="c main.qd --libs ../quarkdown-libs/src/main/resources --pdf" />
+    <shortenClasspath name="NONE" />
+    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/mock" />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,16 @@ Function call-heavy documents now compile faster, by extracting metadata once at
 
 &nbsp;
 
+#### PDF output size and compile time reduction
+
+PDF output:
+- is up to 90% smaller,
+- compiles up to 2x faster.
+
+Thanks @philipredstone!
+
+&nbsp;
+
 #### Fixed inline code inside compact footnote definitions
 
 Compact footnotes like `` [^: text with `code`] `` were incorrectly parsed as plain text instead of footnotes. The definition pattern now allows backtick-enclosed spans inside the footnote body.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,11 +73,11 @@ Function call-heavy documents now compile faster, by extracting metadata once at
 
 &nbsp;
 
-#### PDF output size and compile time reduction
+#### PDF size and generation time reduction
 
-PDF output:
-- is up to 90% smaller,
-- compiles up to 2x faster.
+PDF generation now produces output that is:
+- up to 90% smaller,
+- generated up to 2x faster.
 
 Thanks @philipredstone!
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,9 +73,9 @@ Function call-heavy documents now compile faster, by extracting metadata once at
 
 &nbsp;
 
-#### PDF size and generation time reduction
+#### PDF size and generation time reduction in `paged` documents
 
-PDF generation now produces output that is:
+For `paged` documents, PDF generation now produces output that is:
 - up to 90% smaller,
 - generated up to 2x faster.
 

--- a/quarkdown-html/src/main/scss/components/_paged.scss
+++ b/quarkdown-html/src/main/scss/components/_paged.scss
@@ -5,22 +5,16 @@
 }
 
 body.quarkdown-paged {
-  background-color: lightgray;
-
   // Paged rendering is not yet complete
   &:not(:has(.pagedjs_page)) {
     opacity: 0;
   }
 
-  .pagedjs_page {
-    box-shadow: 0 16px 48px rgba(0, 0, 0, 0.1);
-  }
-
-  @include media-queries.print {
-    background-color: transparent;
+  @media screen, pagedjs-ignore {
+    background-color: lightgray;
 
     .pagedjs_page {
-      box-shadow: none;
+      box-shadow: 0 16px 48px rgba(0, 0, 0, 0.1);
     }
   }
 }

--- a/quarkdown-html/src/main/scss/components/_paged.scss
+++ b/quarkdown-html/src/main/scss/components/_paged.scss
@@ -1,5 +1,3 @@
-@use "util/media-queries" as media-queries;
-
 :root:has(.quarkdown-paged) {
   color-scheme: light;
 }

--- a/quarkdown-html/src/main/scss/components/_paged.scss
+++ b/quarkdown-html/src/main/scss/components/_paged.scss
@@ -1,3 +1,5 @@
+@use "util/media-queries" as media-queries;
+
 :root:has(.quarkdown-paged) {
   color-scheme: light;
 }
@@ -12,5 +14,13 @@ body.quarkdown-paged {
 
   .pagedjs_page {
     box-shadow: 0 16px 48px rgba(0, 0, 0, 0.1);
+  }
+
+  @include media-queries.print {
+    background-color: transparent;
+
+    .pagedjs_page {
+      box-shadow: none;
+    }
   }
 }

--- a/quarkdown-html/src/test/e2e/doctype/paged/decorations/decorations.spec.ts
+++ b/quarkdown-html/src/test/e2e/doctype/paged/decorations/decorations.spec.ts
@@ -2,6 +2,8 @@ import {suite} from "../../../quarkdown";
 
 const {testMatrix, expect} = suite(__dirname);
 
+const LIGHTGRAY = "rgb(211, 211, 211)";
+
 testMatrix(
     "shows colored body background and shadow around pages, only in screen view",
     ["paged"],
@@ -9,20 +11,16 @@ testMatrix(
         const body = page.locator("body");
         const pagedPage = page.locator(".pagedjs_page").first();
 
-        // Screen view: body has the lightgray background, pages have a drop shadow.
-        const bodyBgScreen = await body.evaluate((el) => getComputedStyle(el).backgroundColor);
-        const shadowScreen = await pagedPage.evaluate((el) => getComputedStyle(el).boxShadow);
+        await expect(pagedPage).toBeAttached();
 
-        expect(bodyBgScreen).toBe("rgb(211, 211, 211)");
-        expect(shadowScreen).not.toBe("none");
+        // Screen view: body has the lightgray background, pages have a drop shadow.
+        await expect(body).toHaveCSS("background-color", LIGHTGRAY);
+        await expect(pagedPage).not.toHaveCSS("box-shadow", "none");
 
         // Print view: both are dropped to avoid bloating the PDF output.
         await page.emulateMedia({media: "print"});
 
-        const bodyBgPrint = await body.evaluate((el) => getComputedStyle(el).backgroundColor);
-        const shadowPrint = await pagedPage.evaluate((el) => getComputedStyle(el).boxShadow);
-
-        expect(bodyBgPrint).not.toBe(bodyBgScreen);
-        expect(shadowPrint).toBe("none");
+        await expect(body).not.toHaveCSS("background-color", LIGHTGRAY);
+        await expect(pagedPage).toHaveCSS("box-shadow", "none");
     }
 );

--- a/quarkdown-html/src/test/e2e/doctype/paged/decorations/decorations.spec.ts
+++ b/quarkdown-html/src/test/e2e/doctype/paged/decorations/decorations.spec.ts
@@ -1,0 +1,28 @@
+import {suite} from "../../../quarkdown";
+
+const {testMatrix, expect} = suite(__dirname);
+
+testMatrix(
+    "shows colored body background and shadow around pages, only in screen view",
+    ["paged"],
+    async (page) => {
+        const body = page.locator("body");
+        const pagedPage = page.locator(".pagedjs_page").first();
+
+        // Screen view: body has the lightgray background, pages have a drop shadow.
+        const bodyBgScreen = await body.evaluate((el) => getComputedStyle(el).backgroundColor);
+        const shadowScreen = await pagedPage.evaluate((el) => getComputedStyle(el).boxShadow);
+
+        expect(bodyBgScreen).toBe("rgb(211, 211, 211)");
+        expect(shadowScreen).not.toBe("none");
+
+        // Print view: both are dropped to avoid bloating the PDF output.
+        await page.emulateMedia({media: "print"});
+
+        const bodyBgPrint = await body.evaluate((el) => getComputedStyle(el).backgroundColor);
+        const shadowPrint = await pagedPage.evaluate((el) => getComputedStyle(el).boxShadow);
+
+        expect(bodyBgPrint).not.toBe(bodyBgScreen);
+        expect(shadowPrint).toBe("none");
+    }
+);

--- a/quarkdown-html/src/test/e2e/doctype/paged/decorations/main.qd
+++ b/quarkdown-html/src/test/e2e/doctype/paged/decorations/main.qd
@@ -1,0 +1,3 @@
+# Page
+
+Content


### PR DESCRIPTION
Closes #500 

## Problem
The `paged` doctype applies a gray body background and a blurred `box-shadow` to each `.pagedjs_page` so pages "float" in the browser preview. During PDF export Chromium rasterizes the blurred shadow into a full-page image embedded once per page (~90 KB/page), so PDF size grows roughly linearly with page count regardless of content.

## Fix
Gate the backdrop and the page shadow behind `@media print`, which Puppeteer's PDF export honors (same mechanism already used in `_page-margin.scss` and `_docs.scss`). On screen the preview is unchanged. In print/PDF the redundant rasterized shadow disappears.

## Measured impact
A 100-page document of empty pages, before vs. after:

| Variant | Pages | Images embedded | PDF size |
|---|---|---|---|
| before (`box-shadow` on) | ~109 | ~325 (3/page) | 13 MB |
| after (`@media print`) | ~109 | 0 | 198 KB |

Visible output is identical. only the screen-only decoration is suppressed in print.

## Testing
- `_paged.scss` compiles cleanly.
- Built locally via `./gradlew installDist` and verified with the reproduction from the issue: `pdfimages -list` shows 3 images/page before and 0 after. File size 13 MB -> 198 KB.
- Confirmed the floating-page effect still renders on screen.