### PR TITLE
fix(output): preserve Unicode letters in file name sanitization.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,15 +38,17 @@ This behavior can be turned off with the new [`--forbid-function-overwriting`](h
 
 #### Preserve Unicode characters in output names
 
-When compiling with `--out-name`, output file names now preserve Unicode letters and numbers instead of replacing them with dashes.
+Output file names now preserve Unicode letters and numbers instead of replacing them with dashes.
 
 For example, this command now keeps the Chinese characters in the file name:
 
 ```shell
-quarkdown c src/_main.qd --pdf --allow all --out-name abc123我爱你-_ -o .asset/
+quarkdown c main.qd --pdf --out-name abc123我爱你
 ```
 
-The generated PDF file is now `abc123我爱你-_.pdf`.
+The generated PDF file is now `abc123我爱你.pdf`.
+
+Thanks @CarmJos!
 
 ## [2.1.2] - 2026-05-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,24 @@ quarkdown
 
 This behavior can be turned off with the new [`--forbid-function-overwriting`](https://quarkdown.com/wiki/cli-compiler#function-overwriting) CLI flag, which raises a compilation error instead.
 
+&nbsp;
+
+### Fixed
+
+&nbsp;
+
+#### Preserve Unicode characters in output names
+
+When compiling with `--out-name`, output file names now preserve Unicode letters and numbers instead of replacing them with dashes.
+
+For example, this command now keeps the Chinese characters in the file name:
+
+```shell
+quarkdown c src/_main.qd --pdf --allow all --out-name abc123我爱你-_ -o .asset/
+```
+
+The generated PDF file is now `abc123我爱你-_.pdf`.
+
 ## [2.1.2] - 2026-05-24
 
 ### Changed

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/util/StringUtils.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/util/StringUtils.kt
@@ -104,10 +104,11 @@ fun StringBuilder.replace(
 /**
  * @return [this] string with all non-alphanumeric characters,
  *         except for `-`, `_`, `@`, replaced with [replacement].
+ *         Alphanumeric characters include Unicode letters and numbers.
  *         `.` is sanitized only at the beginning and the end of the string.
  * @param replacement character to replace invalid characters with
  */
-fun String.sanitizeFileName(replacement: String) = this.replace("^\\.|\\.$|[^a-zA-Z0-9\\-_.@]+".toRegex(), replacement)
+fun String.sanitizeFileName(replacement: String) = this.replace("^\\.|\\.$|[^\\p{L}\\p{N}\\p{M}\\-_.@]+".toRegex(), replacement)
 
 /**
  * @return [this] string with line separators replaced with `\n`,

--- a/quarkdown-core/src/test/kotlin/com/quarkdown/core/FileResourceExporterNameSanitizationTest.kt
+++ b/quarkdown-core/src/test/kotlin/com/quarkdown/core/FileResourceExporterNameSanitizationTest.kt
@@ -39,6 +39,16 @@ class FileResourceExporterNameSanitizationTest {
     }
 
     @Test
+    fun `unicode letters are preserved`() {
+        assertEquals("abc123我爱你-_", sanitize("abc123我爱你-_"))
+    }
+
+    @Test
+    fun `unicode letters mixed with spaces`() {
+        assertEquals("封面-版本-2", sanitize("封面 版本 2"))
+    }
+
+    @Test
     fun spaces() {
         assertEquals("file-name", sanitize("file name"))
     }


### PR DESCRIPTION
- [X] I have read the [contributing guidelines](https://github.com/iamgio/quarkdown/blob/main/CONTRIBUTING.md).
- [X] I have tested the changes locally.
- [ ] An issue for this change exists, and it was discussed with maintainers. This is required for new features and non-trivial changes. If present, append `Closes #ISSUE_NUMBER` at the end of this PR description.
- [X] (Optional) I have added necessary documentation to [`docs`](https://github.com/iamgio/quarkdown/tree/main/docs) and [`CHANGELOG.md`](https://github.com/iamgio/quarkdown/blob/main/CHANGELOG.md)

---

## Summary
This PR fixes output filename sanitization so Unicode letters and numbers are preserved when using `--out-name`.

## Problem
When compiling with:

```shell
quarkdown c src/_main.qd --pdf --allow all --out-name abc123我爱你-_ -o .asset/
```

it generated filename removed Chinese characters and became `abc123-_.pdf`.
This behavior was caused by filename sanitization allowing only ASCII letters and digits.


I do understand the original approach was to avoid filename conflicts with the operating system, but in practice, users need to export content based on their language (e.g., Chinese, Russian, Korean, Japanese, etc.). 

**This PR solves this problem and has passed all tests.**

