### PR TITLE
feat(listfiles): add recursive and regex options for file listing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,17 @@ Thanks @CarmJos!
 
 &nbsp;
 
+#### [`listfiles` recursive traversal and regex filtering](https://quarkdown.com/wiki/file-data)
+
+The `.listfiles` function now supports two new options:
+
+- `recursive:{yes}` to include files from nested subdirectories.
+- `regex:{yes}` to treat the first argument as a regular expression pattern.
+
+This makes it easier to target files in deep folder trees and build pattern-based inclusion flows.
+
+Thanks @CarmJos!
+
 ### Fixed
 
 &nbsp;

--- a/docs/file-data.qd
+++ b/docs/file-data.qd
@@ -30,10 +30,21 @@ Open ranges work as follows:
 
 The **`.listfiles {path} {sortby?} {order?}`** .docslink {quarkdown-stdlib/com.quarkdown.stdlib.module.Data/listfiles.html} function returns an [iterable](iterable.qd) of the files in a directory. The result is unordered by default, but you can sort it by name or date.
 
+By default, `path` is treated as a literal directory path. You can optionally:
+
+- Set `recursive:{yes}` to traverse nested subdirectories.
+- Set `regex:{yes}` to treat `path` as a regular expression pattern.
+
+When `regex:{yes}`, Quarkdown traverses from the current working directory. The pattern is applied to each entry name when `fullpath:{no}`, or to each relative path when `fullpath:{yes}`.
+
 Like any other collection, you can iterate over the result or supply it to other functions. For example, you can perform automatic bulk inclusions via [`.includeall`](including-other-quarkdown-files.qd):
 
 ```markdown
 .includeall {.listfiles {somedirectory} sortby:{name}}
+```
+
+```markdown
+.listfiles {^chapters/.+\\.qd$} regex:{yes} recursive:{yes} fullpath:{yes} sortby:{name}
 ```
 
 ## Getting a file name

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Data.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Data.kt
@@ -192,13 +192,15 @@ enum class FileSorting(
 
 /**
  * Lists the files located in a directory.
- * @param path path of the directory to list files from
+ * @param path directory path when [regex] is `false`, or a regular expression pattern when [regex] is `true`
  * @param listDirectories whether to include directories in the listing
+ * @param recursive whether to recursively list files in nested subdirectories
+ * @param regex whether [path] should be interpreted as a regular expression pattern
  * @param fullPath whether to return the absolute path of each file, rather than just the file name
  * @param sortBy criterion to sort the files by
  * @param order order to sort the files in
  * @return an unordered collection of string values, each representing a file located in the directory, with extension
- * @throws IllegalArgumentException if the directory does not exist or if the path is not a directory
+ * @throws IllegalArgumentException if the directory does not exist or if the path is not a directory when [regex] is `false`
  * @permission [Permission.ProjectRead] to list files located in the project directory
  * @permission [Permission.GlobalRead] to list files located outside the project directory
  * @see fileName to exclude the extension from file names
@@ -209,34 +211,58 @@ fun listFiles(
     @Injected context: Context,
     path: String,
     @Name("directories") listDirectories: Boolean = true,
+    @LikelyNamed recursive: Boolean = false,
+    @LikelyNamed regex: Boolean = false,
     @Name("fullpath") fullPath: Boolean = true,
     @Name("sortby") sortBy: FileSorting = FileSorting.NONE,
     @LikelyNamed order: Ordering = Ordering.ASCENDING,
 ): IterableValue<StringValue> {
-    val directory = file(context, path)
+    val rootDirectory = if (regex) file(context, ".") else file(context, path)
 
-    if (!directory.exists()) {
-        throw IllegalArgumentException("Directory $directory does not exist.")
+    if (!rootDirectory.exists()) {
+        throw IllegalArgumentException("Directory $rootDirectory does not exist.")
     }
-    if (!directory.isDirectory) {
-        throw IllegalArgumentException("Path $directory is not a directory.")
+    if (!rootDirectory.isDirectory) {
+        throw IllegalArgumentException("Path $rootDirectory is not a directory.")
     }
+
+    val pattern = if (regex) path.toRegex() else null
 
     val files =
-        directory
-            .listFiles()
-            ?.asSequence()
-            ?.filter { listDirectories || it.isFile }
-            ?.let { sortBy.sort(it, order) }
-            ?.map { if (fullPath) it.absolutePath else it.name }
-            ?.map(::StringValue)
-            ?: emptySequence()
+        listFiles(rootDirectory, recursive)
+            .filter { listDirectories || it.isFile }
+            .filter { currentFile ->
+                pattern == null ||
+                    pattern.matches(
+                        if (fullPath) {
+                            rootDirectory
+                                .toPath()
+                                .relativize(currentFile.toPath())
+                                .toString()
+                                .replace(File.separatorChar, '/')
+                        } else {
+                            currentFile.name
+                        },
+                    )
+            }.let { sortBy.sort(it, order) }
+            .map { if (fullPath) it.absolutePath else it.name }
+            .map(::StringValue)
 
     return when {
         sortBy == FileSorting.NONE -> UnorderedCollectionValue(files.toSet())
         else -> OrderedCollectionValue(files.toList())
     }
 }
+
+private fun listFiles(
+    directory: File,
+    recursive: Boolean,
+): Sequence<File> =
+    if (recursive) {
+        directory.walkTopDown().drop(1)
+    } else {
+        directory.listFiles()?.asSequence() ?: emptySequence()
+    }
 
 /**
  * Retrieves the name of a file located in [path].

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Data.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Data.kt
@@ -226,24 +226,11 @@ fun listFiles(
         throw IllegalArgumentException("Path $rootDirectory is not a directory.")
     }
 
-    val pattern = if (regex) path.toRegex() else null
-
     val files =
         listFiles(rootDirectory, recursive)
             .filter { listDirectories || it.isFile }
             .filter { currentFile ->
-                pattern == null ||
-                    pattern.matches(
-                        if (fullPath) {
-                            rootDirectory
-                                .toPath()
-                                .relativize(currentFile.toPath())
-                                .toString()
-                                .replace(File.separatorChar, '/')
-                        } else {
-                            currentFile.name
-                        },
-                    )
+                !regex || path.toRegex().matches(fileMatchingName(rootDirectory, currentFile, fullPath))
             }.let { sortBy.sort(it, order) }
             .map { if (fullPath) it.absolutePath else it.name }
             .map(::StringValue)
@@ -262,6 +249,26 @@ private fun listFiles(
         directory.walkTopDown().drop(1)
     } else {
         directory.listFiles()?.asSequence() ?: emptySequence()
+    }
+
+/**
+ * Returns the matching key for [file] used by [listFiles] regex filtering.
+ * When [fullPath] is `true`, the result is the forward-slash-normalised path
+ * relative to [rootDirectory]; otherwise it is simply the file name.
+ */
+private fun fileMatchingName(
+    rootDirectory: File,
+    file: File,
+    fullPath: Boolean,
+): String =
+    if (fullPath) {
+        rootDirectory
+            .toPath()
+            .relativize(file.toPath())
+            .toString()
+            .replace(File.separatorChar, '/')
+    } else {
+        file.name
     }
 
 /**

--- a/quarkdown-stdlib/src/test/kotlin/com/quarkdown/stdlib/DataTest.kt
+++ b/quarkdown-stdlib/src/test/kotlin/com/quarkdown/stdlib/DataTest.kt
@@ -288,6 +288,68 @@ class DataTest {
     }
 
     @Test
+    fun `list files recursively`() {
+        val files =
+            listFiles(
+                context,
+                LIST_FILES_FOLDER,
+                listDirectories = false,
+                recursive = true,
+                fullPath = false,
+                sortBy = FileSorting.NAME,
+            )
+        val names = files.unwrappedValue.map { it.unwrappedValue }.toList()
+        assertEquals(listOf("a.txt", "b.txt", "c.txt", "d.txt"), names)
+    }
+
+    @Test
+    fun `list files with regex in current directory`() {
+        val files =
+            listFiles(
+                context,
+                "^listfiles$",
+                regex = true,
+                fullPath = false,
+                sortBy = FileSorting.NAME,
+            )
+        val names = files.unwrappedValue.map { it.unwrappedValue }.toList()
+        assertEquals(listOf("listfiles"), names)
+    }
+
+    @Test
+    fun `list files with recursive regex by relative path`() {
+        val files =
+            listFiles(
+                context,
+                "^listfiles/d/d\\.txt$",
+                listDirectories = false,
+                recursive = true,
+                regex = true,
+                fullPath = true,
+                sortBy = FileSorting.NAME,
+            )
+        val paths = files.unwrappedValue.map { it.unwrappedValue }.toList()
+        assertEquals(1, paths.size)
+        assertTrue(paths.single().endsWith("listfiles${File.separator}d${File.separator}d.txt"))
+    }
+
+    @Test
+    fun `list files with non-recursive regex does not traverse nested directories`() {
+        val files =
+            listFiles(
+                context,
+                "^listfiles/d/d\\.txt$",
+                listDirectories = false,
+                recursive = false,
+                regex = true,
+                fullPath = true,
+                sortBy = FileSorting.NAME,
+            )
+        val paths = files.unwrappedValue.map { it.unwrappedValue }.toList()
+        assertTrue(paths.isEmpty())
+    }
+
+    @Test
     fun `list files non-existent directory`() {
         assertFails { listFiles(context, "nonexistent") }
     }


### PR DESCRIPTION
- [X] I have read the [contributing guidelines](https://github.com/iamgio/quarkdown/blob/main/CONTRIBUTING.md).
- [X] I have tested the changes locally.
- [X] An issue for this change exists, and it was discussed with maintainers. This is required for new features and non-trivial changes. If present, append `Closes #ISSUE_NUMBER` at the end of this PR description.
- [X] (Optional) I have added necessary documentation to [`docs`](https://github.com/iamgio/quarkdown/tree/main/docs) and [`CHANGELOG.md`](https://github.com/iamgio/quarkdown/blob/main/CHANGELOG.md)


This PR extends .listfiles with two new capabilities to improve file discovery in real projects:
- Added recursive:{yes|no} (default: no) to traverse nested subdirectories.
- Added regex:{yes|no} (default: no) to interpret path as a regex pattern.
- Preserved backward compatibility: when regex:{no}, path is still treated as a literal directory path.
Updated docs and changelog to describe the new behavior and usage examples.

I have fully tested in my own documentations, **works fine**!

Resolved #527 .
--- 
My usage:
<img width="2354" height="864" alt="image" src="https://github.com/user-attachments/assets/ff334e9b-dde0-4462-ae13-38b397a15fb4" />
