### PR TITLE
fix(linebreak): Incorrect extra spaces in CJK paragraph soft line breaks

### DIFF
--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/parser/BlockTokenParser.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/parser/BlockTokenParser.kt
@@ -51,6 +51,7 @@ import com.quarkdown.core.lexer.tokens.TableToken
 import com.quarkdown.core.lexer.tokens.UnorderedListToken
 import com.quarkdown.core.util.iterator
 import com.quarkdown.core.util.nextOrNull
+import com.quarkdown.core.util.normalizeSoftBreaks
 import com.quarkdown.core.util.removeOptionalPrefix
 import com.quarkdown.core.util.trimDelimiters
 import com.quarkdown.core.visitor.token.BlockTokenVisitor
@@ -433,6 +434,7 @@ class BlockTokenParser(
         val text =
             token.data.text
                 .trim()
+                .normalizeSoftBreaks()
                 .toInline()
 
         // If the paragraph only consists of a single child, it could be a special block.

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/util/StringUtils.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/util/StringUtils.kt
@@ -158,6 +158,32 @@ fun CharSequence.normalizeLineSeparators(): CharSequence =
     }
 
 /**
+ * Normalizes soft line breaks within paragraph text.
+ *
+ * In Quarkdown, paragraphs can span multiple lines, and the line break (soft break)
+ * is normally rendered as a space. However, for CJK and other non-Latin scripts,
+ * inserting a space at every soft break produces incorrect spacing.
+ *
+ * This function normalizes `\n` within a paragraph:
+ *  - If the character before the newline is a Latin letter, digit, or common Latin
+ *    punctuation (.,"'?!;:-), the newline is replaced with a space.
+ *  - Otherwise (e.g., CJK characters, Chinese punctuation), the newline is removed,
+ *    joining the text without a space.
+ *
+ * Hard line breaks (preceded by two spaces or a backslash) are preserved.
+ *
+ * @return the paragraph text with soft line breaks normalized
+ */
+fun String.normalizeSoftBreaks(): String {
+    val latinBefore = "[a-zA-Z0-9.,\"'?!;:()\\[\\]{}\\-]"
+    // Replace \n with space when preceded by a Latin character, leaving hard breaks intact.
+    var result = this.replace(Regex("(?<=$latinBefore)\n"), " ")
+    // Remove remaining standalone \n that are not part of hard line breaks.
+    result = result.replace(Regex("(?<!  )(?<!\\\\)\n"), "")
+    return result
+}
+
+/**
  * Discards blank entries and trims each remaining entry.
  * @return a list of non-blank, trimmed strings
  */


### PR DESCRIPTION
- [X] I have read the [contributing guidelines](https://github.com/iamgio/quarkdown/blob/main/CONTRIBUTING.md).
- [X] I have tested the changes locally.
- [ ] An issue for this change exists, and it was discussed with maintainers. This is required for new features and non-trivial changes. If present, append `Closes #ISSUE_NUMBER` at the end of this PR description.
- [ ] (Optional) I have added necessary documentation to [`docs`](https://github.com/iamgio/quarkdown/tree/main/docs) and [`CHANGELOG.md`](https://github.com/iamgio/quarkdown/blob/main/CHANGELOG.md)


## Summary

When users split long paragraphs across multiple lines in `.qd` files (a common practice for readability), every soft line break is unconditionally rendered as a space. This produces visually incorrect output for CJK text, where adjacent characters should be joined without spaces.

**Before (broken):**

```
第一行内容，第二句话。
第二行内容，
第三行内容！
```

Renders as: `第一行内容，第二句话。 第二行内容， 第三行内容！` (extra spaces inserted)

**After (fixed):**

Same source renders as: `第一行内容，第二句话。第二行内容，第三行内容！` (no unwanted spaces)

## Rationale

This issue affects all Quarkdown users writing CJK content. The current behavior is a side effect of HTML whitespace collapsing: each `\n` remains as a `Text("\n")` node in the AST, and the browser renders it as a space. The fix applies typographically correct rules at the parsing stage, where the character context is available, rather than at render time where the distinction between intentional and structural spaces is lost.

Hard line breaks (Markdown's `two-space + newline` or `backslash + newline` syntax) are unaffected, as the regex explicitly excludes them via negative lookbehind.


> **I got a severe scolding from my tutor for this problem.** TvT

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved paragraph rendering by normalizing soft line breaks in text content. Line breaks within paragraphs are now correctly converted to spaces, while intentional hard breaks (marked with two spaces or a backslash) remain preserved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->