### PR TITLE
fix(security): fix native content injection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,12 @@ The live preview connection between the local server and the browser now runs ov
 
 &nbsp;
 
+#### [Security] Fixed native content injection via string manipulation
+
+Fixed an issue that allowed string->string functions to let unsanitized HTML through, even when the `native-content` permission was not granted.
+
+&nbsp;
+
 #### Fixed `.extend` on functions with injected parameters
 
 The `.extend` function now maps parameters correctly when wrapping native functions that feature `@Injected` parameters, such as document metadata functions. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,12 @@ The live preview connection between the local server and the browser now runs ov
 
 &nbsp;
 
+#### Fixed `.extend` on functions with injected parameters
+
+The `.extend` function now maps parameters correctly when wrapping native functions that feature `@Injected` parameters, such as document metadata functions. 
+
+&nbsp;
+
 #### [LSP] Concurrency issue in document state
 
 Document state and request dispatching now run through thread-safe primitives, ensuring consistent behavior even under heavy load.

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/function/value/output/node/InlineNodeOutputValueVisitor.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/function/value/output/node/InlineNodeOutputValueVisitor.kt
@@ -2,6 +2,7 @@ package com.quarkdown.core.function.value.output.node
 
 import com.quarkdown.core.ast.base.inline.CheckBox
 import com.quarkdown.core.ast.base.inline.CodeSpan
+import com.quarkdown.core.ast.base.inline.CriticalContent
 import com.quarkdown.core.ast.base.inline.Text
 import com.quarkdown.core.context.Context
 import com.quarkdown.core.function.value.BooleanValue
@@ -19,13 +20,13 @@ import com.quarkdown.core.function.value.factory.ValueFactory
 class InlineNodeOutputValueVisitor(
     private val context: Context,
 ) : NodeOutputValueVisitor() {
-    override fun visit(value: StringValue) = Text(value.unwrappedValue)
+    override fun visit(value: StringValue) = CriticalContent(value.unwrappedValue)
 
     override fun visit(value: NumberValue) = Text(value.unwrappedValue.toString())
 
     override fun visit(value: BooleanValue) = CheckBox(isChecked = value.unwrappedValue)
 
-    override fun visit(value: ObjectValue<*>) = Text(value.unwrappedValue.toString())
+    override fun visit(value: ObjectValue<*>) = CriticalContent(value.unwrappedValue.toString())
 
     override fun visit(value: NoneValue) = CodeSpan(value.unwrappedValue.toString())
 

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Flow.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Flow.kt
@@ -371,7 +371,15 @@ fun extend(
 
     // The wrapper exposes the same parameters as the target, plus `super` which is internal to the lambda.
     val superParameter = body.explicitParameters.firstOrNull()?.copy(isOptional = true)
-    val wrapperParameters = targetFunction.parameters.map { LambdaParameter(it.name, isOptional = true) }
+    val wrapperParameters =
+        targetFunction.parameters
+            .mapNotNull { parameter ->
+                LambdaParameter(
+                    parameter.name,
+                    isOptional = true,
+                ).takeUnless { parameter.isInjected }
+            }
+
     val lambdaParameters =
         when (superParameter) {
             null -> emptyList()

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/String.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/String.kt
@@ -1,5 +1,6 @@
 package com.quarkdown.stdlib
 
+import com.quarkdown.core.ast.InlineMarkdownContent
 import com.quarkdown.core.function.library.module.QuarkdownModule
 import com.quarkdown.core.function.library.module.moduleOf
 import com.quarkdown.core.function.reflect.annotation.LikelyChained
@@ -8,6 +9,7 @@ import com.quarkdown.core.function.value.StringValue
 import com.quarkdown.core.function.value.wrappedAsValue
 import com.quarkdown.core.util.StringCase
 import com.quarkdown.core.util.case
+import com.quarkdown.core.util.node.toPlainText
 import com.quarkdown.core.util.trimDelimiters
 
 /**
@@ -23,6 +25,7 @@ val String: QuarkdownModule =
         ::capitalize,
         ::isEmpty,
         ::isNotEmpty,
+        ::toPlainText,
     )
 
 /**
@@ -124,3 +127,14 @@ fun isEmpty(string: String) = string.isEmpty().wrappedAsValue()
 @Name("isnotempty")
 @LikelyChained
 fun isNotEmpty(string: String) = string.isNotEmpty().wrappedAsValue()
+
+/**
+ * Converts Markdown content to plain text.
+ *
+ * Example: `Hello, **world**!` -> `Hello, world!`
+ *
+ * @param content inline content to convert
+ * @return a new string that is the plain text of the content
+ */
+@Name("plaintext")
+fun toPlainText(content: InlineMarkdownContent): StringValue = content.children.toPlainText().wrappedAsValue()

--- a/quarkdown-test/src/test/kotlin/com/quarkdown/test/CommentsTest.kt
+++ b/quarkdown-test/src/test/kotlin/com/quarkdown/test/CommentsTest.kt
@@ -100,7 +100,7 @@ class CommentsTest {
                 Hi
             """.trimIndent(),
         ) {
-            assertEquals("<p><!-- COMMENT -->\nHI</p>", it)
+            assertEquals("<p>&lt;!-- COMMENT --&gt;\nHI</p>", it)
         }
     }
 

--- a/quarkdown-test/src/test/kotlin/com/quarkdown/test/EmojiTest.kt
+++ b/quarkdown-test/src/test/kotlin/com/quarkdown/test/EmojiTest.kt
@@ -25,7 +25,7 @@ class EmojiTest {
     @Test
     fun `emoji with two skin tones`() {
         execute(".emoji {people-holding-hands~medium-light,medium-dark}") {
-            assertEquals("<p>\uD83E\uDDD1\uD83C\uDFFC\u200D\uD83E\uDD1D\u200D\uD83E\uDDD1\uD83C\uDFFE</p>", it)
+            assertEquals("<p>\uD83E\uDDD1\uD83C\uDFFC&zwj;\uD83E\uDD1D&zwj;\uD83E\uDDD1\uD83C\uDFFE</p>", it)
         }
     }
 

--- a/quarkdown-test/src/test/kotlin/com/quarkdown/test/FunctionExtensionTest.kt
+++ b/quarkdown-test/src/test/kotlin/com/quarkdown/test/FunctionExtensionTest.kt
@@ -302,6 +302,21 @@ class FunctionExtensionTest {
     fun `stdlib extension`() {
         execute(
             """
+            .extend {lowercase}
+                super:
+                .super::uppercase
+            
+            .lowercase {hello}
+            """.trimIndent(),
+        ) {
+            assertEquals("<p>HELLO</p>", it)
+        }
+    }
+
+    @Test
+    fun `stdlib extension with injected parameter`() {
+        execute(
+            """
             .extend {heading}
                 super content:
                 .if {.content::equals {Hi}}

--- a/quarkdown-test/src/test/kotlin/com/quarkdown/test/SecurityTest.kt
+++ b/quarkdown-test/src/test/kotlin/com/quarkdown/test/SecurityTest.kt
@@ -29,6 +29,22 @@ class SecurityTest {
     }
 
     @Test
+    fun `plaintext injection`() {
+        execute(".plaintext {\"><script>alert('XSS')</script>}") {
+            assertContains(it, "&lt;script&gt;")
+            assertContains(it, "&lt;/script&gt;")
+        }
+    }
+
+    @Test
+    fun `string manipulation injection`() {
+        execute(".uppercase {\"><script>alert('XSS')</script>}") {
+            assertContains(it, "&lt;SCRIPT&gt;")
+            assertContains(it, "&lt;/SCRIPT&gt;")
+        }
+    }
+
+    @Test
     fun `mermaid injection`() {
         execute(
             """


### PR DESCRIPTION
- [X] I have read the [contributing guidelines](https://github.com/iamgio/quarkdown/blob/main/CONTRIBUTING.md).
- [X] I have tested the changes locally.
- [ ] An issue for this change exists, and it was discussed with maintainers. This is required for new features and non-trivial changes. If present, append `Closes #ISSUE_NUMBER` at the end of this PR description.
- [x] (Optional) I have added necessary documentation to [`docs`](https://github.com/iamgio/quarkdown/tree/main/docs) and [`CHANGELOG.md`](https://github.com/iamgio/quarkdown/blob/main/CHANGELOG.md)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a security vulnerability related to native content injection bypassing sanitization.
  * Corrected how parameters are mirrored when extending functions that use injected parameters.
  * Improved inline rendering and escaping so literal comment markers and string-manipulation injections are output safely.
* **New Features**
  * Added a new `plaintext` function to convert inline Markdown content into plain text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->