### PR TITLE
build: publish JVM modules to GitHub Packages on release tags

### DIFF
--- a/.github/workflows/gradle-deploy.yml
+++ b/.github/workflows/gradle-deploy.yml
@@ -145,6 +145,40 @@ jobs:
         version: ${{ github.ref_name }}
         committer_token: ${{ secrets.COMMITTER_TOKEN }}
 
+  # Publishes the Quarkdown JVM modules to GitHub Packages as Maven artifacts.
+  # Runs on release tags (v*) so each released version is consumable as a Maven dependency.
+  publish-packages:
+    runs-on: ubuntu-latest
+    needs: [build]
+    if: github.ref_type == 'tag'
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v4
+
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@v3
+
+    # Mirror the version bump performed by the `build` job, so the published
+    # Maven artifacts carry the same version as the tagged release.
+    - name: Bump version
+      run: printf "%s" "${GITHUB_REF_NAME#v}" > version.txt
+
+    - name: Publish to GitHub Packages
+      env:
+        GITHUB_ACTOR: ${{ github.actor }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: ./gradlew publishAllPublicationsToGitHubPackagesRepository --no-daemon
+
   dependency-submission:
 
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,36 @@
 
 &nbsp;
 
+#### Maven artifacts on GitHub Packages
+
+Released versions of Quarkdown are now published to the GitHub Packages Maven registry, so the JVM modules can be consumed as Maven dependencies under the `com.quarkdown` group.
+
+Add the registry to your build:
+
+```kotlin
+repositories {
+    maven {
+        url = uri("https://maven.pkg.github.com/iamgio/quarkdown")
+        credentials {
+            username = System.getenv("GITHUB_ACTOR")
+            password = System.getenv("GITHUB_TOKEN")
+        }
+    }
+}
+```
+
+Then depend on any Quarkdown module, for example:
+
+```kotlin
+dependencies {
+    implementation("com.quarkdown:quarkdown-core:<version>")
+}
+```
+
+Programmatic use still relies on a Quarkdown installation layout at runtime to load `.qd` libraries and HTML rendering resources; see the [Lib directory](CONTRIBUTING.md#lib-directory) notes.
+
+&nbsp;
+
 #### [AI agent skill](https://quarkdown.com/wiki/agent-skill)
 
 Quarkdown now ships with an agent skill, so tools can author `.qd` documents on your behalf.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,23 +8,25 @@
 
 #### Maven artifacts on GitHub Packages
 
-Released versions of Quarkdown are now published to the GitHub Packages Maven registry, so the JVM modules can be consumed as Maven dependencies under the `com.quarkdown` group.
+Released versions of Quarkdown are now published to the GitHub Packages Maven registry under the `com.quarkdown` group, exposing both the JVM modules and a standalone install `lib/` layout zip.
 
-Add the registry to your build:
+GitHub Packages requires authentication even for public reads. For local builds, generate a classic Personal Access Token with the `read:packages` scope and expose it through Gradle properties or environment variables. Inside GitHub Actions, the workflow-provided `GITHUB_ACTOR` and `secrets.GITHUB_TOKEN` already satisfy this with no extra setup.
+
+Add the registry to your build (the example reads credentials from `gpr.user` / `gpr.key` Gradle properties, falling back to env vars for CI):
 
 ```kotlin
 repositories {
     maven {
         url = uri("https://maven.pkg.github.com/iamgio/quarkdown")
         credentials {
-            username = System.getenv("GITHUB_ACTOR")
-            password = System.getenv("GITHUB_TOKEN")
+            username = providers.gradleProperty("gpr.user").orNull ?: System.getenv("GITHUB_ACTOR")
+            password = providers.gradleProperty("gpr.key").orNull ?: System.getenv("GITHUB_TOKEN")
         }
     }
 }
 ```
 
-Then depend on any Quarkdown module, for example:
+Depend on any Quarkdown module:
 
 ```kotlin
 dependencies {
@@ -32,7 +34,22 @@ dependencies {
 }
 ```
 
-Programmatic use still relies on a Quarkdown installation layout at runtime to load `.qd` libraries and HTML rendering resources; see the [Lib directory](CONTRIBUTING.md#lib-directory) notes.
+Programmatic use of the JVM modules relies on a Quarkdown installation `lib/` layout at runtime to load `.qd` libraries, HTML rendering resources, and agent skills. The same release publishes a standalone zip containing that layout as `com.quarkdown:quarkdown-install-lib:<version>@zip`:
+
+```kotlin
+val quarkdownInstallLib by configurations.creating
+dependencies {
+    quarkdownInstallLib("com.quarkdown:quarkdown-install-lib:<version>@zip")
+}
+
+distributions.main {
+    contents {
+        from(zipTree(quarkdownInstallLib.singleFile))
+    }
+}
+```
+
+See the [Lib directory](CONTRIBUTING.md#lib-directory) notes for what the layout contains and how it's resolved.
 
 &nbsp;
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,22 +11,90 @@ plugins {
     id("com.github.ben-manes.versions") version "0.53.0"
     id("se.patrikerdes.use-latest-versions") version "0.2.19"
     application
+    `maven-publish`
 }
 
-group = "com.quarkdown"
-version = file("version.txt").readText().trim()
-
 allprojects {
+    group = "com.quarkdown"
+    version = rootProject.file("version.txt").readText().trim()
+
     repositories {
         mavenCentral()
     }
 }
+
+// Subprojects that should not produce a published Maven artifact.
+// `quarkdown-test` contains only integration tests and has no `src/main/`.
+val publicationExcludedSubprojects = setOf("quarkdown-test")
 
 subprojects {
     apply(plugin = "org.jetbrains.dokka")
     apply(plugin = "org.jlleitschuh.gradle.ktlint")
     apply(plugin = "com.github.ben-manes.versions")
     apply(plugin = "se.patrikerdes.use-latest-versions")
+    apply(plugin = "maven-publish")
+
+    plugins.withType<JavaPlugin>().configureEach {
+        extensions.configure<JavaPluginExtension> {
+            withSourcesJar()
+        }
+    }
+
+    afterEvaluate {
+        if (project.name in publicationExcludedSubprojects) return@afterEvaluate
+        if (!plugins.hasPlugin("java")) return@afterEvaluate
+
+        // GitHub Packages publication.
+        //
+        // The repository URL is derived from the `GITHUB_REPOSITORY` environment variable set by
+        // GitHub Actions, so the same configuration publishes to the correct registry for the
+        // upstream repo and for any fork. Credentials are read from `GITHUB_ACTOR` and
+        // `GITHUB_TOKEN` in CI, and fall back to the `gpr.user` / `gpr.key` Gradle properties for
+        // local publication.
+        extensions.configure<PublishingExtension> {
+            publications {
+                create<MavenPublication>("maven") {
+                    from(components["java"])
+                    pom {
+                        name.set(project.name)
+                        description.set("Quarkdown module: ${project.name}")
+                        url.set("https://github.com/iamgio/quarkdown")
+                        licenses {
+                            license {
+                                name.set("GNU General Public License v3.0")
+                                url.set("https://www.gnu.org/licenses/gpl-3.0.html")
+                            }
+                        }
+                        developers {
+                            developer {
+                                id.set("iamgio")
+                                name.set("Giorgio Garofalo")
+                                url.set("https://github.com/iamgio")
+                            }
+                        }
+                        scm {
+                            connection.set("scm:git:https://github.com/iamgio/quarkdown.git")
+                            developerConnection.set("scm:git:ssh://git@github.com:iamgio/quarkdown.git")
+                            url.set("https://github.com/iamgio/quarkdown")
+                        }
+                    }
+                }
+            }
+            repositories {
+                maven {
+                    name = "GitHubPackages"
+                    val repository = System.getenv("GITHUB_REPOSITORY") ?: "iamgio/quarkdown"
+                    url = uri("https://maven.pkg.github.com/$repository")
+                    credentials {
+                        username = System.getenv("GITHUB_ACTOR")
+                            ?: providers.gradleProperty("gpr.user").orNull
+                        password = System.getenv("GITHUB_TOKEN")
+                            ?: providers.gradleProperty("gpr.key").orNull
+                    }
+                }
+            }
+        }
+    }
 }
 
 // Fat JAR / Distribution dependencies

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,6 +27,32 @@ allprojects {
 // `quarkdown-test` contains only integration tests and has no `src/main/`.
 val publicationExcludedSubprojects = setOf("quarkdown-test")
 
+/**
+ * Shared POM metadata applied to every Quarkdown Maven publication: project URL, licence,
+ * developers, and SCM. Per-publication `name` and `description` are set at the call site.
+ */
+val publicationPomMetadata: MavenPom.() -> Unit = {
+    url.set("https://github.com/iamgio/quarkdown")
+    licenses {
+        license {
+            name.set("GNU General Public License v3.0")
+            url.set("https://www.gnu.org/licenses/gpl-3.0.html")
+        }
+    }
+    developers {
+        developer {
+            id.set("iamgio")
+            name.set("Giorgio Garofalo")
+            url.set("https://github.com/iamgio")
+        }
+    }
+    scm {
+        connection.set("scm:git:https://github.com/iamgio/quarkdown.git")
+        developerConnection.set("scm:git:ssh://git@github.com:iamgio/quarkdown.git")
+        url.set("https://github.com/iamgio/quarkdown")
+    }
+}
+
 subprojects {
     apply(plugin = "org.jetbrains.dokka")
     apply(plugin = "org.jlleitschuh.gradle.ktlint")
@@ -58,25 +84,7 @@ subprojects {
                     pom {
                         name.set(project.name)
                         description.set("Quarkdown module: ${project.name}")
-                        url.set("https://github.com/iamgio/quarkdown")
-                        licenses {
-                            license {
-                                name.set("GNU General Public License v3.0")
-                                url.set("https://www.gnu.org/licenses/gpl-3.0.html")
-                            }
-                        }
-                        developers {
-                            developer {
-                                id.set("iamgio")
-                                name.set("Giorgio Garofalo")
-                                url.set("https://github.com/iamgio")
-                            }
-                        }
-                        scm {
-                            connection.set("scm:git:https://github.com/iamgio/quarkdown.git")
-                            developerConnection.set("scm:git:ssh://git@github.com:iamgio/quarkdown.git")
-                            url.set("https://github.com/iamgio/quarkdown")
-                        }
+                        publicationPomMetadata()
                     }
                 }
             }
@@ -310,6 +318,70 @@ val assembleDevLib by tasks.registering(Sync::class) {
     dependsOn(":quarkdown-html:bundleThirdParty")
     into(layout.buildDirectory.dir("dev-lib"))
     installLibLayout()
+}
+
+/**
+ * Standalone zip artifact containing the Quarkdown install `lib/` layout, with the same
+ * `lib/qd`, `lib/html`, `lib/skills` shape produced by [installLibLayout]. Published as a
+ * Maven artifact alongside the JVM modules so that consumers embedding Quarkdown can fetch
+ * the runtime resources (`.qd` libraries, HTML themes and scripts, third-party bundles,
+ * agent skills) without having to vendor the upstream source or unpack the full
+ * distribution zip.
+ */
+val installLibZip by tasks.registering(Zip::class) {
+    group = "distribution"
+    description = "Packages the Quarkdown install `lib/` layout (qd, html, skills) as a standalone zip artifact."
+
+    archiveBaseName.set("quarkdown-install-lib")
+    destinationDirectory.set(layout.buildDirectory.dir("distributions"))
+
+    // The HTML install layout is produced as a side-effect of these bundling tasks.
+    // Provider-based wiring should detect these automatically, but declaring them explicitly
+    // keeps the published artifact reliably reproducible.
+    dependsOn(
+        ":quarkdown-html:assembleThemes",
+        ":quarkdown-html:bundleTypeScript",
+        ":quarkdown-html:bundleHighlightJs",
+        ":quarkdown-html:bundleThirdParty",
+    )
+
+    into("lib", installLibLayout)
+}
+
+// Root-project publication of the standalone install-lib zip.
+//
+// The JVM module publications live on the subprojects (see the `subprojects` block above);
+// this block adds a single artifact on the root so consumers can resolve the runtime
+// install layout under a stable Maven coordinate:
+//
+//     com.quarkdown:quarkdown-install-lib:<version>@zip
+publishing {
+    publications {
+        create<MavenPublication>("installLib") {
+            artifactId = "quarkdown-install-lib"
+            artifact(installLibZip) {
+                extension = "zip"
+            }
+            pom {
+                name.set("quarkdown-install-lib")
+                description.set("Quarkdown install `lib/` layout (qd, html, skills) as a standalone zip artifact.")
+                publicationPomMetadata()
+            }
+        }
+    }
+    repositories {
+        maven {
+            name = "GitHubPackages"
+            val repository = System.getenv("GITHUB_REPOSITORY") ?: "iamgio/quarkdown"
+            url = uri("https://maven.pkg.github.com/$repository")
+            credentials {
+                username = System.getenv("GITHUB_ACTOR")
+                    ?: providers.gradleProperty("gpr.user").orNull
+                password = System.getenv("GITHUB_TOKEN")
+                    ?: providers.gradleProperty("gpr.key").orNull
+            }
+        }
+    }
 }
 
 tasks.installDist {


### PR DESCRIPTION
## Summary

Closes the gap from #115: Quarkdown's JVM modules aren't consumable as Maven dependencies today. This PR publishes them, plus a standalone install `lib/` layout zip, to the repo's GitHub Packages Maven registry on each `v*` tag under the `com.quarkdown` group.

## Changes

- **`build.gradle.kts`**: apply `maven-publish` to every library subproject (skipping `quarkdown-test`, which has no `src/main/`), add a sources jar and shared POM metadata, and add a root-level `quarkdown-install-lib` zip publication mirroring the existing `installLibLayout` (`lib/qd`, `lib/html`, `lib/skills`). Move `group`/`version` into the existing `allprojects` block so subprojects publish under `com.quarkdown:<module>:<version>` instead of `quarkdown:<module>:unspecified`.
- **`.github/workflows/gradle-deploy.yml`**: new `publish-packages` job gated on `v*` tags, mirrors the existing tag-derived version bump, runs `publishAllPublicationsToGitHubPackagesRepository` with the workflow's `GITHUB_TOKEN`. No new secrets required.
- **`CHANGELOG.md`**: registry setup, JVM module deps, and install-lib zip usage, with an explicit note that local consumers need a classic PAT with `read:packages`.

## Validation

- `./gradlew publishToMavenLocal` publishes all 12 library modules under `com.quarkdown:<module>:2.0.1` and `com.quarkdown:quarkdown-install-lib:2.0.1@zip` (~17.6 MB, 1,756 files), with correct inter-module deps in the generated POMs.
- `./gradlew ktlintCheck` passes.

## Notes

- The install `lib/` layout is still required at runtime, as you noted on #115. The new `quarkdown-install-lib` zip is the path consumers can take instead of vendoring upstream sources.
- The repository URL is derived from `GITHUB_REPOSITORY`, so the same config works for forks.
- Happy to narrow `quarkdown-test`-style exclusions to a stricter allowlist if you prefer, or to split the install-lib publication into its own PR.