### PR TITLE
fix(lsp): make function catalogue caching thread-safe

### DIFF
--- a/quarkdown-lsp/build.gradle.kts
+++ b/quarkdown-lsp/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
 
 dependencies {
     testImplementation("org.jetbrains.kotlin:kotlin-test")
+    testImplementation("io.mockk:mockk:1.14.11")
     implementation("org.eclipse.lsp4j:org.eclipse.lsp4j:1.0.0")
     implementation("com.github.h0tk3y.betterParse:better-parse:0.4.4")
     implementation("com.vladsch.flexmark:flexmark-html2md-converter:0.64.8")

--- a/quarkdown-lsp/src/main/kotlin/com/quarkdown/lsp/cache/CacheableFunctionCatalogue.kt
+++ b/quarkdown-lsp/src/main/kotlin/com/quarkdown/lsp/cache/CacheableFunctionCatalogue.kt
@@ -16,27 +16,21 @@ object CacheableFunctionCatalogue {
     private val catalogue = ConcurrentHashMap<DocsDirectory, Set<DocumentedFunction>>()
 
     /**
-     * Stores the functions extracted from the documentation files in the cache,
-     * overwriting any existing entries for the given directory.
-     * Results are not stored if no functions are found.
+     * Walks the documentation files in [docsDirectory] and caches the extracted functions
+     * if the cache is not already populated for that directory.
+     *
+     * Concurrent calls for the same directory only run the walk once: the lock prevents
+     * parallel callers from re-walking the docs N times.
+     * Empty results are not cached, so a subsequent call will retry.
+     *
      * @param docsDirectory the directory containing the documentation files
      */
     fun storeCatalogue(docsDirectory: DocsDirectory) {
-        val functions =
-            DokkaHtmlWalker(docsDirectory)
-                .walk()
-                .filter { it.isInModule }
-                .mapNotNull {
-                    val extractor = it.extractor()
-                    DocumentedFunction(
-                        data = extractor.extractFunctionData() ?: return@mapNotNull null,
-                        rawData = it,
-                        documentationAsMarkup = extractor.extractContentAsMarkup(),
-                    )
-                }.toSet()
-
-        if (functions.isNotEmpty()) {
-            catalogue[docsDirectory] = functions
+        if (catalogue.containsKey(docsDirectory)) return
+        synchronized(this) {
+            if (catalogue.containsKey(docsDirectory)) return
+            val functions = walk(docsDirectory)
+            if (functions.isNotEmpty()) catalogue[docsDirectory] = functions
         }
     }
 
@@ -47,10 +41,24 @@ object CacheableFunctionCatalogue {
      * @param docsDirectory the directory containing the documentation files
      * @return a sequence of documented functions
      */
-    fun getCatalogue(docsDirectory: DocsDirectory): Sequence<DocumentedFunction> =
-        this.catalogue[docsDirectory]?.asSequence()
-            ?: storeCatalogue(docsDirectory).let { this.catalogue[docsDirectory] }?.asSequence()
-            ?: emptySequence()
+    fun getCatalogue(docsDirectory: DocsDirectory): Sequence<DocumentedFunction> {
+        catalogue[docsDirectory]?.let { return it.asSequence() }
+        storeCatalogue(docsDirectory)
+        return catalogue[docsDirectory]?.asSequence() ?: emptySequence()
+    }
+
+    private fun walk(docsDirectory: DocsDirectory): Set<DocumentedFunction> =
+        DokkaHtmlWalker(docsDirectory)
+            .walk()
+            .filter { it.isInModule }
+            .mapNotNull {
+                val extractor = it.extractor()
+                DocumentedFunction(
+                    data = extractor.extractFunctionData() ?: return@mapNotNull null,
+                    rawData = it,
+                    documentationAsMarkup = extractor.extractContentAsMarkup(),
+                )
+            }.toSet()
 
     /**
      * Searches for functions whose names start with the given query string, case-insensitively.

--- a/quarkdown-lsp/src/test/kotlin/com/quarkdown/lsp/cache/CacheableFunctionCatalogueTest.kt
+++ b/quarkdown-lsp/src/test/kotlin/com/quarkdown/lsp/cache/CacheableFunctionCatalogueTest.kt
@@ -1,0 +1,101 @@
+package com.quarkdown.lsp.cache
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import io.mockk.verify
+import java.io.File
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Regression tests for [CacheableFunctionCatalogue]'s concurrent population path.
+ * The catalogue is a JVM-global singleton, so each test resets its internal map via reflection
+ * before and after running to prevent cross-test contamination.
+ */
+class CacheableFunctionCatalogueTest {
+    private val docsDir = File("/nonexistent/docs")
+
+    @BeforeTest
+    fun setup() {
+        clearCatalogue()
+        mockkObject(CacheableFunctionCatalogue, recordPrivateCalls = true)
+    }
+
+    @AfterTest
+    fun teardown() {
+        unmockkObject(CacheableFunctionCatalogue)
+        clearCatalogue()
+    }
+
+    @Test
+    fun `concurrent storeCatalogue invokes walk exactly once`() {
+        val expected = setOf(mockk<DocumentedFunction>())
+        every { CacheableFunctionCatalogue["walk"](docsDir) } returns expected
+
+        val threadCount = 32
+        val startGate = CountDownLatch(1)
+        val pool = Executors.newFixedThreadPool(threadCount)
+        try {
+            repeat(threadCount) {
+                pool.submit {
+                    startGate.await()
+                    CacheableFunctionCatalogue.storeCatalogue(docsDir)
+                }
+            }
+            startGate.countDown()
+            pool.shutdown()
+            assertTrue(pool.awaitTermination(10, TimeUnit.SECONDS))
+        } finally {
+            pool.shutdownNow()
+        }
+
+        verify(exactly = 1) { CacheableFunctionCatalogue["walk"](docsDir) }
+        assertEquals(1, catalogueMap().size)
+        assertEquals(expected, catalogueMap()[docsDir])
+    }
+
+    /**
+     * Asserts that an empty walk result is not cached, so subsequent calls keep retrying until
+     * a non-empty result is produced.
+     */
+    @Test
+    fun `empty walk result is not cached and triggers retry on next call`() {
+        val empty = emptySet<DocumentedFunction>()
+        val populated = setOf(mockk<DocumentedFunction>())
+
+        every { CacheableFunctionCatalogue["walk"](docsDir) } returnsMany listOf(empty, empty, populated)
+
+        CacheableFunctionCatalogue.storeCatalogue(docsDir)
+        assertTrue(catalogueMap().isEmpty(), "first empty walk must not populate the cache")
+
+        CacheableFunctionCatalogue.storeCatalogue(docsDir)
+        assertTrue(catalogueMap().isEmpty(), "second empty walk must not populate the cache")
+        verify(exactly = 2) { CacheableFunctionCatalogue["walk"](docsDir) }
+
+        CacheableFunctionCatalogue.storeCatalogue(docsDir)
+        assertEquals(populated, catalogueMap()[docsDir], "non-empty walk must populate the cache")
+
+        // Once populated, further calls must short-circuit without walking again.
+        CacheableFunctionCatalogue.storeCatalogue(docsDir)
+        verify(exactly = 3) { CacheableFunctionCatalogue["walk"](docsDir) }
+    }
+
+    private fun catalogueMap(): MutableMap<File, Set<DocumentedFunction>> {
+        val field = CacheableFunctionCatalogue::class.java.getDeclaredField("catalogue")
+        field.isAccessible = true
+        @Suppress("UNCHECKED_CAST")
+        return field.get(CacheableFunctionCatalogue) as MutableMap<File, Set<DocumentedFunction>>
+    }
+
+    private fun clearCatalogue() {
+        catalogueMap().clear()
+    }
+}


### PR DESCRIPTION
- [X] I have read the [contributing guidelines](https://github.com/iamgio/quarkdown/blob/main/CONTRIBUTING.md).
- [X] I have tested the changes locally.
- [ ] An issue for this change exists, and it was discussed with maintainers. This is required for new features and non-trivial changes. If present, append `Closes #ISSUE_NUMBER` at the end of this PR description.
- [ ] (Optional) I have added necessary documentation to [`docs`](https://github.com/iamgio/quarkdown/tree/main/docs) and [`CHANGELOG.md`](https://github.com/iamgio/quarkdown/blob/main/CHANGELOG.md)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Prevents redundant documentation processing by short-circuiting when cached results exist
  * Ensures concurrent requests populate the cache only once

* **Refactor**
  * Internal traversal and extraction logic reorganized for clarity and maintainability

* **Tests**
  * New tests cover concurrent population and retry behavior to ensure correct caching semantics

* **Chores**
  * Added a mocking library to the test dependencies
<!-- end of auto-generated comment: release notes by coderabbit.ai -->