### PR TITLE
feat(toc): enhance table of contents navigation for duplicate headings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,21 @@ The generated PDF file is now `abc123我爱你.pdf`.
 
 Thanks @CarmJos!
 
+&nbsp;
+
+#### [Table of contents navigation for duplicate headings](https://quarkdown.com/wiki/table-of-contents)
+
+In HTML previews and exports, table of contents links now correctly navigate when multiple headings share the same title.
+
+This fix applies to both:
+
+- `.tableofcontents` content in the document body,
+- the docs sidebar navigation.
+
+Navigation and page labels are now resolved from each heading's location metadata, so entries point to the correct section even when heading text is duplicated across chapters.
+
+Thanks @CarmJos!
+
 ## [2.1.2] - 2026-05-24
 
 ### Changed

--- a/quarkdown-html/src/main/typescript/document/handlers/__tests__/page-numbers-document-handler.spec.ts
+++ b/quarkdown-html/src/main/typescript/document/handlers/__tests__/page-numbers-document-handler.spec.ts
@@ -110,4 +110,40 @@ describe('PageNumbersDocumentHandler', () => {
         const numbers = Array.from(document.querySelectorAll<HTMLSpanElement>('.toc-page-number')).map(span => span.textContent);
         expect(numbers).toEqual(['1', '5']);
     });
+
+    it('uses table-of-contents data-location to resolve duplicated heading ids', async () => {
+        document.body.className = 'quarkdown quarkdown-paged';
+        document.body.innerHTML = `
+      <div class="pagedjs_page" data-page-number="1">
+        <div class="pagedjs_area">
+          <nav data-role="table-of-contents">
+            <ol>
+              <li data-location="1.1"><a href="#task-requirements">Task Requirements</a></li>
+              <li data-location="2.1"><a href="#task-requirements">Task Requirements</a></li>
+            </ol>
+          </nav>
+          <h2 id="task-requirements" data-location="1.1">Task Requirements</h2>
+          <span class="current-page-number">X</span>
+        </div>
+      </div>
+      <div class="pagedjs_page" data-page-number="2">
+        <div class="pagedjs_area">
+          <span class="page-number-reset" data-start="10"></span>
+          <h2 id="task-requirements" data-location="2.1">Task Requirements</h2>
+          <span class="current-page-number">Y</span>
+        </div>
+      </div>`;
+
+        const pages = Array.from(document.querySelectorAll<HTMLElement>('.pagedjs_page'));
+        const handler = new Concrete(new DummyDocument(pages));
+
+        await handler.onPostRendering();
+
+        const numbers = Array.from(document.querySelectorAll<HTMLSpanElement>('.toc-page-number')).map(span => span.textContent);
+        expect(numbers).toEqual(['1', '10']);
+
+        const links = Array.from(document.querySelectorAll<HTMLAnchorElement>('nav[data-role="table-of-contents"] a'));
+        expect(links[0].getAttribute('href')).toBe('#task-requirements');
+        expect(links[1].getAttribute('href')).toBe('#qd-location-2-1');
+    });
 });

--- a/quarkdown-html/src/main/typescript/document/handlers/page-numbers.ts
+++ b/quarkdown-html/src/main/typescript/document/handlers/page-numbers.ts
@@ -1,6 +1,5 @@
 import {DocumentHandler} from "../document-handler";
 import {PagedLikeQuarkdownDocument, QuarkdownPage} from "../paged-like-quarkdown-document";
-import {getAnchorTargetId} from "../../util/id";
 import {formatNumber} from "../../util/numbering";
 
 /**
@@ -9,6 +8,75 @@ import {formatNumber} from "../../util/numbering";
  * including support for page number resets and displaying page numbers in tables of contents.
  */
 export class PageNumbers extends DocumentHandler<PagedLikeQuarkdownDocument<any>> {
+    private static readonly TOC_NAV_SELECTOR = 'nav[data-role="table-of-contents"]';
+    private static readonly GENERATED_TOC_ID_PREFIX = 'qd-location-';
+
+    /**
+     * Escapes a string so it can be safely used in a CSS attribute selector.
+     */
+    private escapeForAttributeSelector(value: string): string {
+        return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+    }
+
+    /**
+     * Converts a location label like "2.1" into a stable id-friendly token.
+     */
+    private toLocationToken(location: string): string {
+        return location.toLowerCase().replace(/[^a-z0-9_-]+/g, '-').replace(/^-+|-+$/g, '');
+    }
+
+    /**
+     * Finds a unique available ID based on a preferred candidate.
+     */
+    private getAvailableId(preferred: string): string {
+        if (!document.getElementById(preferred)) {
+            return preferred;
+        }
+
+        let suffix = 2;
+        while (document.getElementById(`${preferred}-${suffix}`)) {
+            suffix += 1;
+        }
+        return `${preferred}-${suffix}`;
+    }
+
+    /**
+     * Ensures TOC anchors point to an unambiguous target id, even when duplicate heading ids exist.
+     */
+    private updateTableOfContentsHref(anchor: HTMLAnchorElement, target: HTMLElement, location: string) {
+        const hasUsableId = target.id.length > 0 && document.getElementById(target.id) === target;
+        if (!hasUsableId) {
+            const locationToken = this.toLocationToken(location) || 'item';
+            const generatedId = this.getAvailableId(`${PageNumbers.GENERATED_TOC_ID_PREFIX}${locationToken}`);
+            target.id = generatedId;
+        }
+        anchor.setAttribute('href', `#${target.id}`);
+    }
+
+    /**
+     * Resolves a TOC anchor target from its list item `data-location`, falling back to href id lookup.
+     */
+    private resolveTableOfContentsTarget(anchor: HTMLAnchorElement): HTMLElement | undefined {
+        const location = anchor.closest<HTMLElement>('li[data-location]')?.dataset.location;
+        if (location) {
+            const escaped = this.escapeForAttributeSelector(location);
+            const candidates = document.querySelectorAll<HTMLElement>(`[data-location="${escaped}"]`);
+            const target = Array.from(candidates).find(element => !element.closest(PageNumbers.TOC_NAV_SELECTOR));
+            if (target) {
+                this.updateTableOfContentsHref(anchor, target, location);
+                return target;
+            }
+        }
+
+        const href = anchor.getAttribute('href');
+        if (!href || !href.startsWith('#')) {
+            return undefined;
+        }
+
+        const id = decodeURIComponent(href).slice(1);
+        return id ? document.getElementById(id) ?? undefined : undefined;
+    }
+
     /**
      * Gets all elements that display the total page count.
      * @returns NodeList of total page number elements (`.total-page-number`)
@@ -91,11 +159,10 @@ export class PageNumbers extends DocumentHandler<PagedLikeQuarkdownDocument<any>
      * Updates table of contents entries so they display the logical (reset-aware) page numbers.
      */
     private updateTableOfContentsPageNumbers() {
-        const tocs = document.querySelectorAll<HTMLElement>('nav[data-role="table-of-contents"]');
+        const tocs = document.querySelectorAll<HTMLElement>(PageNumbers.TOC_NAV_SELECTOR);
         tocs.forEach(nav => {
             nav.querySelectorAll<HTMLAnchorElement>(':scope a[href^="#"]').forEach(anchor => {
-                const targetId = getAnchorTargetId(anchor);
-                const target = targetId ? document.getElementById(targetId) : undefined;
+                const target = this.resolveTableOfContentsTarget(anchor);
                 const displayNumber = target ? this.quarkdownDocument.getDisplayPageNumber(this.quarkdownDocument.getPage(target)) : undefined;
                 this.setTableOfContentsPageNumber(anchor, displayNumber?.toString());
             });

--- a/quarkdown-html/src/main/typescript/navigation/active-tracking.ts
+++ b/quarkdown-html/src/main/typescript/navigation/active-tracking.ts
@@ -5,13 +5,67 @@
  * @param navigation - The navigation element containing items with `data-target-id` attributes
  */
 export function initNavigationActiveTracking(navigation: HTMLElement): void {
-    const items = navigation.querySelectorAll<HTMLLIElement>('li[data-target-id]');
+    const items = navigation.querySelectorAll<HTMLLIElement>('li[data-target-id], li[data-location]');
     if (items.length === 0) return;
+
+    const NAVIGATION_CONTAINER_SELECTOR = 'nav[role="doc-toc"], nav[data-role="table-of-contents"]';
+    const GENERATED_ID_PREFIX = 'qd-location-';
+
+    const escapeForAttributeSelector = (value: string): string =>
+        value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+
+    const toLocationToken = (location: string): string =>
+        location.toLowerCase().replace(/[^a-z0-9_-]+/g, '-').replace(/^-+|-+$/g, '');
+
+    const getAvailableId = (preferred: string): string => {
+        if (!document.getElementById(preferred)) {
+            return preferred;
+        }
+
+        let suffix = 2;
+        while (document.getElementById(`${preferred}-${suffix}`)) {
+            suffix += 1;
+        }
+        return `${preferred}-${suffix}`;
+    };
+
+    const ensureUniqueTargetId = (target: HTMLElement, location: string): string => {
+        const hasUsableId = target.id.length > 0 && document.getElementById(target.id) === target;
+        if (hasUsableId) {
+            return target.id;
+        }
+
+        const locationToken = toLocationToken(location) || 'item';
+        const generatedId = getAvailableId(`${GENERATED_ID_PREFIX}${locationToken}`);
+        target.id = generatedId;
+        return generatedId;
+    };
+
+    const resolveTargetByLocation = (location: string): HTMLElement | undefined => {
+        const escapedLocation = escapeForAttributeSelector(location);
+        const candidates = document.querySelectorAll<HTMLElement>(`[data-location="${escapedLocation}"]`);
+        return Array.from(candidates).find(element => !element.closest(NAVIGATION_CONTAINER_SELECTOR));
+    };
+
+    const resolveNavigationTargetId = (item: HTMLLIElement): string | undefined => {
+        const location = item.dataset.location;
+        if (location) {
+            const target = resolveTargetByLocation(location);
+            if (target) {
+                const targetId = ensureUniqueTargetId(target, location);
+                item.dataset.targetId = targetId;
+                item.querySelector<HTMLAnchorElement>('a[href^="#"]')?.setAttribute('href', `#${targetId}`);
+                return targetId;
+            }
+        }
+
+        return item.dataset.targetId;
+    };
 
     // Map target IDs to their corresponding navigation items
     const targetToItem = new Map<string, HTMLLIElement>();
     items.forEach(item => {
-        const targetId = item.dataset.targetId;
+        const targetId = resolveNavigationTargetId(item);
         if (targetId) {
             targetToItem.set(targetId, item);
         }


### PR DESCRIPTION
- [X] I have read the [contributing guidelines](https://github.com/iamgio/quarkdown/blob/main/CONTRIBUTING.md).
- [X] I have tested the changes locally.
- [X] An issue for this change exists, and it was discussed with maintainers. This is required for new features and non-trivial changes. If present, append `Closes #ISSUE_NUMBER` at the end of this PR description.
- [X] (Optional) I have added necessary documentation to [`docs`](https://github.com/iamgio/quarkdown/tree/main/docs) and [`CHANGELOG.md`](https://github.com/iamgio/quarkdown/blob/main/CHANGELOG.md)

## Summary
This PR improves table of contents navigation when multiple headings share the same text.
It fixes incorrect navigation targets in both in-document's `.tableofcontents`, and html sidebar navigation.

see #516 .

## Problem
When headings had duplicate titles (for example across different chapters), TOC entries could navigate to the wrong section and show incorrect page references, because matching was effectively ambiguous.

## Solution
TOC navigation now resolves targets using each heading’s location metadata, instead of relying only on heading text / ambiguous IDs.
This makes navigation deterministic and chapter-aware for duplicate heading names.

## Breaking Changes
**None.**

---

Close #516 as solved.