### PR TITLE
perf(preview): symlink static deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,9 +56,14 @@ HELLO, world
 
 &nbsp;
 
-#### Live preview now uses SSE
+#### Faster live preview
 
-The live preview connection between the local server and the browser now runs over Server-Sent Events instead of WebSockets.
+Live preview now references third-party libraries through symbolic links instead of copying them (although already checksum-optimized). Preview rebuilds are faster and use less disk space, especially in documents that include code blocks, equations, or Mermaid diagrams.
+
+Additionally, the live preview connection between the local server and the browser now runs over Server-Sent Events (SSE) instead of WebSockets.
+
+> [!NOTE]
+> If you experience errors after launching live preview for the first time after updating, delete the output directory and run again (or run with `--clean`).
 
 &nbsp;
 

--- a/quarkdown-cli/src/main/kotlin/com/quarkdown/cli/util/IOUtils.kt
+++ b/quarkdown-cli/src/main/kotlin/com/quarkdown/cli/util/IOUtils.kt
@@ -1,8 +1,8 @@
 package com.quarkdown.cli.util
 
+import com.quarkdown.core.util.IOUtils
 import java.io.File
 import kotlin.io.path.ExperimentalPathApi
-import kotlin.io.path.deleteRecursively
 
 /**
  * Cleans [this] directory by deleting all files and directories inside it.
@@ -10,5 +10,5 @@ import kotlin.io.path.deleteRecursively
  */
 @OptIn(ExperimentalPathApi::class)
 fun File.cleanDirectory() {
-    listFiles()?.forEach { it.toPath().deleteRecursively() }
+    listFiles()?.forEach { IOUtils.deleteWithoutFollowingLinks(it.toPath()) }
 }

--- a/quarkdown-cli/src/test/kotlin/com/quarkdown/cli/util/IOUtilsTest.kt
+++ b/quarkdown-cli/src/test/kotlin/com/quarkdown/cli/util/IOUtilsTest.kt
@@ -1,0 +1,83 @@
+package com.quarkdown.cli.util
+
+import com.quarkdown.cli.TempDirectory
+import java.io.File
+import java.nio.file.Files
+import kotlin.io.path.createSymbolicLinkPointingTo
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Tests for [cleanDirectory] and other CLI-level IO utilities.
+ */
+class IOUtilsTest : TempDirectory() {
+    @BeforeTest
+    fun setUp() {
+        reset()
+    }
+
+    @AfterTest
+    fun tearDown() {
+        directory.deleteRecursively()
+    }
+
+    @Test
+    fun `clean removes children but keeps directory`() {
+        File(directory, "a.txt").writeText("a")
+        File(directory, "b.txt").writeText("b")
+        File(directory, "nested").apply {
+            mkdir()
+            File(this, "c.txt").writeText("c")
+        }
+
+        directory.cleanDirectory()
+
+        assertTrue(directory.exists())
+        assertEquals(emptyList(), directory.listFiles()?.toList())
+    }
+
+    @Test
+    fun `clean on empty directory is a no-op`() {
+        directory.cleanDirectory()
+
+        assertTrue(directory.exists())
+        assertEquals(emptyList(), directory.listFiles()?.toList())
+    }
+
+    @Test
+    fun `clean on non-existent file is a no-op`() {
+        val missing = File(directory, "missing")
+        missing.cleanDirectory()
+
+        assertFalse(missing.exists())
+    }
+
+    @Test
+    fun `clean does not follow symlinks to external files`() {
+        val externalTarget =
+            Files.createTempDirectory("external-target").toFile().apply {
+                File(this, "keepme.txt").writeText("keep me")
+            }
+
+        try {
+            File(directory, "link")
+                .toPath()
+                .createSymbolicLinkPointingTo(externalTarget.toPath())
+
+            directory.cleanDirectory()
+
+            assertEquals(emptyList(), directory.listFiles()?.toList(), "Symlink entry should be removed")
+            assertTrue(externalTarget.exists(), "External target directory should not be touched")
+            assertTrue(
+                File(externalTarget, "keepme.txt").exists(),
+                "Files inside the symlink target should not be touched",
+            )
+        } finally {
+            externalTarget.deleteRecursively()
+        }
+    }
+}

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/pipeline/PipelineOptions.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/pipeline/PipelineOptions.kt
@@ -45,4 +45,11 @@ data class PipelineOptions(
     val permissions: Set<Permission> = Permission.DEFAULT_SET,
     val mediaStorageOptionsOverrides: MediaStorageOptions = ReadOnlyMediaStorageOptions(),
     val errorHandler: PipelineErrorHandler = BasePipelineErrorHandler(),
-)
+) {
+    /**
+     * Whether to symlink or copy dependency files from the installation layout,
+     * such as third-party JavaScript libraries.
+     */
+    val symlinkDependencies: Boolean
+        get() = this.isPreview
+}

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/pipeline/output/FileReferenceOutputArtifact.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/pipeline/output/FileReferenceOutputArtifact.kt
@@ -8,12 +8,15 @@ import java.io.File
  * @param name the output file name (with extension, since the original file name is used as-is)
  * @param file the source file (or directory) to copy
  * @param useChecksumInvalidation whether to also create a checksum file for this artifact, used for incremental builds
- *                                to determine whether the artifact has changed since the last build and should be recreated.
+ *                                to determine whether the artifact has changed since the last build and should be recreated
+ * @param symlink whether to create a symbolic link to the source file instead of copying it.
+ *                Takes precedence over [useChecksumInvalidation]
  */
 data class FileReferenceOutputArtifact(
     override val name: String,
     val file: File,
     val useChecksumInvalidation: Boolean = false,
+    val symlink: Boolean = false,
 ) : OutputResource {
     override fun <T> accept(visitor: OutputResourceVisitor<T>): T = visitor.visit(this)
 }

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/pipeline/output/visitor/FileResourceExporter.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/pipeline/output/visitor/FileResourceExporter.kt
@@ -14,6 +14,7 @@ import com.quarkdown.core.pipeline.output.visitor.FileResourceExporter.NameProvi
 import com.quarkdown.core.util.IOUtils
 import com.quarkdown.core.util.sanitizeFileName
 import java.io.File
+import java.nio.file.Files
 
 /**
  * A visitor that saves each type of [OutputResource] to a file and returns it.
@@ -84,13 +85,17 @@ class FileResourceExporter(
         }
 
     /**
-     * Copies a [FileReferenceOutputArtifact] to the output location.
+     * Exports a [FileReferenceOutputArtifact] to the output location.
      * If the source is a directory, it is copied recursively.
      *
-     * When [FileReferenceOutputArtifact.useChecksumInvalidation] is enabled, a sibling
-     * `.checksum` file is maintained next to the output. If the checksum of the source
-     * matches the stored value, the copy is skipped entirely. This avoids redundant I/O
-     * for large assets (fonts, third-party libraries) that rarely change between builds.
+     * Resolution order:
+     * 1. If [FileReferenceOutputArtifact.symlink] is set and the platform supports symbolic links,
+     *    a link is created instead of copying.
+     * 2. Otherwise, if [FileReferenceOutputArtifact.useChecksumInvalidation] is enabled, a sibling
+     *    `.checksum` file is maintained next to the output; the copy is skipped when the source's
+     *    checksum matches the stored value. This avoids redundant I/O for large assets (fonts,
+     *    third-party libraries) that rarely change between builds.
+     * 3. Otherwise, the source is copied unconditionally.
      *
      * @return the copied file or directory
      */
@@ -100,26 +105,36 @@ class FileResourceExporter(
 
             target.parentFile?.mkdirs()
 
+            if (artifact.symlink && IOUtils.trySymlink(target.toPath(), artifact.file.toPath())) return@also
+
             if (artifact.useChecksumInvalidation) {
-                val checksumFile = target.resolveSibling("${target.name}.checksum")
-                val currentChecksum = IOUtils.computeChecksum(artifact.file)
-                val storedChecksum = checksumFile.takeIf { it.isFile }?.readText()
-
-                if (currentChecksum == storedChecksum && target.exists()) {
-                    Log.debug { "Skipping '${artifact.name}': checksum unchanged ($currentChecksum)" }
-                    return@also
-                }
-
-                Log.debug {
-                    "Copying '${artifact.name}': checksum changed " +
-                        "(stored=${storedChecksum ?: "<none>"}, current=$currentChecksum)"
-                }
-                copyFileOrDirectory(artifact.file, target)
-                checksumFile.writeText(currentChecksum)
+                copyWithChecksumInvalidation(artifact, target)
             } else {
                 copyFileOrDirectory(artifact.file, target)
             }
         }
+
+    private fun copyWithChecksumInvalidation(
+        artifact: FileReferenceOutputArtifact,
+        target: File,
+    ) {
+        val checksumFile = target.resolveSibling("${target.name}.checksum")
+        val currentChecksum = IOUtils.computeChecksum(artifact.file)
+        val storedChecksum = checksumFile.takeIf { it.isFile }?.readText()
+
+        if (currentChecksum == storedChecksum && target.exists() && !Files.isSymbolicLink(target.toPath())) {
+            Log.debug { "Skipping '${artifact.name}': checksum unchanged ($currentChecksum)" }
+            return
+        }
+
+        Log.debug {
+            "Copying '${artifact.name}': checksum changed " +
+                "(stored=${storedChecksum ?: "<none>"}, current=$currentChecksum)"
+        }
+
+        copyFileOrDirectory(artifact.file, target)
+        checksumFile.writeText(currentChecksum)
+    }
 
     private fun copyFileOrDirectory(
         source: File,

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/util/IOUtils.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/util/IOUtils.kt
@@ -1,10 +1,16 @@
 package com.quarkdown.core.util
 
+import com.quarkdown.core.log.Log
 import java.io.File
 import java.io.IOException
+import java.nio.file.FileAlreadyExistsException
+import java.nio.file.Files
 import java.nio.file.Path
 import java.security.MessageDigest
+import kotlin.io.path.ExperimentalPathApi
 import kotlin.io.path.Path
+import kotlin.io.path.createSymbolicLinkPointingTo
+import kotlin.io.path.deleteRecursively
 
 /**
  * Utility methods for file-based operations.
@@ -67,6 +73,58 @@ object IOUtils {
                 }
         }
         return digest.digest().joinToString("") { "%02x".format(it) }
+    }
+
+    /**
+     * Recursively deletes the file or directory at [path] without following symbolic links:
+     * each link entry is removed, but the file or directory the link points to is left untouched.
+     * No-op if [path] does not exist.
+     */
+    @OptIn(ExperimentalPathApi::class)
+    fun deleteWithoutFollowingLinks(path: Path) = path.deleteRecursively()
+
+    /**
+     * Attempts to (re)create a symbolic link at [target] pointing to [source]. Returns `true` on
+     * success, `false` if symbolic links are unavailable on this platform (caller should fall
+     * back to a copy-based path).
+     */
+    fun trySymlink(
+        target: Path,
+        source: Path,
+    ): Boolean =
+        try {
+            if (isAlreadySymlinkTo(target, source)) {
+                Log.debug { "Symlink '${target.fileName}' already points to '$source'; reusing" }
+            } else {
+                createOrReplaceSymlinkAt(target, source)
+                Log.debug { "Symlinked '${target.fileName}' to '$source'" }
+            }
+            true
+        } catch (e: IOException) {
+            Log.debug { "Symlink unavailable for '${target.fileName}' (${e.message}); falling back" }
+            false
+        }
+
+    /** Whether [target] is already a symbolic link whose stored target is exactly [source]. */
+    private fun isAlreadySymlinkTo(
+        target: Path,
+        source: Path,
+    ): Boolean = Files.isSymbolicLink(target) && Files.readSymbolicLink(target) == source
+
+    /**
+     * Creates a symbolic link at [target] pointing to [source]. If a file, directory, or stale
+     * symlink already occupies the target, it is cleared and the creation is retried.
+     */
+    private fun createOrReplaceSymlinkAt(
+        target: Path,
+        source: Path,
+    ) {
+        try {
+            target.createSymbolicLinkPointingTo(source)
+        } catch (_: FileAlreadyExistsException) {
+            deleteWithoutFollowingLinks(target)
+            target.createSymbolicLinkPointingTo(source)
+        }
     }
 
     /**

--- a/quarkdown-core/src/test/kotlin/com/quarkdown/core/FileResourceExporterTest.kt
+++ b/quarkdown-core/src/test/kotlin/com/quarkdown/core/FileResourceExporterTest.kt
@@ -6,8 +6,12 @@ import com.quarkdown.core.pipeline.output.FileReferenceOutputArtifact
 import com.quarkdown.core.pipeline.output.OutputResourceGroup
 import com.quarkdown.core.pipeline.output.TextOutputArtifact
 import com.quarkdown.core.pipeline.output.visitor.FileResourceExporter
+import org.junit.Assume.assumeTrue
 import java.io.File
+import java.io.IOException
 import java.nio.file.Files
+import java.nio.file.LinkOption
+import java.nio.file.attribute.BasicFileAttributes
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -248,6 +252,288 @@ class FileResourceExporterTest {
 
             artifact.accept(FileResourceExporter(output))
             assertTrue(File(output, "lib.js").isFile)
+            assertFalse(File(output, "lib.js.checksum").exists())
+        }
+
+    // Symlink references
+
+    /**
+     * Probes whether the underlying filesystem can create symbolic links in [dir].
+     * Skips the calling test (via JUnit assumption) if it cannot - notably the default
+     * configuration on Windows, where `SeCreateSymbolicLinkPrivilege` is not granted to
+     * standard users.
+     */
+    private fun assumeSymlinksWork(dir: File) {
+        val probeSource = File(dir, "_probe_src").also { it.writeText("probe") }
+        val probeLink = File(dir, "_probe_link")
+        val supported =
+            try {
+                Files.createSymbolicLink(probeLink.toPath(), probeSource.toPath())
+                true
+            } catch (_: IOException) {
+                false
+            } catch (_: UnsupportedOperationException) {
+                false
+            }
+        Files.deleteIfExists(probeLink.toPath())
+        probeSource.delete()
+        assumeTrue("Symbolic links are not supported in this environment", supported)
+    }
+
+    @Test
+    fun `symlink reference creates a symbolic link to a file`() =
+        withTempDir { dir ->
+            assumeSymlinksWork(dir)
+
+            val source = File(dir, "src").also { it.mkdir() }
+            val sourceFile = File(source, "lib.js").also { it.writeText("var v = 1;") }
+
+            val output = File(dir, "out").also { it.mkdir() }
+            val artifact = FileReferenceOutputArtifact(name = "lib.js", file = sourceFile, symlink = true)
+            val result = artifact.accept(FileResourceExporter(output))
+
+            assertTrue(Files.isSymbolicLink(result.toPath()))
+            assertEquals("var v = 1;", result.readText())
+        }
+
+    @Test
+    fun `symlink reference creates a symbolic link to a directory`() =
+        withTempDir { dir ->
+            assumeSymlinksWork(dir)
+
+            val source = File(dir, "lib").also { it.mkdir() }
+            File(source, "a.js").writeText("var a;")
+            File(source, "sub").mkdir()
+            File(source, "sub/b.js").writeText("var b;")
+
+            val output = File(dir, "out").also { it.mkdir() }
+            val artifact = FileReferenceOutputArtifact(name = "lib", file = source, symlink = true)
+            val result = artifact.accept(FileResourceExporter(output))
+
+            assertTrue(Files.isSymbolicLink(result.toPath()))
+            assertTrue(result.isDirectory)
+            assertEquals("var a;", File(result, "a.js").readText())
+            assertEquals("var b;", File(result, "sub/b.js").readText())
+        }
+
+    @Test
+    fun `symlink reflects changes to the source without re-export`() =
+        withTempDir { dir ->
+            assumeSymlinksWork(dir)
+
+            val source = File(dir, "src").also { it.mkdir() }
+            val sourceFile = File(source, "lib.js").also { it.writeText("v1") }
+
+            val output = File(dir, "out").also { it.mkdir() }
+            val artifact = FileReferenceOutputArtifact(name = "lib.js", file = sourceFile, symlink = true)
+            val result = artifact.accept(FileResourceExporter(output))
+
+            assertEquals("v1", result.readText())
+
+            // Mutating the source must be visible through the link, since it's not a copy.
+            sourceFile.writeText("v2")
+            assertEquals("v2", result.readText())
+        }
+
+    @Test
+    fun `symlink replaces an existing regular file at target`() =
+        withTempDir { dir ->
+            assumeSymlinksWork(dir)
+
+            val source = File(dir, "src").also { it.mkdir() }
+            val sourceFile = File(source, "lib.js").also { it.writeText("source") }
+
+            val output = File(dir, "out").also { it.mkdir() }
+            File(output, "lib.js").writeText("stale copy")
+
+            val artifact = FileReferenceOutputArtifact(name = "lib.js", file = sourceFile, symlink = true)
+            val result = artifact.accept(FileResourceExporter(output))
+
+            assertTrue(Files.isSymbolicLink(result.toPath()))
+            assertEquals("source", result.readText())
+        }
+
+    @Test
+    fun `symlink replaces a stale broken symlink at target`() =
+        withTempDir { dir ->
+            assumeSymlinksWork(dir)
+
+            val output = File(dir, "out").also { it.mkdir() }
+
+            // Leftover from a previous export, pointing at a now-missing source.
+            val ghost = File(dir, "ghost-source")
+            Files.createSymbolicLink(File(output, "lib.js").toPath(), ghost.toPath())
+            assertTrue(Files.isSymbolicLink(File(output, "lib.js").toPath()))
+            assertFalse(File(output, "lib.js").exists(), "Broken link should not resolve")
+
+            val source = File(dir, "src").also { it.mkdir() }
+            val sourceFile = File(source, "lib.js").also { it.writeText("fresh") }
+            val artifact = FileReferenceOutputArtifact(name = "lib.js", file = sourceFile, symlink = true)
+            val result = artifact.accept(FileResourceExporter(output))
+
+            assertTrue(Files.isSymbolicLink(result.toPath()))
+            assertEquals("fresh", result.readText())
+        }
+
+    @Test
+    fun `symlink replaces a previously copied non-empty directory at target`() =
+        withTempDir { dir ->
+            assumeSymlinksWork(dir)
+
+            val output = File(dir, "out").also { it.mkdir() }
+
+            // Simulate a prior non-preview run: a real directory copy lives at the target,
+            // and it must be torn down (recursively) before the symlink can be created.
+            val stale = File(output, "lib").also { it.mkdir() }
+            File(stale, "a.js").writeText("old-a")
+            File(stale, "sub").mkdir()
+            File(stale, "sub/b.js").writeText("old-b")
+
+            val source = File(dir, "src").also { it.mkdir() }
+            File(source, "a.js").writeText("new-a")
+
+            val artifact = FileReferenceOutputArtifact(name = "lib", file = source, symlink = true)
+            val result = artifact.accept(FileResourceExporter(output))
+
+            assertTrue(Files.isSymbolicLink(result.toPath()))
+            assertEquals("new-a", File(result, "a.js").readText())
+            // The stale `sub/` from the previous copy must not leak through the link.
+            assertFalse(File(result, "sub").exists())
+        }
+
+    @Test
+    fun `symlink replaces a live symlink to a directory without touching its source`() =
+        withTempDir { dir ->
+            assumeSymlinksWork(dir)
+
+            // The original source directory (e.g. lib/<library> in the install layout) MUST be
+            // preserved across re-runs. This guards against deleteRecursively following the link.
+            val protectedSource = File(dir, "install/lib").also { it.mkdirs() }
+            File(protectedSource, "do-not-delete.js").writeText("install layout contents")
+            File(protectedSource, "sub").mkdir()
+            File(protectedSource, "sub/nested.js").writeText("nested install contents")
+
+            val output = File(dir, "out").also { it.mkdir() }
+            val link = File(output, "lib")
+            Files.createSymbolicLink(link.toPath(), protectedSource.toPath())
+            assertTrue(Files.isSymbolicLink(link.toPath()))
+
+            // Re-run the visitor with the same symlink artifact, simulating a second preview build.
+            val artifact = FileReferenceOutputArtifact(name = "lib", file = protectedSource, symlink = true)
+            val result = artifact.accept(FileResourceExporter(output))
+
+            assertTrue(Files.isSymbolicLink(result.toPath()))
+            // The layout files must still be intact.
+            assertTrue(File(protectedSource, "do-not-delete.js").isFile, "Symlink source was destroyed")
+            assertTrue(File(protectedSource, "sub/nested.js").isFile, "Nested symlink source was destroyed")
+        }
+
+    @Test
+    fun `deletion does not follow symlinks nested inside a stale directory at target`() =
+        withTempDir { dir ->
+            assumeSymlinksWork(dir)
+
+            // Something precious living *outside* the export tree that an internal symlink reaches into.
+            val protectedSource = File(dir, "outside").also { it.mkdir() }
+            File(protectedSource, "do-not-delete.js").writeText("must survive")
+
+            val output = File(dir, "out").also { it.mkdir() }
+
+            // A stale plain directory left behind by a previous run, with an internal symlink
+            // pointing into the protected source. If the recursive delete followed the link,
+            // `do-not-delete.js` would be wiped.
+            val stale = File(output, "lib").also { it.mkdir() }
+            File(stale, "regular.js").writeText("stale regular file")
+            Files.createSymbolicLink(File(stale, "linked").toPath(), protectedSource.toPath())
+
+            val source = File(dir, "src").also { it.mkdir() }
+            File(source, "new.js").writeText("new content")
+
+            val artifact = FileReferenceOutputArtifact(name = "lib", file = source, symlink = true)
+            artifact.accept(FileResourceExporter(output))
+
+            // The protected source must be untouched.
+            assertTrue(File(protectedSource, "do-not-delete.js").isFile, "Nested symlink was followed during deletion")
+        }
+
+    @Test
+    fun `symlink reuses existing link when it already points to the source`() =
+        withTempDir { dir ->
+            assumeSymlinksWork(dir)
+
+            val source = File(dir, "src").also { it.mkdir() }
+            val sourceFile = File(source, "lib.js").also { it.writeText("v1") }
+
+            val output = File(dir, "out").also { it.mkdir() }
+            val artifact = FileReferenceOutputArtifact(name = "lib.js", file = sourceFile, symlink = true)
+
+            // First export creates the link.
+            val result = artifact.accept(FileResourceExporter(output))
+            assertTrue(Files.isSymbolicLink(result.toPath()))
+
+            // Capture the inode (file key) of the link entry itself, NOT its target.
+            val keyBefore =
+                Files
+                    .readAttributes(result.toPath(), BasicFileAttributes::class.java, LinkOption.NOFOLLOW_LINKS)
+                    .fileKey()
+            // Some filesystems (notably on Windows) don't expose a stable file key.
+            if (keyBefore == null) return@withTempDir
+
+            // Second export: same source, same target. The visitor must not delete+recreate
+            // the link entry, so the file key must be identical.
+            artifact.accept(FileResourceExporter(output))
+            val keyAfter =
+                Files
+                    .readAttributes(result.toPath(), BasicFileAttributes::class.java, LinkOption.NOFOLLOW_LINKS)
+                    .fileKey()
+            assertEquals(keyBefore, keyAfter, "Symlink entry was recreated despite already pointing at the source")
+        }
+
+    @Test
+    fun `symlink recreates link when pointing to a different source`() =
+        withTempDir { dir ->
+            assumeSymlinksWork(dir)
+
+            val sourceA = File(dir, "srcA").also { it.mkdir() }
+            val fileA = File(sourceA, "lib.js").also { it.writeText("from A") }
+            val sourceB = File(dir, "srcB").also { it.mkdir() }
+            val fileB = File(sourceB, "lib.js").also { it.writeText("from B") }
+
+            val output = File(dir, "out").also { it.mkdir() }
+
+            // First export points at A.
+            FileReferenceOutputArtifact(name = "lib.js", file = fileA, symlink = true)
+                .accept(FileResourceExporter(output))
+            val result = File(output, "lib.js")
+            assertEquals("from A", result.readText())
+
+            // Second export points at B: the prior link must be replaced, not reused.
+            FileReferenceOutputArtifact(name = "lib.js", file = fileB, symlink = true)
+                .accept(FileResourceExporter(output))
+            assertTrue(Files.isSymbolicLink(result.toPath()))
+            assertEquals("from B", result.readText())
+        }
+
+    @Test
+    fun `symlink takes precedence over checksum invalidation`() =
+        withTempDir { dir ->
+            assumeSymlinksWork(dir)
+
+            val source = File(dir, "src").also { it.mkdir() }
+            val sourceFile = File(source, "lib.js").also { it.writeText("hello") }
+
+            val output = File(dir, "out").also { it.mkdir() }
+            val artifact =
+                FileReferenceOutputArtifact(
+                    name = "lib.js",
+                    file = sourceFile,
+                    useChecksumInvalidation = true,
+                    symlink = true,
+                )
+            val result = artifact.accept(FileResourceExporter(output))
+
+            assertTrue(Files.isSymbolicLink(result.toPath()))
+            // The checksum sidecar belongs to the copy path; it must not be written when symlinking.
             assertFalse(File(output, "lib.js.checksum").exists())
         }
 }

--- a/quarkdown-html/src/main/kotlin/com/quarkdown/rendering/html/post/HtmlPostRenderer.kt
+++ b/quarkdown-html/src/main/kotlin/com/quarkdown/rendering/html/post/HtmlPostRenderer.kt
@@ -52,13 +52,18 @@ class HtmlPostRenderer(
         ),
     private val resourcesProvider: () -> Set<PostRendererResource> =
         {
+            // During live preview, symlink file references instead of deep copying.
+            val symlinkDependencies = context.attachedPipeline?.options?.symlinkDependencies ?: false
             setOfNotNull(
                 ThemePostRendererResource(
                     theme = context.documentInfo.theme.orDefault(DEFAULT_THEME),
                     locale = context.documentInfo.locale,
                     themeLayout = resourcesLayout?.themes,
                 ),
-                ScriptPostRendererResource(scriptsLayout = resourcesLayout?.scripts),
+                ScriptPostRendererResource(
+                    scriptsLayout = resourcesLayout?.scripts,
+                    symlink = symlinkDependencies,
+                ),
                 MediaPostRendererResource(context.mediaStorage),
                 context.fileSystem.workingDirectory
                     ?.let(::StaticAssetsPostRendererResource),
@@ -67,7 +72,11 @@ class HtmlPostRenderer(
                     .takeIf { context.documentInfo.type == DocumentType.DOCS }
                     ?.generate(context.sharedSubdocumentsData)
                     ?.let(::SearchIndexPostRendererResource),
-                ThirdPartyPostRendererResource(context, librariesLayout = resourcesLayout?.libraries),
+                ThirdPartyPostRendererResource(
+                    context,
+                    librariesLayout = resourcesLayout?.libraries,
+                    symlink = symlinkDependencies,
+                ),
             )
         },
 ) : PostRenderer by base {

--- a/quarkdown-html/src/main/kotlin/com/quarkdown/rendering/html/post/resources/ScriptPostRendererResource.kt
+++ b/quarkdown-html/src/main/kotlin/com/quarkdown/rendering/html/post/resources/ScriptPostRendererResource.kt
@@ -28,9 +28,11 @@ const val HTML_SCRIPT_FILE_NAME = "quarkdown.min.js"
  *
  * @param scriptsLayout the install layout node for the `script/` directory,
  *        typically [com.quarkdown.installlayout.InstallLayout.Html.scripts]
+ * @param symlink whether to create a symbolic link instead of copying
  */
 class ScriptPostRendererResource(
     private val scriptsLayout: InstallLayoutDirectory?,
+    private val symlink: Boolean,
 ) : PostRendererResource {
     override fun includeTo(
         resources: MutableSet<OutputResource>,
@@ -43,6 +45,6 @@ class ScriptPostRendererResource(
                 "This likely indicates a broken Quarkdown installation."
         }
 
-        resources += scriptsLayout.asOutputResource()
+        resources += scriptsLayout.asOutputResource(symlink = symlink)
     }
 }

--- a/quarkdown-html/src/main/kotlin/com/quarkdown/rendering/html/post/resources/ThirdPartyPostRendererResource.kt
+++ b/quarkdown-html/src/main/kotlin/com/quarkdown/rendering/html/post/resources/ThirdPartyPostRendererResource.kt
@@ -22,10 +22,12 @@ const val HTML_LIBRARY_OUTPUT_PATH = "lib"
  * @param librariesLayout the install layout node for the `lib/` directory containing third-party
  *        library files, typically [InstallLayout.Html.libraries][com.quarkdown.installlayout.InstallLayout.Html.libraries].
  *        If `null`, no libraries are bundled.
+ * @param symlink whether to create symbolic links to library files instead of copying
  */
 class ThirdPartyPostRendererResource(
     private val context: Context,
     private val librariesLayout: InstallLayoutDirectory?,
+    private val symlink: Boolean,
 ) : PostRendererResource {
     override fun includeTo(
         resources: MutableSet<OutputResource>,
@@ -51,7 +53,7 @@ class ThirdPartyPostRendererResource(
                             librariesLayout
                                 .resolveDirectory(libraryName)
                                 .also { if (!it.exists()) error("HTML library directory not found: ${it.file.path}") }
-                                .asOutputResource()
+                                .asOutputResource(symlink = symlink)
                         }.toSet(),
             )
     }

--- a/quarkdown-html/src/test/e2e/live-preview/live-preview.spec.ts
+++ b/quarkdown-html/src/test/e2e/live-preview/live-preview.spec.ts
@@ -136,6 +136,50 @@ for (const docType of SCROLLABLE_DOC_TYPES) {
     });
 }
 
+// --- Third-party library re-applied across multiple live edits ---
+
+test("highlight.js re-applies tokenization across multiple live edits [plain]", async ({page}) => {
+    test.setTimeout(TEST_TIMEOUT);
+
+    await runLivePreviewTest(
+        TEST_DIR,
+        page,
+        async (ctx) => {
+            // Initial load.
+            await expect(ctx.activeFrame.locator("body")).toContainText("Marker Alpha", {
+                timeout: RELOAD_TIMEOUT,
+            });
+
+            // First edit: introduce a Kotlin code block. `fun` should be tagged as a keyword.
+            ctx.editFile(
+                "main.qd",
+                'Marker Beta\n\n```kotlin\nfun greet(name: String) {\n    println("Hello, $name")\n}\n```\n',
+            );
+            await expect(ctx.activeFrame.locator("body")).toContainText("Marker Beta", {
+                timeout: RELOAD_TIMEOUT,
+            });
+
+            const kotlinCode = ctx.activeFrame.locator("pre code.hljs");
+            await expect(kotlinCode).toBeVisible({timeout: RELOAD_TIMEOUT});
+            await expect(kotlinCode.locator(".hljs-keyword").first()).toHaveText("fun");
+
+            // Second edit: swap in a Python code block. `def` should now be the highlighted keyword.
+            ctx.editFile(
+                "main.qd",
+                'Marker Gamma\n\n```python\ndef greet(name):\n    print(f"Hello, {name}")\n```\n',
+            );
+            await expect(ctx.activeFrame.locator("body")).toContainText("Marker Gamma", {
+                timeout: RELOAD_TIMEOUT,
+            });
+
+            const pythonCode = ctx.activeFrame.locator("pre code.hljs");
+            await expect(pythonCode).toBeVisible({timeout: RELOAD_TIMEOUT});
+            await expect(pythonCode.locator(".hljs-keyword").first()).toHaveText("def");
+        },
+        {docType: "plain"},
+    );
+});
+
 // --- Sticky-to-bottom scroll preserved across reload ---
 
 for (const docType of SCROLLABLE_DOC_TYPES) {

--- a/quarkdown-html/src/test/kotlin/com/quarkdown/rendering/html/HtmlResourceGenerationTest.kt
+++ b/quarkdown-html/src/test/kotlin/com/quarkdown/rendering/html/HtmlResourceGenerationTest.kt
@@ -240,7 +240,7 @@ class HtmlResourceGenerationTest {
         val bogusLibDir = InstallLayoutDirectory(File("nonexistent"))
         val resources =
             buildSet {
-                ThirdPartyPostRendererResource(context, librariesLayout = bogusLibDir)
+                ThirdPartyPostRendererResource(context, librariesLayout = bogusLibDir, symlink = false)
                     .includeTo(this, plainHtml)
             }
         assertNull(resources.filterIsInstance<OutputResourceGroup>().firstOrNull { it.name == HTML_LIBRARY_OUTPUT_PATH })

--- a/quarkdown-install-layout-navigator/src/main/kotlin/com/quarkdown/installlayout/InstallLayoutEntry.kt
+++ b/quarkdown-install-layout-navigator/src/main/kotlin/com/quarkdown/installlayout/InstallLayoutEntry.kt
@@ -24,8 +24,17 @@ interface InstallLayoutEntry {
     /** Resolves a child directory relative to this entry's [file]. */
     fun resolveDirectory(relativePath: String): InstallLayoutDirectory = InstallLayoutDirectory(file.resolve(relativePath))
 
-    /** Wraps this entry as an [OutputResource] for the pipeline to output. */
-    fun asOutputResource(): OutputResource = FileReferenceOutputArtifact(name, file, useChecksumInvalidation = true)
+    /**
+     * Wraps this entry as an [OutputResource] for the pipeline to output.
+     * @param symlink whether to create a symbolic link to the source file instead of copying it
+     */
+    fun asOutputResource(symlink: Boolean = false): OutputResource =
+        FileReferenceOutputArtifact(
+            name,
+            file,
+            useChecksumInvalidation = true,
+            symlink = symlink,
+        )
 }
 
 /**

--- a/quarkdown-test/src/test/kotlin/com/quarkdown/test/HtmlOutputResourceTest.kt
+++ b/quarkdown-test/src/test/kotlin/com/quarkdown/test/HtmlOutputResourceTest.kt
@@ -4,6 +4,7 @@ import com.quarkdown.core.media.storage.MEDIA_SUBDIRECTORY_NAME
 import com.quarkdown.core.pipeline.output.ArtifactType
 import com.quarkdown.core.pipeline.output.FileReferenceOutputArtifact
 import com.quarkdown.core.pipeline.output.OutputResource
+import com.quarkdown.core.pipeline.output.OutputResourceGroup
 import com.quarkdown.core.pipeline.output.TextOutputArtifact
 import com.quarkdown.test.util.DATA_FOLDER
 import com.quarkdown.test.util.execute
@@ -316,6 +317,59 @@ class HtmlOutputResourceTest {
                 assertContains(resources, "theme")
                 assertContains(resources, "script")
                 assertContains(resources, "index")
+            },
+        ) {}
+    }
+
+    /**
+     * Returns the [FileReferenceOutputArtifact]s nested inside the third-party `lib/` group,
+     * which is where the symlink-vs-copy decision for dependencies is wired through.
+     */
+    private fun getThirdPartyLibraryArtifacts(group: OutputResource?): List<FileReferenceOutputArtifact> {
+        val libGroup =
+            getSubResources(group)
+                .filterIsInstance<OutputResourceGroup>()
+                .firstOrNull { it.name == "lib" }
+        assertNotNull(libGroup, "Expected a 'lib' group with third-party dependencies")
+        return libGroup.resources.filterIsInstance<FileReferenceOutputArtifact>()
+    }
+
+    /**
+     * Returns the top-level `script` artifact.
+     */
+    private fun getScriptArtifact(group: OutputResource?): FileReferenceOutputArtifact {
+        val script =
+            getSubResources(group)
+                .filterIsInstance<FileReferenceOutputArtifact>()
+                .firstOrNull { it.name == "script" }
+        assertNotNull(script)
+        return script
+    }
+
+    @Test
+    fun `preview mode marks third-party libraries and script as symlinks`() {
+        execute(
+            source = "",
+            previewMode = true,
+            outputResourceHook = { group ->
+                val libs = getThirdPartyLibraryArtifacts(group)
+                assertTrue(libs.isNotEmpty())
+                assertTrue(libs.all { it.symlink })
+                assertTrue(getScriptArtifact(group).symlink)
+            },
+        ) {}
+    }
+
+    @Test
+    fun `non-preview mode copies third-party libraries and script instead of symlinking`() {
+        execute(
+            source = "",
+            previewMode = false,
+            outputResourceHook = { group ->
+                val libs = getThirdPartyLibraryArtifacts(group)
+                assertTrue(libs.isNotEmpty())
+                assertTrue(libs.none { it.symlink })
+                assertFalse(getScriptArtifact(group).symlink)
             },
         ) {}
     }


### PR DESCRIPTION
- [x] I have read the [contributing guidelines](https://github.com/iamgio/quarkdown/blob/main/CONTRIBUTING.md).
- [x] I have tested the changes locally.
- [ ] An issue for this change exists, and it was discussed with maintainers. This is required for new features and non-trivial changes. If present, append `Closes #ISSUE_NUMBER` at the end of this PR description.
- [x] (Optional) I have added necessary documentation to [`docs`](https://github.com/iamgio/quarkdown/tree/main/docs) and [`CHANGELOG.md`](https://github.com/iamgio/quarkdown/blob/main/CHANGELOG.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the Unreleased changelog to highlight faster live preview using SSE, reduced disk usage, and guidance to delete the output directory (or use `--clean`) if errors occur after the first update.
  * Removed the Unreleased entry for the embeddable language server.
* **New Features**
  * Preview mode can now emit generated runtime/library resources as symbolic links to reduce copying and disk usage.
* **Bug Fixes**
  * Improved live resource updates so symlinks take precedence over checksum-based copying and stale targets are cleaned more reliably.
  * `clean` avoids following symlinks when removing directories.
* **Tests**
  * Added symlink-focused unit coverage and a live-preview e2e syntax-highlight test.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->