### PR TITLE
feat(filetree): add support for explicit directory markers with trailing slashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,28 @@ The generated PDF file is now `abc123我爱你.pdf`.
 
 Thanks @CarmJos!
 
+&nbsp;
+
+#### [File tree explicit directories](https://quarkdown.com/wiki/file-tree)
+
+The `.filetree` block now accepts a trailing slash (`/`) marker so you can explicitly render directories, including empty ones.
+
+For example:
+
+```markdown
+.filetree
+    - src/
+      - main.c
+    - target/
+    - docs
+      - guide.md
+    - README.md
+```
+
+In this example, `target/` is now rendered as an empty folder, while entries with children still work as directories without needing the slash.
+
+Thanks @CarmJos!
+
 ## [2.1.2] - 2026-05-24
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,26 +45,6 @@ This behavior can be turned off with the new [`--forbid-function-overwriting`](h
 
 &nbsp;
 
-### Fixed
-
-&nbsp;
-
-#### Preserve Unicode characters in output names
-
-Output file names now preserve Unicode letters and numbers instead of replacing them with dashes.
-
-For example, this command now keeps the Chinese characters in the file name:
-
-```shell
-quarkdown c main.qd --pdf --out-name abc123我爱你
-```
-
-The generated PDF file is now `abc123我爱你.pdf`.
-
-Thanks @CarmJos!
-
-&nbsp;
-
 #### [File tree explicit directories](https://quarkdown.com/wiki/file-tree)
 
 The `.filetree` block now accepts a trailing slash (`/`) marker so you can explicitly render directories, including empty ones.
@@ -82,6 +62,26 @@ For example:
 ```
 
 In this example, `target/` is now rendered as an empty folder, while entries with children still work as directories without needing the slash.
+
+Thanks @CarmJos!
+
+&nbsp;
+
+### Fixed
+
+&nbsp;
+
+#### Preserve Unicode characters in output names
+
+Output file names now preserve Unicode letters and numbers instead of replacing them with dashes.
+
+For example, this command now keeps the Chinese characters in the file name:
+
+```shell
+quarkdown c main.qd --pdf --out-name abc123我爱你
+```
+
+The generated PDF file is now `abc123我爱你.pdf`.
 
 Thanks @CarmJos!
 

--- a/docs/file-tree.qd
+++ b/docs/file-tree.qd
@@ -14,19 +14,7 @@ The slash is only a marker and is not rendered.
             - Button.ts
             - Card.ts
           - index.ts
-        - README.md
-
-## Explicit directory marker
-
-A trailing slash is useful for empty directories and for disambiguating names.
-
-.examplemirror
-    .filetree
-        - src/
-          - main.c
         - target/
-        - docs
-          - guide.md
         - README.md
 
 ## Ellipsis

--- a/docs/file-tree.qd
+++ b/docs/file-tree.qd
@@ -2,7 +2,7 @@
 .include {docs}
 
 The **`.filetree`** .docslink {quarkdown-stdlib/com.quarkdown.stdlib.module.MiscElements/fileTree.html} function creates a visual file tree from a standard Markdown list.
-Each inline item becomes a file, and each nested list becomes a directory.
+Each inline item becomes a file by default; entries with nested children (or a trailing slash marker) become directories.
 
 Use a trailing slash (`/`) to explicitly mark an entry as a directory, even when it has no children.
 The slash is only a marker and is not rendered.

--- a/docs/file-tree.qd
+++ b/docs/file-tree.qd
@@ -4,6 +4,9 @@
 The **`.filetree`** .docslink {quarkdown-stdlib/com.quarkdown.stdlib.module.MiscElements/fileTree.html} function creates a visual file tree from a standard Markdown list.
 Each inline item becomes a file, and each nested list becomes a directory.
 
+Use a trailing slash (`/`) to explicitly mark an entry as a directory, even when it has no children.
+The slash is only a marker and is not rendered.
+
 .examplemirror
     .filetree
         - src
@@ -11,6 +14,19 @@ Each inline item becomes a file, and each nested list becomes a directory.
             - Button.ts
             - Card.ts
           - index.ts
+        - README.md
+
+## Explicit directory marker
+
+A trailing slash is useful for empty directories and for disambiguating names.
+
+.examplemirror
+    .filetree
+        - src/
+          - main.c
+        - target/
+        - docs
+          - guide.md
         - README.md
 
 ## Ellipsis

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/MiscElements.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/MiscElements.kt
@@ -27,12 +27,17 @@ val MiscElements: QuarkdownModule =
  * Creates a visual file tree from a Markdown list.
  * Each inline item is rendered as a file, and each nested list as a directory.
  *
+ * To explicitly mark an item as a directory, add a trailing slash (`/`).
+ * This is useful for empty directories that have no nested children.
+ * The slash marker is not shown in the rendered output.
+ *
  * Example:
  * ```
  * .filetree
- *     - src
+ *     - src/
  *       - main.ts
  *       - utils.ts
+ *     - target/
  *     - README.md
  * ```
  * @param content body content containing a Markdown list that defines the file tree structure

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/MiscElements.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/MiscElements.kt
@@ -34,7 +34,7 @@ val MiscElements: QuarkdownModule =
  * Example:
  * ```
  * .filetree
- *     - src/
+ *     - src
  *       - main.ts
  *       - utils.ts
  *     - target/

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/internal/FileTree.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/internal/FileTree.kt
@@ -26,14 +26,26 @@ private fun Node.isHighlighted(): Boolean =
         (this is NestableNode && children.any { it.isHighlighted() })
 
 /**
- * Checks whether the entry name explicitly marks a directory (`name/`).
+ * Trims trailing whitespace used around list item text before marker inspection.
  */
-private fun String.isExplicitDirectory(): Boolean = endsWith("/")
+private fun String.normalizeDirectoryMarkerInput(): String = trimEnd()
 
 /**
- * Removes a trailing directory marker slash from an entry name.
+ * Checks whether the entry name explicitly marks a directory (`name/`).
+ * A single `/` is treated as a literal file name, not as a marker.
  */
-private fun String.stripDirectoryMarker(): String = if (isExplicitDirectory()) dropLast(1) else this
+private fun String.isExplicitDirectory(): Boolean {
+    val normalized = normalizeDirectoryMarkerInput()
+    return normalized.length > 1 && normalized.endsWith("/")
+}
+
+/**
+ * Removes a trailing directory marker slash from an entry name when present.
+ */
+private fun String.stripDirectoryMarker(): String {
+    val normalized = normalizeDirectoryMarkerInput()
+    return if (normalized.isExplicitDirectory()) normalized.dropLast(1) else this
+}
 
 /**
  * Recursively converts a Markdown [ListBlock] into a flat list of [FileTreeEntry] elements.

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/internal/FileTree.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/internal/FileTree.kt
@@ -26,9 +26,19 @@ private fun Node.isHighlighted(): Boolean =
         (this is NestableNode && children.any { it.isHighlighted() })
 
 /**
+ * Checks whether the entry name explicitly marks a directory (`name/`).
+ */
+private fun String.isExplicitDirectory(): Boolean = endsWith("/")
+
+/**
+ * Removes a trailing directory marker slash from an entry name.
+ */
+private fun String.stripDirectoryMarker(): String = if (isExplicitDirectory()) dropLast(1) else this
+
+/**
  * Recursively converts a Markdown [ListBlock] into a flat list of [FileTreeEntry] elements.
- * Inline items become [FileTreeEntry.File]s, nested items become [FileTreeEntry.Directory]s,
- * and items with `...` as text become [FileTreeEntry.Ellipsis].
+ * Inline items become [FileTreeEntry.File]s unless they explicitly end with `/`,
+ * nested items become [FileTreeEntry.Directory]s, and items with `...` as text become [FileTreeEntry.Ellipsis].
  * Entries wrapped in strong emphasis are marked as highlighted.
  */
 internal fun fileTreeFromList(list: ListBlock): List<FileTreeEntry> =
@@ -37,15 +47,16 @@ internal fun fileTreeFromList(list: ListBlock): List<FileTreeEntry> =
         inlineValueMapper = { node, _ ->
             val text = listOf(node).toPlainText()
             val highlighted = node.isHighlighted()
-            if (text in ELLIPSIS_TEXTS) {
-                FileTreeEntry.Ellipsis(highlighted)
-            } else {
-                FileTreeEntry.File(text, highlighted)
+            when {
+                text in ELLIPSIS_TEXTS -> FileTreeEntry.Ellipsis(highlighted)
+                text.isExplicitDirectory() -> FileTreeEntry.Directory(text.stripDirectoryMarker(), emptyList(), highlighted)
+                else -> FileTreeEntry.File(text, highlighted)
             }
         },
         nestedValueMapper = { parent, nestedList ->
+            val text = listOf(parent).toPlainText().stripDirectoryMarker()
             FileTreeEntry.Directory(
-                listOf(parent).toPlainText(),
+                text,
                 fileTreeFromList(nestedList),
                 highlighted = parent.isHighlighted(),
             )

--- a/quarkdown-test/src/test/kotlin/com/quarkdown/test/FileTreeTest.kt
+++ b/quarkdown-test/src/test/kotlin/com/quarkdown/test/FileTreeTest.kt
@@ -150,12 +150,14 @@ class FileTreeTest {
                 - README.md
             """.trimIndent(),
         ) {
-            assertEquals(
-                "<div class=\"file-tree\"><ul>" +
-                    "<li class=\"directory\" data-name=\"src\">src<ul></ul></li>" +
-                    "<li class=\"directory\" data-name=\"target\">target<ul></ul></li>" +
-                    "<li class=\"file\" data-name=\"README.md\">README.md</li>" +
-                    "</ul></div>",
+            assertHtmlEquals(
+                """
+                <div class="file-tree"><ul>
+                    <li class="directory" data-name="src">src<ul></ul></li>
+                    <li class="directory" data-name="target">target<ul></ul></li>
+                    <li class="file" data-name="README.md">README.md</li>
+                </ul></div>
+                """.trimIndent(),
                 it,
             )
         }
@@ -171,17 +173,71 @@ class FileTreeTest {
                 - docs
             """.trimIndent(),
         ) {
+            assertHtmlEquals(
+                """
+                <div class="file-tree"><ul>
+                    <li class="directory" data-name="docs">docs<ul>
+                            <li class="file" data-name="guide.md">guide.md</li>
+                        </ul></li>
+                    <li class="file" data-name="docs">docs</li>
+                </ul></div>
+                """.trimIndent(),
+                it,
+            )
+        }
+    }
+
+    @Test
+    fun `single slash remains file`() {
+        execute(
+            """
+            .filetree
+                - /
+            """.trimIndent(),
+        ) {
             assertEquals(
                 "<div class=\"file-tree\"><ul>" +
-                    "<li class=\"directory\" data-name=\"docs\">docs" +
-                    "<ul>" +
-                    "<li class=\"file\" data-name=\"guide.md\">guide.md</li>" +
-                    "</ul>" +
-                    "</li>" +
-                    "<li class=\"file\" data-name=\"docs\">docs</li>" +
+                    "<li class=\"file\" data-name=\"/\">/</li>" +
                     "</ul></div>",
                 it,
             )
         }
     }
+
+    @Test
+    fun `explicit directory marker ignores trailing spaces`() {
+        execute(
+            """
+            .filetree
+                - src/   
+                - docs
+                  - guide.md
+            """.trimIndent(),
+        ) {
+            assertHtmlEquals(
+                """
+                <div class="file-tree"><ul>
+                    <li class="directory" data-name="src">src<ul></ul></li>
+                    <li class="directory" data-name="docs">docs<ul>
+                            <li class="file" data-name="guide.md">guide.md</li>
+                        </ul></li>
+                </ul></div>
+                """.trimIndent(),
+                it,
+            )
+        }
+    }
+
+    /**
+     * Compares compacted HTML to keep test expectations readable while remaining strict on structure.
+     */
+    private fun assertHtmlEquals(
+        expected: CharSequence,
+        actual: CharSequence,
+    ) = assertEquals(expected.compactHtml(), actual.compactHtml())
+
+    /**
+     * Removes layout whitespace between tags used only for test readability.
+     */
+    private fun CharSequence.compactHtml(): String = toString().trim().replace(Regex(">\\s+<"), "><")
 }

--- a/quarkdown-test/src/test/kotlin/com/quarkdown/test/FileTreeTest.kt
+++ b/quarkdown-test/src/test/kotlin/com/quarkdown/test/FileTreeTest.kt
@@ -139,4 +139,49 @@ class FileTreeTest {
             )
         }
     }
+
+    @Test
+    fun `explicit empty directory marker`() {
+        execute(
+            """
+            .filetree
+                - src/
+                - target/
+                - README.md
+            """.trimIndent(),
+        ) {
+            assertEquals(
+                "<div class=\"file-tree\"><ul>" +
+                    "<li class=\"directory\" data-name=\"src\">src<ul></ul></li>" +
+                    "<li class=\"directory\" data-name=\"target\">target<ul></ul></li>" +
+                    "<li class=\"file\" data-name=\"README.md\">README.md</li>" +
+                    "</ul></div>",
+                it,
+            )
+        }
+    }
+
+    @Test
+    fun `explicit directory marker with children`() {
+        execute(
+            """
+            .filetree
+                - docs/
+                  - guide.md
+                - docs
+            """.trimIndent(),
+        ) {
+            assertEquals(
+                "<div class=\"file-tree\"><ul>" +
+                    "<li class=\"directory\" data-name=\"docs\">docs" +
+                    "<ul>" +
+                    "<li class=\"file\" data-name=\"guide.md\">guide.md</li>" +
+                    "</ul>" +
+                    "</li>" +
+                    "<li class=\"file\" data-name=\"docs\">docs</li>" +
+                    "</ul></div>",
+                it,
+            )
+        }
+    }
 }


### PR DESCRIPTION

- [X] I have read the [contributing guidelines](https://github.com/iamgio/quarkdown/blob/main/CONTRIBUTING.md).
- [X] I have tested the changes locally.
- [x] An issue for this change exists, and it was discussed with maintainers. This is required for new features and non-trivial changes. If present, append `Closes #ISSUE_NUMBER` at the end of this PR description.
- [x] (Optional) I have added necessary documentation to [`docs`](https://github.com/iamgio/quarkdown/tree/main/docs) and [`CHANGELOG.md`](https://github.com/iamgio/quarkdown/blob/main/CHANGELOG.md)

Resolved #530 .