### PR TITLE
fix(filetree): fix file tree font size getting smaller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -187,6 +187,12 @@ The generated PDF file is now `abc123我爱你.pdf`.
 
 Thanks @CarmJos!
 
+&nbsp;
+
+#### File tree font size shrinking at nested levels
+
+Entries in a `.filetree` block used to incorrectly get progressively smaller at each level of nesting.
+
 ## [2.1.2] - 2026-05-24
 
 ### Changed

--- a/quarkdown-html/src/main/scss/components/_filetree.scss
+++ b/quarkdown-html/src/main/scss/components/_filetree.scss
@@ -1,6 +1,9 @@
 @use "util/icon" as *;
 
 .quarkdown .file-tree.file-tree.file-tree {
+  font-family: var(--qd-code-font), monospace;
+  font-size: var(--qd-code-span-font-size);
+
   ul {
     list-style: none;
     margin: 0.5em 0 0 0.5em;
@@ -12,9 +15,6 @@
     }
 
     li {
-      font-family: var(--qd-code-font), monospace;
-      font-size: var(--qd-code-span-font-size);
-
       &::before {
         margin-right: 0.5em;
         vertical-align: middle;


### PR DESCRIPTION
- [x] I have read the [contributing guidelines](https://github.com/iamgio/quarkdown/blob/main/CONTRIBUTING.md).
- [x] I have tested the changes locally.
- [ ] An issue for this change exists, and it was discussed with maintainers. This is required for new features and non-trivial changes. If present, append `Closes #ISSUE_NUMBER` at the end of this PR description.
- [x] (Optional) I have added necessary documentation to [`docs`](https://github.com/iamgio/quarkdown/tree/main/docs) and [`CHANGELOG.md`](https://github.com/iamgio/quarkdown/blob/main/CHANGELOG.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * File tree entries no longer shrink in font size when displayed at deeper nesting levels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->