### PR TITLE
fix(theme/paperwhite): clean up code snippet borders in error box

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,12 @@ The following snippet now correctly preserves formatting when iterating over a M
 
 Fixed an issue that caused live preview to crash with an *"Address already in use"* error on recompile.
 
+&nbsp;
+
+#### [theme/paperwhite] Cleaned up border around code snippets in error boxes
+
+Fixed unexpected borders around code snippets in error boxes when using the `paperwhite` color theme.
+
 * * *
 
 ### Sponsors

--- a/quarkdown-html/src/main/scss/color/paperwhite.scss
+++ b/quarkdown-html/src/main/scss/color/paperwhite.scss
@@ -22,16 +22,22 @@
         border-color: rgba(0, 0, 0, 0.2);
     }
 
-    pre code {
-        background-color: transparent;
+    pre {
         border: 1px solid var(--qd-main-color-muted);
+
+        code {
+            background-color: transparent;
+        }
     }
 
     &.quarkdown-paged {
-        pre code {
-            padding-left: 0;
-            padding-right: 0;
+        pre {
             border: none;
+
+            code {
+                padding-left: 0;
+                padding-right: 0;
+            }
         }
     }
 


### PR DESCRIPTION
- [x] I have read the [contributing guidelines](https://github.com/iamgio/quarkdown/blob/main/CONTRIBUTING.md).
- [x] I have tested the changes locally.
- [ ] An issue for this change exists, and it was discussed with maintainers. This is required for new features and non-trivial changes. If present, append `Closes #ISSUE_NUMBER` at the end of this PR description.
- [x] (Optional) I have added necessary documentation to [`docs`](https://github.com/iamgio/quarkdown/tree/main/docs) and [`CHANGELOG.md`](https://github.com/iamgio/quarkdown/blob/main/CHANGELOG.md)