### PR TITLE
feat(stdlib): change .extend behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,9 +34,37 @@ The Quarkdown language server API now allows the LSP to be embedded in custom ho
 
 &nbsp;
 
+#### [Changed `.extend` behavior](https://quarkdown.com/wiki/extending-functions) (breaking change)
+
+`.extend`, introduced in v2.2.0 as experimental, has undergone a shift in behavior.
+
+`super` now exposes the original function, rather than its precomputed output, and no longer needs to be declared as a parameter.
+
+Because `.super` is the original function itself, it accepts the same arguments: anything you pass overrides the corresponding argument the wrapper was called with, while anything you leave out falls through unchanged. This lets the wrapper invoke the original with adjusted inputs.
+
+```markdown
+.function {greet}
+    greeting name:
+    .greeting, .name!
+
+.extend {greet}
+    name greeting:
+    .super greeting:{.greeting::uppercase}
+
+.greet {Hello} {world}
+```
+
+Output:
+
+```markdown
+HELLO, world
+```
+
+&nbsp;
+
 #### Live preview now uses SSE
 
-The live preview connection between the local server and the browser now runs over Server-Sent Events instead of WebSockets. 
+The live preview connection between the local server and the browser now runs over Server-Sent Events instead of WebSockets.
 
 &nbsp;
 

--- a/docs/extending-functions.qd
+++ b/docs/extending-functions.qd
@@ -9,14 +9,17 @@ You can extend any previously-declared function using the **`.extend`** .docslin
         Hello, .name!
 
     .extend {greet}
-        super:
         .super::uppercase
 
     .greet {world}
 
+## Accessing the original
+
+Within the wrapper body, the original function is exposed as **`.super`**. Calling it invokes the original with the same arguments.
+
 ## Parameters
 
-The wrapper body is a [lambda](lambda.qd). Its first explicit parameter, conventionally called `super`, is bound to the result of the original function. Any further parameters must match the names of the original function's parameters and let you read the arguments the caller passed.
+The wrapper body is a [lambda](lambda.qd). Its explicit parameters, if any, must match the names of the original function's parameters and let you read the arguments the caller passed.
 
 .examplemirror prelude:{The output may depend on an argument's value:}
     .function {greet}
@@ -24,7 +27,7 @@ The wrapper body is a [lambda](lambda.qd). Its first explicit parameter, convent
         Hello, .name!
 
     .extend {greet}
-        super name:
+        name:
         .if {.name::equals {world}}
             .super::uppercase
         .ifnot {.name::equals {world}}
@@ -38,7 +41,7 @@ All wrapper parameters are always optional. You only need to declare the paramet
 
 .examplemirror prelude:{Built-in functions can be extended:}
     .extend {heading}
-        super depth:
+        depth:
         .let {.depth::islower than:{4}}
             .if {.1}
                 .container background:{teal} fullwidth:{yes}
@@ -51,3 +54,29 @@ All wrapper parameters are always optional. You only need to declare the paramet
     .heading {H3} depth:{3} indexed:{no}
 
     .heading {H4} depth:{4} indexed:{no}
+
+## Overriding arguments
+
+Because `.super` is the original function itself, it accepts the same arguments. Any argument you pass overrides the one the wrapper was called with, while everything you leave out falls through unchanged. This lets the wrapper invoke the original with adjusted inputs.
+
+.examplemirror
+    .function {greet}
+        greeting name:
+        .greeting, .name!
+
+    .extend {greet}
+        name:
+        .super greeting:{Howdy}
+
+    .greet {Hello} {world}
+
+.examplemirror prelude:{New argument values can also rely on the original arguments, letting you transform them before passing them on:}
+    .function {greet}
+        greeting name:
+        .greeting, .name!
+
+    .extend {greet}
+        greeting name:
+        .super greeting:{.greeting::uppercase}
+
+    .greet {Hello} {world}

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/function/call/FunctionCall.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/function/call/FunctionCall.kt
@@ -60,10 +60,14 @@ data class FunctionCall<T : OutputValue<*>>(
  * the caller's arguments, as in the `extend` stdlib function.
  *
  * @param function function to re-dispatch the call to
+ * @param arguments optional new arguments to use instead of the original ones
  * @return the output of executing [function] against this call's arguments
  */
 @Suppress("UNCHECKED_CAST")
-fun FunctionCall<*>.executeAs(function: Function<*>): OutputValue<*> =
+fun FunctionCall<*>.executeAs(
+    function: Function<*>,
+    arguments: List<FunctionCallArgument> = this.arguments,
+): OutputValue<*> =
     (this as FunctionCall<OutputValue<*>>)
-        .copy(function = function as Function<OutputValue<*>>)
+        .copy(function = function as Function<OutputValue<*>>, arguments = arguments)
         .execute()

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/function/value/data/Lambda.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/function/value/data/Lambda.kt
@@ -38,23 +38,26 @@ open class Lambda(
     /**
      * Registers the arguments in the context, which can be accessed as function calls.
      * @param arguments arguments of the lambda action
+     * @param additionalFunctions additional functions to register in the lambda execution context, alongside the lambda parameters.
      */
-    private fun createLambdaParametersLibrary(arguments: List<Value<*>>) =
-        Library(
-            LAMBDA_LIBRARY_NAME,
-            functions =
-                arguments
-                    .mapIndexed { index, argument ->
-                        val parameterName = explicitParameters.getOrNull(index)?.name ?: (index + 1).toString()
-                        SimpleFunction(
-                            parameterName,
-                            parameters = emptyList(),
-                        ) { _, call ->
-                            // Value associated to the lambda argument.
-                            DynamicValue(argument.unwrappedValue, evaluationContext = call.context)
-                        }
-                    }.toSet(),
-        )
+    private fun createLambdaParametersLibrary(
+        arguments: List<Value<*>>,
+        additionalFunctions: Set<SimpleFunction<*>> = emptySet(),
+    ) = Library(
+        LAMBDA_LIBRARY_NAME,
+        functions =
+            arguments
+                .mapIndexed { index, argument ->
+                    val parameterName = explicitParameters.getOrNull(index)?.name ?: (index + 1).toString()
+                    SimpleFunction(
+                        parameterName,
+                        parameters = emptyList(),
+                    ) { _, call ->
+                        // Value associated to the lambda argument.
+                        DynamicValue(argument.unwrappedValue, evaluationContext = call.context)
+                    }
+                }.toSet() + additionalFunctions,
+    )
 
     /**
      * Checks if the amount of arguments matches the amount of expected parameters.
@@ -76,6 +79,7 @@ open class Lambda(
      *                       When provided, its own libraries (e.g. lambda parameters, local variables)
      *                       are propagated to the forked execution context, allowing body arguments
      *                       containing dynamic references to resolve variables from the calling scope.
+     * @param additionalFunctions additional functions to register in the lambda execution context, alongside the lambda parameters.
      * @param allowDestructuring if `true`, [arguments] has only 1 element which is [Destructurable], and the lambda has N>1 explicit parameters,
      *                           the argument is destructured into N parts.
      *                           For example, a dictionary may be destructured into its key and value.
@@ -84,13 +88,20 @@ open class Lambda(
     fun invokeDynamic(
         arguments: List<Value<*>>,
         callingContext: Context? = null,
+        additionalFunctions: Set<SimpleFunction<*>> = emptySet(),
         allowDestructuring: Boolean = true,
     ): OutputValue<*> {
         // Destructuring
         if (allowDestructuring && explicitParameters.size > 1) {
             // The lambda is invoked with the first N destructured components.
             (arguments.singleOrNull() as? Destructurable<*>)
-                ?.let { return invokeDynamic(it.destructured(componentCount = explicitParameters.size), callingContext) }
+                ?.let {
+                    return invokeDynamic(
+                        it.destructured(componentCount = explicitParameters.size),
+                        callingContext,
+                        additionalFunctions,
+                    )
+                }
         }
 
         // Check if the amount of arguments matches the amount of expected parameters.
@@ -127,7 +138,7 @@ open class Lambda(
 
         // Register the arguments in the context, which can be accessed as function calls.
         // Lambda parameters are registered last so they shadow any same-named declarations from the calling context.
-        context.loadLibrary(createLambdaParametersLibrary(actualArguments))
+        context.loadLibrary(createLambdaParametersLibrary(actualArguments, additionalFunctions))
 
         // The result of the lambda action is processed.
         return action(actualArguments, context)

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Flow.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Flow.kt
@@ -3,8 +3,6 @@ package com.quarkdown.stdlib
 import com.quarkdown.core.ast.base.block.BlankNode
 import com.quarkdown.core.context.MutableContext
 import com.quarkdown.core.context.ScopeContext
-import com.quarkdown.core.function.Function
-import com.quarkdown.core.function.call.executeAs
 import com.quarkdown.core.function.library.Library
 import com.quarkdown.core.function.library.module.QuarkdownModule
 import com.quarkdown.core.function.library.module.moduleOf
@@ -27,6 +25,7 @@ import com.quarkdown.core.function.value.factory.ValueFactory
 import com.quarkdown.core.function.value.wrappedAsValue
 import com.quarkdown.stdlib.internal.CUSTOM_FUNCTION_LIBRARY_NAME_PREFIX
 import com.quarkdown.stdlib.internal.declareFunction
+import com.quarkdown.stdlib.internal.extendFunction
 
 /**
  * `Flow` stdlib module exporter.
@@ -316,9 +315,9 @@ fun function(
 /**
  * Defines a custom function that extends an existing one by name, wrapping its output.
  *
- * The body lambda receives an optional first parameter (conventionally called `super`),
- * which holds the result of the original function for the same arguments,
- * followed by the original function's parameters in their declared order.
+ * Within the body, the original function is exposed as `.super`: calling it invokes the original
+ * with the arguments the wrapper was called with. The body's explicit parameters, if any, must match
+ * the original function's parameters by name and let the wrapper read those same arguments.
  * All wrapper parameters are optional, regardless of whether the original parameters are.
  *
  * ```
@@ -327,7 +326,6 @@ fun function(
  *     Hello, .name
  *
  * .extend {greet}
- *     super:
  *     .super::uppercase
  *
  * .greet {World}
@@ -335,29 +333,36 @@ fun function(
  *
  * > Output: `HELLO, WORLD`
  *
- * The wrapper can also reference the original parameters by name to alter the behavior conditionally:
+ * The wrapper can reference the original parameters by name to alter the behavior conditionally:
  *
  * ```
  * .extend {greet}
- *     super name:
+ *     name:
  *     .if {.name::equals {World}}
  *         .super::uppercase
  *     .ifnot {.name::equals {World}}
  *         .super
  * ```
  *
- * In implicit form, the parameters can be accessed positionally:
+ * Because `.super` is the original function itself, it accepts the same arguments. Anything you pass
+ * overrides the corresponding argument the wrapper was called with, while anything you leave out
+ * falls through unchanged:
  *
  * ```
  * .extend {greet}
- *     .1::uppercase
+ *     name:
+ *     .super name:{.name::uppercase}
+ *
+ * .greet {John}
  * ```
  *
+ * > Output: `Hello, JOHN`
+ *
  * @param name name of the existing function to extend
- * @param body wrapper content. Its first parameter is bound to the original function's output;
- *             any further explicit parameters must match the original function's parameter names
+ * @param body wrapper content. Its explicit parameters, if any, must match the original function's
+ *             parameter names. `.super` is implicitly available within the body
  * @throws IllegalArgumentException if no function named [name] exists, or if any explicit parameter
- *         beyond `super` does not match an original parameter
+ *         does not match an original parameter
  * @wiki extending-functions
  */
 fun extend(
@@ -365,45 +370,7 @@ fun extend(
     name: String,
     @LikelyBody body: Lambda,
 ): VoidValue {
-    val targetFunction: Function<*> =
-        context.getFunctionByName(name)
-            ?: throw IllegalArgumentException("Cannot extend function $name because it does not exist.")
-
-    // The wrapper exposes the same parameters as the target, plus `super` which is internal to the lambda.
-    val superParameter = body.explicitParameters.firstOrNull()?.copy(isOptional = true)
-    val wrapperParameters =
-        targetFunction.parameters
-            .mapNotNull { parameter ->
-                LambdaParameter(
-                    parameter.name,
-                    isOptional = true,
-                ).takeUnless { parameter.isInjected }
-            }
-
-    val lambdaParameters =
-        when (superParameter) {
-            null -> emptyList()
-            else -> listOf(superParameter) + wrapperParameters
-        }
-
-    // After the first (which represents `super`), every explicit body parameter must match an original parameter by name.
-    val targetNames = targetFunction.parameters.mapTo(mutableSetOf()) { it.name }
-    val unresolved = body.explicitParameters.drop(1).filter { it.name !in targetNames }
-    if (unresolved.isNotEmpty()) {
-        throw IllegalArgumentException(
-            "The following parameters are not part of ${targetFunction.signatureAsString()}: " +
-                unresolved.joinToString { it.name },
-        )
-    }
-
-    val lambda = Lambda(context, lambdaParameters, body.action)
-
-    declareFunction(context, name, wrapperParameters) { call, args, _ ->
-        val wrappedResult = call.executeAs(targetFunction)
-        val lambdaArgs = listOf(wrappedResult) + args
-        lambda.invokeDynamic(lambdaArgs, callingContext = call.context)
-    }
-
+    extendFunction(context, name, body)
     return VoidValue
 }
 

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/internal/FunctionExtension.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/internal/FunctionExtension.kt
@@ -1,0 +1,68 @@
+package com.quarkdown.stdlib.internal
+
+import com.quarkdown.core.context.MutableContext
+import com.quarkdown.core.function.Function
+import com.quarkdown.core.function.SimpleFunction
+import com.quarkdown.core.function.call.executeAs
+import com.quarkdown.core.function.signatureAsString
+import com.quarkdown.core.function.value.data.Lambda
+import com.quarkdown.core.function.value.data.LambdaParameter
+import com.quarkdown.stdlib.extend
+
+/**
+ * Name under which the original function is exposed inside an [extend] wrapper body.
+ */
+private const val SUPER_NAME = "super"
+
+/**
+ * Implementation of [extend]: registers a wrapper around [targetName] in [context],
+ * exposing the original function as `.${SUPER_NAME}` within [body].
+ *
+ * @param context context to register the wrapper in
+ * @param targetName name of the existing function to extend
+ * @param body wrapper content; its explicit parameters, if any, must match the target's parameter names
+ * @throws IllegalArgumentException if no function named [targetName] exists,
+ *         or if any explicit body parameter does not match an original parameter
+ */
+internal fun extendFunction(
+    context: MutableContext,
+    targetName: String,
+    body: Lambda,
+) {
+    val targetFunction: Function<*> =
+        context.getFunctionByName(targetName)
+            ?: throw IllegalArgumentException("Cannot extend function $targetName because it does not exist.")
+
+    // The wrapper mirrors the target's non-injected parameters, all marked optional.
+    val wrapperParameters =
+        targetFunction.parameters
+            .filterNot { it.isInjected }
+            .map { it.copy(isOptional = true) }
+
+    val lambdaParameters = wrapperParameters.map { LambdaParameter(it.name, isOptional = true) }
+
+    // Every explicit body parameter must match an original parameter by name.
+    val targetNames = wrapperParameters.mapTo(mutableSetOf()) { it.name }
+    val unresolved = body.explicitParameters.filter { it.name !in targetNames }
+    if (unresolved.isNotEmpty()) {
+        throw IllegalArgumentException(
+            "The following parameters are not part of ${targetFunction.signatureAsString()}: " +
+                unresolved.joinToString { it.name },
+        )
+    }
+
+    val lambda = Lambda(context, lambdaParameters, body.action)
+
+    declareFunction(context, targetName, lambdaParameters) { call, args, outerBindings ->
+        // `super` is exposed as a callable within the body: its explicit arguments override the outer call's bindings.
+        val superFunction =
+            SimpleFunction(SUPER_NAME, parameters = wrapperParameters) { overrides, _ ->
+                // Each merged argument is re-emitted as named so the relative order of named overrides
+                // and positional fall-throughs cannot violate the "named arguments come last" rule.
+                val mergedArgs = (outerBindings + overrides).map { (param, arg) -> arg.copy(name = param.name) }
+                call.executeAs(targetFunction, arguments = mergedArgs)
+            }
+
+        lambda.invokeDynamic(args, callingContext = call.context, additionalFunctions = setOf(superFunction))
+    }
+}

--- a/quarkdown-test/src/test/kotlin/com/quarkdown/test/FunctionExtensionTest.kt
+++ b/quarkdown-test/src/test/kotlin/com/quarkdown/test/FunctionExtensionTest.kt
@@ -48,7 +48,6 @@ class FunctionExtensionTest {
                Hello
             
             .extend {test}
-               super:
                .super::uppercase
             
             .test
@@ -67,7 +66,7 @@ class FunctionExtensionTest {
                 Hello, .name
             
             .extend {test}
-                super name:
+                name:
                 .if {.name::equals {World}}
                     .super::uppercase
                 .ifnot {.name::equals {World}}
@@ -92,7 +91,7 @@ class FunctionExtensionTest {
                     Hello, .name
                 
                 .extend {test}
-                    super unknown:
+                    unknown:
                     .super
                 
                 .test {World}
@@ -112,7 +111,6 @@ class FunctionExtensionTest {
                 Hello, .name
             
             .extend {test}
-                super:
                 .super::uppercase
             
             .test {World}
@@ -131,7 +129,7 @@ class FunctionExtensionTest {
                 .greeting, .name
             
             .extend {test}
-                super name greeting:
+                name greeting:
                 .greeting .super .name
             
             .test {World} {Hello}
@@ -151,7 +149,7 @@ class FunctionExtensionTest {
                     Hello, .name .lastname
                 
                 .extend {test}
-                    super name firstunknown secondunknown:
+                    name firstunknown secondunknown:
                     .super
                 
                 .test {World}
@@ -171,7 +169,6 @@ class FunctionExtensionTest {
                 .greeting, .name .lastname
             
             .extend {test}
-                super:
                 .super!
             
             .test {John} {Doe} {Hello}
@@ -190,7 +187,7 @@ class FunctionExtensionTest {
                 .greeting, .name .lastname
             
             .extend {test}
-                super name:
+                name:
                 .name, .super!
             
             .test {John} {Doe} {Hello}
@@ -209,7 +206,7 @@ class FunctionExtensionTest {
                 .greeting, .name .lastname
 
             .extend {test}
-                super greeting:
+                greeting:
                 .greeting, .super!
 
             .test {John} {Doe} {Hello}
@@ -228,7 +225,7 @@ class FunctionExtensionTest {
                 .greeting, .name .lastname
 
             .extend {test}
-                super name lastname greeting:
+                name lastname greeting:
                 .greeting .name .lastname: .super
 
             .test greeting:{Hi} name:{John} lastname:{Doe}
@@ -247,7 +244,7 @@ class FunctionExtensionTest {
                 .greeting::otherwise {Hello}, .name::otherwise {?} .lastname::otherwise {?}
 
             .extend {test}
-                super name? lastname? greeting?:
+                name? lastname? greeting?:
                 .greeting::otherwise {none}/.name::otherwise {none}/.lastname::otherwise {none}: .super
 
             .test name:{John} greeting:{Hi}
@@ -266,11 +263,9 @@ class FunctionExtensionTest {
                 Hello, .name
 
             .extend {greet}
-                super:
                 .super::uppercase
 
             .extend {greet}
-                super:
                 [.super]
 
             .greet {world}
@@ -281,20 +276,59 @@ class FunctionExtensionTest {
     }
 
     @Test
-    fun `super access via implicit parameter`() {
+    fun `super argument override, single param`() {
         execute(
             """
             .function {test}
                 name:
                 Hello, .name
-
+            
             .extend {test}
-                .1::uppercase
-
-            .test {World}
+                name:
+                .super name:{World}
+            
+            .test {John}
             """.trimIndent(),
         ) {
-            assertEquals("<p>HELLO, WORLD</p>", it)
+            assertEquals("<p>Hello, World</p>", it)
+        }
+    }
+
+    @Test
+    fun `super argument override, multiple partial params`() {
+        execute(
+            """
+            .function {greet}
+                greeting name:
+                .greeting, .name!
+
+            .extend {greet}
+                name:
+                .name, .super greeting:{Howdy}
+
+            .greet {Hello} {world}
+            """.trimIndent(),
+        ) {
+            assertEquals("<p>world, Howdy, world!</p>", it)
+        }
+    }
+
+    @Test
+    fun `super argument override, argument transformation`() {
+        execute(
+            """
+            .function {test}
+                name lastname greeting:
+                .greeting, .name .lastname
+            
+            .extend {test}
+                name greeting:
+                .name, .super greeting:{.greeting::uppercase}
+            
+            .test {John} {Doe} {Hello}
+            """.trimIndent(),
+        ) {
+            assertEquals("<p>John, HELLO, John Doe</p>", it)
         }
     }
 
@@ -303,7 +337,6 @@ class FunctionExtensionTest {
         execute(
             """
             .extend {lowercase}
-                super:
                 .super::uppercase
             
             .lowercase {hello}
@@ -318,7 +351,7 @@ class FunctionExtensionTest {
         execute(
             """
             .extend {heading}
-                super content:
+                content:
                 .if {.content::equals {Hi}}
                     .container
                         .super


### PR DESCRIPTION
- [x] I have read the [contributing guidelines](https://github.com/iamgio/quarkdown/blob/main/CONTRIBUTING.md).
- [x] I have tested the changes locally.
- [ ] An issue for this change exists, and it was discussed with maintainers. This is required for new features and non-trivial changes. If present, append `Closes #ISSUE_NUMBER` at the end of this PR description.
- [x] (Optional) I have added necessary documentation to [`docs`](https://github.com/iamgio/quarkdown/tree/main/docs) and [`CHANGELOG.md`](https://github.com/iamgio/quarkdown/blob/main/CHANGELOG.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Breaking Changes**
    - Updated `.extend` behavior: `super` now targets the original function directly; wrapper calls pass through arguments, with explicitly provided values overriding while omitted values remain unchanged.
    - `executeAs` now supports optional argument replacement (the prior function-only overload was removed).
- **Improvements**
    - Live preview now uses Server-Sent Events (SSE) instead of WebSockets.
- **Documentation**
    - Revised `.extend` guidance and examples for `super` usage and overriding/transforming arguments.
- **Tests**
    - Updated and expanded `.extend` coverage, including new “super argument override” scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->