### PR TITLE
fix(scripting): preserve rich formatting of iterated lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,23 @@ Templates, used in `quarkdown create` and live preview, are now precompiled at b
 
 &nbsp;
 
+#### Preserve rich formatting in iterated lists
+
+The following snippet now correctly preserves formatting when iterating over a Markdown list, rather than treating entries as plain text:
+
+```markdown
+.var {mylist}
+  - text
+  - *italic*
+  - **bold**
+
+.row alignment:{spacearound}
+    .foreach {.mylist}
+        .1
+```
+
+&nbsp;
+
 #### Fixed live preview sometimes failing on edit
 
 Fixed an issue that caused live preview to crash with an *"Address already in use"* error on recompile.

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/base/block/list/ListItem.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/base/block/list/ListItem.kt
@@ -7,11 +7,13 @@ import com.quarkdown.core.visitor.node.NodeVisitor
 /**
  * An item of a [ListBlock]. A list item may be enhanced via [ListItemVariant]s.
  * @param variants additional functionalities and characteristics of this item. For example, this item may contain a checked/unchecked task.
- * @param children content
+ * @param rawContent the raw source content of this item, if available. This is used for value conversion to iterable and dictionary values.
+ * @see com.quarkdown.core.util.node.conversion.list.MarkdownListConverter for list-to-value conversion that utilizes the raw content.
  */
 class ListItem(
     val variants: List<ListItemVariant> = emptyList(),
     override val children: List<Node>,
+    val rawContent: String? = null,
 ) : NestableNode {
     /**
      * The list that owns this item.

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/parser/BlockTokenParser.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/parser/BlockTokenParser.kt
@@ -54,6 +54,7 @@ import com.quarkdown.core.util.nextOrNull
 import com.quarkdown.core.util.removeOptionalPrefix
 import com.quarkdown.core.util.trimDelimiters
 import com.quarkdown.core.visitor.token.BlockTokenVisitor
+import java.nio.file.Files.lines
 
 /**
  * The position of this character in the delimiter of a table header defines its column alignment.
@@ -293,14 +294,15 @@ class BlockTokenParser(
             token.data.text
                 .removePrefix(marker)
                 .removePrefix(task)
-        val lines = content.lineSequence()
 
-        if (lines.none()) {
-            return ListItem(children = emptyList())
+        if (content.isBlank()) {
+            return ListItem(children = emptyList(), rawContent = content)
         }
 
+        val lines = content.lineSequence()
+
         // Trims the content, removing common indentation.
-        val trimmedContent = trimMinIndent(lines, minIndent = marker.trim().length)
+        val trimmedContent = trimMinIndent(lines, minIndent = marker.trim().length).trimEnd()
 
         // Additional features of this list item.
         val variants =
@@ -318,7 +320,7 @@ class BlockTokenParser(
                 .newBlockLexer(source = trimmedContent)
                 .tokenizeAndParse()
 
-        return ListItem(variants, children)
+        return ListItem(variants, children, rawContent = trimmedContent)
     }
 
     override fun visit(token: TableToken): Node {

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/util/node/conversion/list/MarkdownListConverter.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/util/node/conversion/list/MarkdownListConverter.kt
@@ -40,7 +40,10 @@ abstract class MarkdownListConverter<T, E, N : Node>(
      * @param child the first child of a list item. In the previous example, it would be a paragraph which contains "Inline 1", "Inline 2" or "Inline 3".
      * @return the element to push
      */
-    protected abstract fun inlineValue(child: N): E
+    protected abstract fun inlineValue(
+        child: N,
+        rawContent: String?,
+    ): E
 
     /**
      * Converts the nested child of a list item to a pushable element.
@@ -72,11 +75,11 @@ abstract class MarkdownListConverter<T, E, N : Node>(
     fun convert(): T {
         list.items
             .asSequence()
-            .map { it.children.filterNot { child -> child is Newline } }
-            .forEach { children ->
+            .map { it.rawContent to it.children.filterNot { child -> child is Newline } }
+            .forEach { (rawContent, children) ->
                 val firstChild: N = validateChild(children.first())
                 when (val secondChild = children.getOrNull(1)) {
-                    null -> push(inlineValue(firstChild))
+                    null -> push(inlineValue(firstChild, rawContent))
                     is ListBlock -> push(nestedValue(firstChild, secondChild))
                     else -> throw IllegalRawValueException("Unexpected element", secondChild)
                 }

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/util/node/conversion/list/MarkdownListToCollectionValue.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/util/node/conversion/list/MarkdownListToCollectionValue.kt
@@ -4,11 +4,10 @@ import com.quarkdown.core.ast.Node
 import com.quarkdown.core.ast.base.TextNode
 import com.quarkdown.core.ast.base.block.list.ListBlock
 import com.quarkdown.core.context.Context
+import com.quarkdown.core.function.value.DynamicValue
 import com.quarkdown.core.function.value.NodeValue
 import com.quarkdown.core.function.value.OrderedCollectionValue
 import com.quarkdown.core.function.value.OutputValue
-import com.quarkdown.core.function.value.factory.ValueFactory
-import com.quarkdown.core.util.node.toPlainText
 
 /**
  * Helper that converts a Markdown list to an [OrderedCollectionValue].
@@ -18,18 +17,18 @@ import com.quarkdown.core.util.node.toPlainText
  *        The first argument is the parent node, and the second is the nested [ListBlock]
  * @param T type of values in the collection
  * @see OrderedCollectionValue
- * @see ValueFactory.iterable
+ * @see com.quarkdown.core.function.value.factory.ValueFactory.iterable
  */
 class MarkdownListToCollectionValue<T : OutputValue<*>>(
     list: ListBlock,
-    inlineValueMapper: (Node) -> T,
+    inlineValueMapper: (Node, rawContent: String?) -> T,
     nestedValueMapper: (Node, ListBlock) -> T,
 ) : MarkdownListToIterable<OrderedCollectionValue<T>, T>(list, inlineValueMapper, nestedValueMapper) {
     override fun wrap(): OrderedCollectionValue<T> = OrderedCollectionValue(elements.toList())
 
     companion object {
         /**
-         * [MarkdownListToCollectionValue] factory via a [ValueFactory].
+         * [MarkdownListToCollectionValue] factory via a [com.quarkdown.core.function.value.factory.ValueFactory].
          * @param list list to convert
          * @param context context to use for the conversion
          */
@@ -39,10 +38,10 @@ class MarkdownListToCollectionValue<T : OutputValue<*>>(
         ): MarkdownListToCollectionValue<*> =
             MarkdownListToCollectionValue(
                 list,
-                inlineValueMapper = {
-                    when (it) {
-                        is TextNode -> ValueFactory.eval(it.text.toPlainText(), context)
-                        else -> NodeValue(it)
+                inlineValueMapper = { node, rawContent ->
+                    when {
+                        node is TextNode && rawContent != null -> DynamicValue(rawContent, context)
+                        else -> NodeValue(node)
                     }
                 },
                 nestedValueMapper = { _, list -> viaValueFactory(list, context).convert() },

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/util/node/conversion/list/MarkdownListToDictionaryValue.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/util/node/conversion/list/MarkdownListToDictionaryValue.kt
@@ -55,7 +55,10 @@ class MarkdownListToDictionaryValue<T : OutputValue<*>>(
                 firstChild,
             )
 
-    override fun inlineValue(child: TextNode): Pair<String, T> {
+    override fun inlineValue(
+        child: TextNode,
+        rawContent: String?,
+    ): Pair<String, T> {
         val text = child.text.toPlainText()
         // A key-value pair.
         // - This: that

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/util/node/conversion/list/MarkdownListToIterable.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/util/node/conversion/list/MarkdownListToIterable.kt
@@ -33,7 +33,7 @@ import com.quarkdown.core.ast.base.block.list.ListBlock
  */
 abstract class MarkdownListToIterable<O, T>(
     list: ListBlock,
-    private val inlineValueMapper: (Node) -> T,
+    private val inlineValueMapper: (Node, rawContent: String?) -> T,
     private val nestedValueMapper: (Node, ListBlock) -> T,
 ) : MarkdownListConverter<O, T, Node>(list) {
     protected val elements = mutableListOf<T>()
@@ -44,13 +44,15 @@ abstract class MarkdownListToIterable<O, T>(
 
     override fun validateChild(firstChild: Node) = firstChild
 
-    override fun inlineValue(child: Node) =
-        when (child) {
-            // Compact syntax: the parent node is the list itself.
-            is ListBlock -> nestedValueMapper(child, child)
+    override fun inlineValue(
+        child: Node,
+        rawContent: String?,
+    ) = when (child) {
+        // Compact syntax: the parent node is the list itself.
+        is ListBlock -> nestedValueMapper(child, child)
 
-            else -> inlineValueMapper(child)
-        }
+        else -> inlineValueMapper(child, rawContent)
+    }
 
     // Extended syntax.
     override fun nestedValue(

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/util/node/conversion/list/MarkdownListToList.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/util/node/conversion/list/MarkdownListToList.kt
@@ -13,7 +13,7 @@ import com.quarkdown.core.ast.base.block.list.ListBlock
  */
 class MarkdownListToList<T>(
     list: ListBlock,
-    inlineValueMapper: (Node) -> T,
+    inlineValueMapper: (Node, rawContent: String?) -> T,
     nestedValueMapper: (Node, ListBlock) -> T,
 ) : MarkdownListToIterable<List<T>, T>(list, inlineValueMapper, nestedValueMapper) {
     override fun wrap(): List<T> = elements.toList()

--- a/quarkdown-core/src/test/kotlin/com/quarkdown/core/ValueFactoryTest.kt
+++ b/quarkdown-core/src/test/kotlin/com/quarkdown/core/ValueFactoryTest.kt
@@ -1,5 +1,6 @@
 package com.quarkdown.core
 
+import com.quarkdown.core.context.Context
 import com.quarkdown.core.context.MutableContext
 import com.quarkdown.core.document.size.Size
 import com.quarkdown.core.document.size.Sizes
@@ -260,8 +261,9 @@ class ValueFactoryTest {
 
     @Test
     fun `simple iterable`() {
+        val context = newContext()
         assertEquals(
-            listOf(DynamicValue("1"), DynamicValue("2"), DynamicValue("3")),
+            listOf(DynamicValue("1", context), DynamicValue("2", context), DynamicValue("3", context)),
             ValueFactory
                 .iterable(
                     """
@@ -269,20 +271,21 @@ class ValueFactoryTest {
                     - 2
                     - 3
                     """.trimIndent(),
-                    newContext(),
+                    context,
                 ).unwrappedValue,
         )
     }
 
     @Test
     fun `nested iterable, compact`() {
+        val context = newContext()
         assertEquals(
             listOf(
                 OrderedCollectionValue(
-                    listOf(DynamicValue("11"), DynamicValue("12")),
+                    listOf(DynamicValue("11", context), DynamicValue("12", context)),
                 ),
                 OrderedCollectionValue(
-                    listOf(DynamicValue("22")),
+                    listOf(DynamicValue("22", context)),
                 ),
             ),
             ValueFactory
@@ -292,21 +295,21 @@ class ValueFactoryTest {
                       - 12
                     - - 22
                     """.trimIndent(),
-                    newContext(),
+                    context,
                 ).unwrappedValue,
         )
     }
 
-    private val complexIterableResult =
+    private fun complexIterableResult(context: Context) =
         listOf(
             OrderedCollectionValue(
                 listOf(
-                    DynamicValue("11"),
-                    DynamicValue("12"),
+                    DynamicValue("11", context),
+                    DynamicValue("12", context),
                     OrderedCollectionValue(
                         listOf(
-                            DynamicValue("121"),
-                            DynamicValue("122"),
+                            DynamicValue("121", context),
+                            DynamicValue("122", context),
                         ),
                     ),
                 ),
@@ -314,17 +317,18 @@ class ValueFactoryTest {
             OrderedCollectionValue(
                 listOf(
                     OrderedCollectionValue(
-                        listOf(DynamicValue("211")),
+                        listOf(DynamicValue("211", context)),
                     ),
-                    DynamicValue("22"),
+                    DynamicValue("22", context),
                 ),
             ),
         )
 
     @Test
     fun `complex nested iterable, compact`() {
+        val context = newContext()
         assertEquals(
-            complexIterableResult,
+            complexIterableResult(context),
             ValueFactory
                 .iterable(
                     """
@@ -335,15 +339,16 @@ class ValueFactoryTest {
                     - - - 211
                       - 22
                     """.trimIndent(),
-                    newContext(),
+                    context,
                 ).unwrappedValue,
         )
     }
 
     @Test
     fun `complex nested iterable, extended syntax`() {
+        val context = newContext()
         assertEquals(
-            complexIterableResult,
+            complexIterableResult(context),
             ValueFactory
                 .iterable(
                     """
@@ -358,7 +363,7 @@ class ValueFactoryTest {
                         - 211
                       - 22
                     """.trimIndent(),
-                    newContext(),
+                    context,
                 ).unwrappedValue,
         )
     }

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/internal/FileTree.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/internal/FileTree.kt
@@ -34,7 +34,7 @@ private fun Node.isHighlighted(): Boolean =
 internal fun fileTreeFromList(list: ListBlock): List<FileTreeEntry> =
     MarkdownListToList(
         list,
-        inlineValueMapper = { node ->
+        inlineValueMapper = { node, _ ->
             val text = listOf(node).toPlainText()
             val highlighted = node.isHighlighted()
             if (text in ELLIPSIS_TEXTS) {

--- a/quarkdown-test/src/test/kotlin/com/quarkdown/test/ScriptingTest.kt
+++ b/quarkdown-test/src/test/kotlin/com/quarkdown/test/ScriptingTest.kt
@@ -310,6 +310,33 @@ class ScriptingTest {
     }
 
     @Test
+    fun `iterated list keeps formatting`() {
+        execute(
+            """
+            .var {abc}
+                - text
+                - *italic*
+                - **bold**
+                - [Link](https://example.com)
+                - .sum {1} {2}
+            
+            .row
+                .foreach {.abc}
+                    .1
+            """.trimIndent(),
+        ) {
+            assertEquals(
+                "<div style=\"justify-content: flex-start; align-items: center;\" class=\"stack stack-row\">" +
+                    "<p>text</p><p><em>italic</em></p><p><strong>bold</strong></p>" +
+                    "<p><a href=\"https://example.com\">Link</a></p>" +
+                    "<p>3</p>" +
+                    "</div>",
+                it,
+            )
+        }
+    }
+
+    @Test
     fun dictionaries() {
         val authors =
             """


### PR DESCRIPTION
- [x] I have read the [contributing guidelines](https://github.com/iamgio/quarkdown/blob/main/CONTRIBUTING.md).
- [x] I have tested the changes locally.
- [ ] An issue for this change exists, and it was discussed with maintainers. This is required for new features and non-trivial changes. If present, append `Closes #ISSUE_NUMBER` at the end of this PR description.
- [x] (Optional) I have added necessary documentation to [`docs`](https://github.com/iamgio/quarkdown/tree/main/docs) and [`CHANGELOG.md`](https://github.com/iamgio/quarkdown/blob/main/CHANGELOG.md)

Closes #482