### PR TITLE
feat(lsp): allow non-stdio connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 ## [Unreleased]
 
+### Added
+
+&nbsp;
+
+#### [LSP] Embeddable language server
+
+The Quarkdown language server API now allows the LSP to be embedded in custom hosts and run across multiple instances inside a single JVM, thanks to customizable IO streams and pluggable hooks.
+
+&nbsp;
+
+### Fixed
+
+&nbsp;
+
+#### [LSP] Concurrency issue in document state
+
+Document state and request dispatching now run through thread-safe primitives, ensuring consistent behavior even under heavy load.
+
 ## [2.2.0] - 2026-06-03
 
 ### Added

--- a/quarkdown-lsp/src/main/kotlin/com/quarkdown/lsp/QuarkdownLanguageServer.kt
+++ b/quarkdown-lsp/src/main/kotlin/com/quarkdown/lsp/QuarkdownLanguageServer.kt
@@ -28,20 +28,27 @@ import org.eclipse.lsp4j.services.TextDocumentService
 import org.eclipse.lsp4j.services.WorkspaceService
 import java.io.File
 import java.util.concurrent.CompletableFuture
-import kotlin.concurrent.thread
+import java.util.concurrent.Executor
+import java.util.concurrent.ForkJoinPool
 import kotlin.system.exitProcess
 
 /**
  * Quarkdown Language Server implementation.
  * @param quarkdownDirectory the directory containing the Quarkdown distribution, if available
+ * @param executor executor used to dispatch background work (catalogue warm-up, diagnostics, completion)
+ * @param onExit hook invoked when the client sends the LSP `exit` notification. Defaults to
+ *               terminating the JVM, which is appropriate for stdio mode
  */
 class QuarkdownLanguageServer(
     private val quarkdownDirectory: File?,
+    private val executor: Executor = ForkJoinPool.commonPool(),
+    private val onExit: () -> Unit = { exitProcess(0) },
 ) : LanguageServer,
     LanguageClientAware {
     private val textDocumentService: TextDocumentService =
         QuarkdownTextDocumentService(
             this,
+            executor,
             CompletionSuppliersFactory.default(this),
             SemanticTokensSuppliersFactory.default(),
             HoverSuppliersFactory.default(this),
@@ -95,8 +102,8 @@ class QuarkdownLanguageServer(
         val response = InitializeResult(serverCaps)
 
         // Caching the available function catalogue for improved performance.
-        thread {
-            docsDirectory?.let(CacheableFunctionCatalogue::storeCatalogue)
+        docsDirectory?.let { dir ->
+            executor.execute { CacheableFunctionCatalogue.storeCatalogue(dir) }
         }
 
         return CompletableFuture.completedFuture(response)
@@ -104,7 +111,7 @@ class QuarkdownLanguageServer(
 
     override fun shutdown(): CompletableFuture<in Any>? = CompletableFuture.completedFuture(null)
 
-    override fun exit() = exitProcess(0)
+    override fun exit() = onExit()
 
     override fun getTextDocumentService() = textDocumentService
 

--- a/quarkdown-lsp/src/main/kotlin/com/quarkdown/lsp/QuarkdownLanguageServerLauncher.kt
+++ b/quarkdown-lsp/src/main/kotlin/com/quarkdown/lsp/QuarkdownLanguageServerLauncher.kt
@@ -3,31 +3,57 @@ package com.quarkdown.lsp
 import org.eclipse.lsp4j.jsonrpc.Launcher
 import org.eclipse.lsp4j.services.LanguageClient
 import java.io.File
+import java.io.InputStream
+import java.io.OutputStream
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+import java.util.concurrent.Future
+import kotlin.system.exitProcess
 
 /**
  * Launcher for the Quarkdown Language Server.
+ *
+ * Each launcher instance wraps a single client connection. Hosts that need to serve multiple
+ * clients in the same JVM (e.g. WebSockets) should construct one launcher
+ * per connection, passing the per-connection streams and a JVM-wide shared [executor].
+ *
  * @param quarkdownDirectory the directory containing the Quarkdown distribution, if available
+ * @param input the input stream to read JSON-RPC messages from. Defaults to [System.in].
+ * @param output the output stream to write JSON-RPC messages to. Defaults to [System.out].
+ * @param executor the executor service to dispatch JSON-RPC requests and background work on.
+ *                  Defaults to a per-launcher cached thread pool. Pass a shared instance when
+ *                  hosting multiple servers in one JVM.
+ * @param onExit hook invoked when the client sends the LSP `exit` notification. Defaults to
+ *                terminating the JVM, which is appropriate for stdio mode.
  */
 class QuarkdownLanguageServerLauncher(
     quarkdownDirectory: File?,
+    private val input: InputStream = System.`in`,
+    private val output: OutputStream = System.out,
+    private val executor: ExecutorService = Executors.newCachedThreadPool(),
+    onExit: () -> Unit = { exitProcess(0) },
 ) {
-    private val languageServer = QuarkdownLanguageServer(quarkdownDirectory)
+    private val languageServer = QuarkdownLanguageServer(quarkdownDirectory, executor, onExit)
 
     private val launcher by lazy {
         Launcher
             .Builder<LanguageClient>()
             .setLocalService(languageServer)
             .setRemoteInterface(LanguageClient::class.java)
-            .setInput(System.`in`)
-            .setOutput(System.out)
+            .setInput(input)
+            .setOutput(output)
+            .setExecutorService(executor)
             .create()
             .let(::requireNotNull)
     }
 
-    fun startListening() {
+    /**
+     * Connects the server to the client and starts listening for incoming JSON-RPC messages.
+     * @return the future that completes when the client disconnects
+     */
+    fun startListening(): Future<Void> {
         val client: LanguageClient = requireNotNull(launcher.remoteProxy)
         languageServer.connect(client)
-
-        launcher.startListening()
+        return launcher.startListening()
     }
 }

--- a/quarkdown-lsp/src/main/kotlin/com/quarkdown/lsp/QuarkdownTextDocumentService.kt
+++ b/quarkdown-lsp/src/main/kotlin/com/quarkdown/lsp/QuarkdownTextDocumentService.kt
@@ -29,15 +29,21 @@ import org.eclipse.lsp4j.TextEdit
 import org.eclipse.lsp4j.jsonrpc.messages.Either
 import org.eclipse.lsp4j.services.TextDocumentService
 import java.util.concurrent.CompletableFuture
-import kotlin.concurrent.thread
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.Executor
 
 private typealias CompletionResult = CompletableFuture<Either<List<CompletionItem>, CompletionList>>
 
 /**
  * Service for handling text document operations in the Quarkdown Language Server.
+ *
+ * @param server the parent language server
+ * @param executor executor used to dispatch background work (e.g. diagnostics).
+ *                 Should be shared across instances when hosting multiple servers in the same JVM.
  */
 class QuarkdownTextDocumentService(
     private val server: QuarkdownLanguageServer,
+    private val executor: Executor,
     completionSuppliers: List<CompletionSupplier>,
     tokensSuppliers: List<SemanticTokensSupplier>,
     hoverSuppliers: List<HoverSupplier>,
@@ -52,8 +58,10 @@ class QuarkdownTextDocumentService(
 
     /**
      * Maps document URIs to their text content.
+     * Backed by a [ConcurrentHashMap] since the map is written from the LSP4J dispatcher thread
+     * (didOpen/didChange/didClose) and read from background diagnostics tasks submitted to [executor].
      */
-    private val documents = mutableMapOf<String, TextDocument>()
+    private val documents = ConcurrentHashMap<String, TextDocument>()
 
     /**
      * Adds or updates a document in the internal URI association map,
@@ -81,7 +89,7 @@ class QuarkdownTextDocumentService(
 
         documents[uri] = new
 
-        thread { processDiagnostics(uri, new) }
+        executor.execute { processDiagnostics(uri, new) }
     }
 
     /**
@@ -139,10 +147,10 @@ class QuarkdownTextDocumentService(
     override fun completion(params: CompletionParams): CompletionResult {
         val document = getDocument(params.textDocument)
 
-        return CompletableFuture.supplyAsync {
+        return CompletableFuture.supplyAsync({
             server.log("Operation 'text/completion'")
             Either.forLeft(completionService.process(params, document))
-        }
+        }, executor)
     }
 
     override fun resolveCompletionItem(unresolved: CompletionItem): CompletableFuture<CompletionItem> =


### PR DESCRIPTION
- [x] I have read the [contributing guidelines](https://github.com/iamgio/quarkdown/blob/main/CONTRIBUTING.md).
- [x] I have tested the changes locally.
- [ ] An issue for this change exists, and it was discussed with maintainers. This is required for new features and non-trivial changes. If present, append `Closes #ISSUE_NUMBER` at the end of this PR description.
- [x] (Optional) I have added necessary documentation to [`docs`](https://github.com/iamgio/quarkdown/tree/main/docs) and [`CHANGELOG.md`](https://github.com/iamgio/quarkdown/blob/main/CHANGELOG.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Make the language server embeddable with configurable input/output streams, a pluggable exit hook, and a returned listener handle for integration.
- **Bug Fixes**
  - Resolve concurrency in document state handling by switching to thread-safe storage and safer dispatch for diagnostics.
- **Refactor**
  - Run background work, diagnostics, and completion tasks on a configurable executor for predictable async behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->