### PR TITLE
feat: introduce node primitive boxing

### DIFF
--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/attributes/primitive/PrimitiveFunctionBackedNode.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/attributes/primitive/PrimitiveFunctionBackedNode.kt
@@ -1,0 +1,54 @@
+package com.quarkdown.core.ast.attributes.primitive
+
+import com.quarkdown.core.ast.Node
+import com.quarkdown.core.ast.quarkdown.FunctionCallNode
+import com.quarkdown.core.context.MutableContext
+import com.quarkdown.core.function.call.FunctionCallArgument
+
+/**
+ * A node backed by a primitive function: the node is wrapped into a call to
+ * that function, so any `.extend` registered for the function name is applied to the node's rendering.
+ *
+ * For example, a `Heading` is backed by `.heading`, so wrapping `.extend {heading}` affects both
+ * `.heading {...}` calls and Markdown `#` syntax. See stdlib's `Primitives` module for more primitive functions.
+ *
+ * The wrapped call carries the original node as its delegator, allowing the expander to skip the
+ * function-call machinery entirely when no extension is registered for the backing function.
+ *
+ * @see com.quarkdown.core.pipeline.stages.ParsingStage
+ */
+interface PrimitiveFunctionBackedNode : Node {
+    /**
+     * Materializes this node's properties into the arguments of the backing function call.
+     * Argument names must match the parameter names of the function identified by name.
+     * @return a pair of the function name, from a loaded library, and a list of arguments to call it with
+     */
+    fun toFunctionCall(): Pair<String, List<FunctionCallArgument>>
+}
+
+/**
+ * If [this] node is a [PrimitiveFunctionBackedNode], returns a [FunctionCallNode] that wraps it
+ * (with the original node as its delegator) and registers the call on [context] for later expansion;
+ * otherwise returns [this] unchanged.
+ *
+ * Called from every spot that produces freshly parsed nodes so that primitive wrapping reaches
+ * nested content too (e.g. a heading inside a blockquote or list), not just top-level children.
+ *
+ * @param context context that the new call is parsed under and registered for expansion in
+ * @param isBlock whether the wrap is being applied within a block-level parse, carried into the
+ *                resulting [FunctionCallNode] so the expander picks the right value->node mapper
+ */
+internal fun Node.wrapIfPrimitive(
+    context: MutableContext,
+    isBlock: Boolean,
+): Node {
+    if (this !is PrimitiveFunctionBackedNode) return this
+    val (name, arguments) = toFunctionCall()
+    return FunctionCallNode(
+        context = context,
+        name = name,
+        arguments = arguments,
+        isBlock = isBlock,
+        delegator = this,
+    ).also(context::register)
+}

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/base/block/Heading.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/base/block/Heading.kt
@@ -1,13 +1,21 @@
 package com.quarkdown.core.ast.base.block
 
 import com.quarkdown.core.ast.InlineContent
+import com.quarkdown.core.ast.InlineMarkdownContent
 import com.quarkdown.core.ast.attributes.id.Identifiable
 import com.quarkdown.core.ast.attributes.id.IdentifierProvider
 import com.quarkdown.core.ast.attributes.localization.LocalizedKind
 import com.quarkdown.core.ast.attributes.localization.LocalizedKindKeys
 import com.quarkdown.core.ast.attributes.location.LocationTrackableNode
+import com.quarkdown.core.ast.attributes.primitive.PrimitiveFunctionBackedNode
 import com.quarkdown.core.ast.base.TextNode
 import com.quarkdown.core.ast.quarkdown.reference.CrossReferenceableNode
+import com.quarkdown.core.function.call.FunctionCallArgument
+import com.quarkdown.core.function.value.BooleanValue
+import com.quarkdown.core.function.value.InlineMarkdownContentValue
+import com.quarkdown.core.function.value.NoneValue
+import com.quarkdown.core.function.value.NumberValue
+import com.quarkdown.core.function.value.StringValue
 import com.quarkdown.core.visitor.node.NodeVisitor
 
 /**
@@ -35,7 +43,8 @@ class Heading(
     Identifiable,
     LocationTrackableNode,
     CrossReferenceableNode,
-    LocalizedKind {
+    LocalizedKind,
+    PrimitiveFunctionBackedNode {
     override fun <T> accept(visitor: NodeVisitor<T>) = visitor.visit(this)
 
     override fun <T> accept(visitor: IdentifierProvider<T>) = visitor.visit(this)
@@ -54,6 +63,20 @@ class Heading(
      */
     override val referenceId: String?
         get() = this.customId
+
+    override fun toFunctionCall() =
+        "heading" to
+            listOf(
+                FunctionCallArgument(
+                    name = "content",
+                    expression = InlineMarkdownContentValue(InlineMarkdownContent(text)),
+                ),
+                FunctionCallArgument(name = "depth", expression = NumberValue(depth)),
+                FunctionCallArgument(name = "ref", expression = referenceId?.let(::StringValue) ?: NoneValue),
+                FunctionCallArgument(name = "numbered", expression = BooleanValue(canTrackLocation)),
+                FunctionCallArgument(name = "indexed", expression = BooleanValue(!excludeFromTableOfContents)),
+                FunctionCallArgument(name = "breakpage", expression = BooleanValue(canBreakPage)),
+            )
 
     companion object {
         /**

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/quarkdown/FunctionCallNode.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/quarkdown/FunctionCallNode.kt
@@ -15,6 +15,10 @@ import com.quarkdown.core.visitor.node.NodeVisitor
  * @param name name of the function to call
  * @param arguments arguments to call the function with
  * @param isBlock whether this function call is an isolated block (opposite: inline)
+ * @param delegator if this call was synthesized at parse time from a primitive Markdown node
+ *                  (see [com.quarkdown.core.ast.attributes.primitive.PrimitiveFunctionBackedNode]), the original node.
+ *                  When set, the expander falls back to rendering this node directly if no `.extend`
+ *                  has been registered for [name], skipping function dispatch overhead
  * @param sourceText if available, the source code of the whole function call
  * @param sourceRange if available, the range of the function call in the source code
  */
@@ -23,6 +27,7 @@ class FunctionCallNode(
     val name: String,
     val arguments: List<FunctionCallArgument>,
     val isBlock: Boolean,
+    val delegator: Node? = null,
     val sourceText: CharSequence? = null,
     val sourceRange: IntRange? = null,
 ) : NestableNode,

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/context/BaseContext.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/context/BaseContext.kt
@@ -87,6 +87,8 @@ open class BaseContext(
             .flatMap { it.functions }
             .find { it.name == name }
 
+    override fun isFunctionExtended(name: String): Boolean = false
+
     override fun resolve(call: FunctionCallNode): FunctionCall<*>? {
         val function = getFunctionByName(call.name)
 

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/context/Context.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/context/Context.kt
@@ -110,6 +110,12 @@ interface Context : PermissionHolder {
     fun getFunctionByName(name: String): Function<*>?
 
     /**
+     * Whether a function with [name] has been wrapped via an `.extend` call visible from this context.
+     * Used for optimization of [com.quarkdown.core.ast.attributes.primitive.PrimitiveFunctionBackedNode].
+     */
+    fun isFunctionExtended(name: String): Boolean
+
+    /**
      * @param call function call node to get a function call from
      * @return a new function call that [call] references to, with [call]'s arguments,
      * or `null` if [call] references to an unknown function

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/context/MutableContext.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/context/MutableContext.kt
@@ -45,6 +45,22 @@ open class MutableContext(
     // Prevents function calls from being enqueued.
     private var lockFunctionCallEnqueuing = false
 
+    private val extendedFunctionNames: MutableSet<String> = mutableSetOf()
+
+    /**
+     * Whether a function with [name] has been wrapped via an `.extend` call visible from this context.
+     * Used for optimization of [com.quarkdown.core.ast.attributes.primitive.PrimitiveFunctionBackedNode].
+     */
+    override fun isFunctionExtended(name: String): Boolean = name in extendedFunctionNames
+
+    /**
+     * Marks [name] as extended in this context.
+     * Used for optimization of [com.quarkdown.core.ast.attributes.primitive.PrimitiveFunctionBackedNode], so it can know whether to short-circuit or not.
+     */
+    open fun markFunctionAsExtended(name: String) {
+        extendedFunctionNames += name
+    }
+
     /**
      * Enqueues a new [FunctionCallNode], which is executed in the next stage of the pipeline.
      * Nothing happens if enqueuing is locked via [lockFunctionCallEnqueuing].

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/context/SharedContext.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/context/SharedContext.kt
@@ -29,4 +29,8 @@ open class SharedContext(
     override var sharedSubdocumentsData by parent::sharedSubdocumentsData
 
     override fun getFunctionByName(name: String): Function<*>? = parent.getFunctionByName(name)
+
+    override fun isFunctionExtended(name: String): Boolean = parent.isFunctionExtended(name)
+
+    override fun markFunctionAsExtended(name: String) = parent.markFunctionAsExtended(name)
 }

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/context/SubdocumentContext.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/context/SubdocumentContext.kt
@@ -53,4 +53,10 @@ open class SubdocumentContext(
      * @see Context.getFunctionByName
      */
     override fun getFunctionByName(name: String): Function<*>? = super.getFunctionByName(name) ?: parent.getFunctionByName(name)
+
+    /**
+     * A subdocument inherits the parent's `.extend` registrations, but new ones declared inside it
+     * stay local and don't propagate back to the main document's context.
+     */
+    override fun isFunctionExtended(name: String): Boolean = super.isFunctionExtended(name) || parent.isFunctionExtended(name)
 }

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/function/call/FunctionCallNodeExpander.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/function/call/FunctionCallNodeExpander.kt
@@ -34,6 +34,14 @@ class FunctionCallNodeExpander(
             return
         }
 
+        // Fast path: a call to a Node's primitive function (delegated by such node, see PrimitiveFunctionBacked) whose
+        // backing function has not been extended (see .extend) renders directly from the original node, skipping the reflection-based function dispatch entirely.
+        val delegator = node.delegator
+        if (delegator != null && !node.context.isFunctionExtended(node.name)) {
+            node.children += delegator
+            return
+        }
+
         try {
             // The function call node is used to retrieve its corresponding function call.
             // By resolving it from the node's context instead of the root one,

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/lexer/Token.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/lexer/Token.kt
@@ -1,5 +1,8 @@
 package com.quarkdown.core.lexer
 
+import com.quarkdown.core.ast.Node
+import com.quarkdown.core.ast.attributes.primitive.wrapIfPrimitive
+import com.quarkdown.core.context.MutableContext
 import com.quarkdown.core.visitor.token.TokenVisitor
 
 /**
@@ -21,6 +24,25 @@ abstract class Token(
 /**
  * Lazily accepts a sequence of tokens to a shared visitor.
  * @param visitor the visitor to visit for each token.
- * @return the list of results from each visit
+ * @return a lazy sequence of results from each visit
  */
-fun <T> Sequence<Token>.acceptAll(visitor: TokenVisitor<T>): List<T> = this.map { it.accept(visitor) }.toList()
+private fun <T> Sequence<Token>.acceptAll(visitor: TokenVisitor<T>): Sequence<T> = this.map { it.accept(visitor) }
+
+/**
+ * Like the generic [acceptAll], but specialized to [Node] output: each parsed node is also passed
+ * through [wrapIfPrimitive], so primitive nodes (e.g. [com.quarkdown.core.ast.base.block.Heading])
+ * are wrapped into a [com.quarkdown.core.ast.quarkdown.FunctionCallNode] backed by their stdlib
+ * function, both at the top level (see [com.quarkdown.core.pipeline.stages.ParsingStage]) and inside
+ * nested content (see [com.quarkdown.core.parser.BlockTokenParser]).
+ *
+ * @param visitor parser to visit each token with
+ * @param context context the wrapped calls are registered under
+ * @param isBlock whether the produced nodes belong in a block-level position; carried into the
+ *                resulting wrap so the expander selects the right value→node mapper
+ * @return a lazy sequence of parsed nodes, with primitives wrapped as function calls
+ */
+fun Sequence<Token>.acceptAll(
+    visitor: TokenVisitor<Node>,
+    context: MutableContext,
+    isBlock: Boolean,
+): Sequence<Node> = acceptAll(visitor).map { it.wrapIfPrimitive(context, isBlock) }

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/parser/BlockTokenParser.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/parser/BlockTokenParser.kt
@@ -69,16 +69,20 @@ class BlockTokenParser(
     private val context: MutableContext,
 ) : BlockTokenVisitor<Node> {
     /**
-     * @return the parsed content of the tokenization from [this] lexer
+     * @return the parsed content of the tokenization from [this] lexer.
+     *         Nested [com.quarkdown.core.ast.attributes.primitive.PrimitiveFunctionBackedNode]s
+     *         (e.g. a heading inside a blockquote or list) are wrapped here too, mirroring the
+     *         top-level wrap done by [com.quarkdown.core.pipeline.stages.ParsingStage].
      */
     private fun Lexer.tokenizeAndParse(): List<Node> =
         this
             .tokenize()
-            .acceptAll(context.flavor.parserFactory.newParser(context))
+            .acceptAll(context.flavor.parserFactory.newParser(context), context, isBlock = true)
+            .toList()
 
     /**
      * @return [this] raw string tokenized and parsed into processed inline content,
-     *                based on this [flavor]'s specifics
+     *                based on this flavor's specifics
      */
     private fun String.toInline(): InlineContent =
         context.flavor.lexerFactory

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/parser/FunctionCallRefiner.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/parser/FunctionCallRefiner.kt
@@ -74,7 +74,15 @@ class FunctionCallRefiner(
      * Refines the walked function [call] into a [FunctionCallNode].
      */
     fun toNode(): FunctionCallNode {
-        val node = FunctionCallNode(context, call.name, extractArguments(), isBlock, sourceText, sourceRange)
+        val node =
+            FunctionCallNode(
+                context,
+                call.name,
+                extractArguments(),
+                isBlock,
+                sourceText = sourceText,
+                sourceRange = sourceRange,
+            )
 
         // Chaining: if this function call (A) is chained with another one (B),
         // then the result node is B(A).

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/parser/InlineTokenParser.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/parser/InlineTokenParser.kt
@@ -83,7 +83,8 @@ class InlineTokenParser(
     private fun Lexer.tokenizeAndParse(): List<Node> =
         this
             .tokenize()
-            .acceptAll(context.flavor.parserFactory.newParser(context))
+            .acceptAll(context.flavor.parserFactory.newParser(context), context, isBlock = false)
+            .toList()
 
     /**
      * Tokenizes and parses sub-nodes.

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/pipeline/stages/ParsingStage.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/pipeline/stages/ParsingStage.kt
@@ -2,6 +2,7 @@ package com.quarkdown.core.pipeline.stages
 
 import com.quarkdown.core.ast.AstRoot
 import com.quarkdown.core.ast.Node
+import com.quarkdown.core.ast.attributes.primitive.PrimitiveFunctionBackedNode
 import com.quarkdown.core.lexer.Token
 import com.quarkdown.core.lexer.acceptAll
 import com.quarkdown.core.pipeline.PipelineHooks
@@ -17,6 +18,12 @@ import com.quarkdown.core.visitor.token.TokenVisitor
  *
  * The AST represents the hierarchical structure of the document and is used by
  * subsequent stages for further processing and rendering.
+ *
+ * Primitive Markdown nodes that implement [PrimitiveFunctionBackedNode] (e.g. headings) are wrapped here
+ * into a [com.quarkdown.core.ast.quarkdown.FunctionCallNode] that delegates to their backing stdlib function. When the document
+ * later wraps that function via `.extend`, the wrapper sees the node's properties as named
+ * arguments and can override them; when it does not, the `FunctionCallNode` short-circuits and
+ * renders the original node directly with no reflection overhead.
  */
 object ParsingStage : PipelineStage<Sequence<Token>, AstRoot> {
     override val hook = PipelineHooks::afterParsing
@@ -29,6 +36,11 @@ object ParsingStage : PipelineStage<Sequence<Token>, AstRoot> {
             data.context.flavor.parserFactory
                 .newParser(data.context)
 
-        return AstRoot(children = input.acceptAll(parser))
+        val nodes =
+            input
+                .acceptAll(parser, data.context, isBlock = true)
+                .toList()
+
+        return AstRoot(children = nodes)
     }
 }

--- a/quarkdown-core/src/test/kotlin/com/quarkdown/core/BlockParserTest.kt
+++ b/quarkdown-core/src/test/kotlin/com/quarkdown/core/BlockParserTest.kt
@@ -76,6 +76,13 @@ class BlockParserTest {
         }
 
     /**
+     * Strips the primitive-function wrap added by the parser so tests can keep asserting on the
+     * underlying node (e.g. a heading inside a list item) instead of the synthetic [FunctionCallNode]
+     * that backs it.
+     */
+    private fun Node.unwrapPrimitive(): Node = (this as? FunctionCallNode)?.delegator ?: this
+
+    /**
      * @param node parent node
      * @param childIndex index of the text child
      * @return text content of the [childIndex]-th child
@@ -83,7 +90,7 @@ class BlockParserTest {
     private fun rawText(
         node: NestableNode,
         childIndex: Int = 0,
-    ): String = (node.children[childIndex] as TextNode).rawText
+    ): String = (node.children[childIndex].unwrapPrimitive() as TextNode).rawText
 
     @Test
     fun paragraph() {
@@ -828,7 +835,7 @@ class BlockParserTest {
 
             with(items.next()) {
                 assertIs<ListItem>(this)
-                assertIs<Heading>(children[0])
+                assertIs<Heading>(children[0].unwrapPrimitive())
                 assertEquals("Heading", rawText(this))
             }
             with(items.next()) {
@@ -838,7 +845,7 @@ class BlockParserTest {
             }
             with(items.next()) {
                 assertIs<ListItem>(this)
-                assertIs<Heading>(children[0])
+                assertIs<Heading>(children[0].unwrapPrimitive())
                 assertEquals("Heading", rawText(this, childIndex = 0))
                 assertIs<Paragraph>(children[1])
                 assertEquals("Some paragraph", rawText(this, childIndex = 1))

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Logical.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Logical.kt
@@ -6,6 +6,7 @@ import com.quarkdown.core.function.reflect.annotation.LikelyChained
 import com.quarkdown.core.function.reflect.annotation.Name
 import com.quarkdown.core.function.value.BooleanValue
 import com.quarkdown.core.function.value.DynamicValue
+import com.quarkdown.stdlib.internal.asComparablePlainText
 
 /**
  * `Logical` stdlib module exporter.
@@ -69,7 +70,11 @@ fun isGreater(
 fun equals(
     a: DynamicValue,
     @Name("to") b: DynamicValue,
-) = BooleanValue(a == b || a.unwrappedValue == b.unwrappedValue)
+) = BooleanValue(
+    a == b ||
+        a.unwrappedValue == b.unwrappedValue ||
+        asComparablePlainText(a.unwrappedValue) == asComparablePlainText(b.unwrappedValue),
+)
 
 /**
  * Negates a boolean value.

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/internal/Comparison.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/internal/Comparison.kt
@@ -1,0 +1,21 @@
+package com.quarkdown.stdlib.internal
+
+import com.quarkdown.core.ast.InlineMarkdownContent
+import com.quarkdown.core.ast.MarkdownContent
+import com.quarkdown.core.util.node.toPlainText
+
+/**
+ * Lets Markdown content be compared to its plain-text form
+ *
+ * Returns `null` for values that have no plain-text representation, so callers can fall back
+ * to equality on the underlying value.
+ *
+ * @return the plain-text projection of [value] if one is defined, `null` otherwise.
+ */
+internal fun asComparablePlainText(value: Any?): String? =
+    when (value) {
+        is String -> value
+        is InlineMarkdownContent -> value.children.toPlainText()
+        is MarkdownContent -> value.children.toPlainText()
+        else -> null
+    }

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/internal/FunctionExtension.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/internal/FunctionExtension.kt
@@ -53,13 +53,19 @@ internal fun extendFunction(
 
     val lambda = Lambda(context, lambdaParameters, body.action)
 
+    context.markFunctionAsExtended(targetName)
+
     declareFunction(context, targetName, lambdaParameters) { call, args, outerBindings ->
         // `super` is exposed as a callable within the body: its explicit arguments override the outer call's bindings.
         val superFunction =
             SimpleFunction(SUPER_NAME, parameters = wrapperParameters) { overrides, _ ->
                 // Each merged argument is re-emitted as named so the relative order of named overrides
                 // and positional fall-throughs cannot violate the "named arguments come last" rule.
-                val mergedArgs = (outerBindings + overrides).map { (param, arg) -> arg.copy(name = param.name) }
+                val mergedArgs =
+                    (outerBindings.entries + overrides.entries)
+                        .associate { (param, arg) -> param.name to arg.copy(name = param.name) }
+                        .values
+                        .toList()
                 call.executeAs(targetFunction, arguments = mergedArgs)
             }
 

--- a/quarkdown-test/src/test/kotlin/com/quarkdown/test/FunctionExtensionTest.kt
+++ b/quarkdown-test/src/test/kotlin/com/quarkdown/test/FunctionExtensionTest.kt
@@ -1,10 +1,12 @@
 package com.quarkdown.test
 
+import com.quarkdown.core.context.MutableContext
 import com.quarkdown.test.util.execute
 import kotlin.test.Test
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
 import kotlin.test.assertFails
+import kotlin.test.assertTrue
 
 /**
  * Tests for function extension via `.extend`.
@@ -24,6 +26,7 @@ class FunctionExtensionTest {
             """.trimIndent(),
             forbidFunctionOverwriting = true,
         ) {
+            assertTrue((this as MutableContext).isFunctionExtended("test"))
             assertEquals("<p>Hi</p>", it)
         }
     }

--- a/quarkdown-test/src/test/kotlin/com/quarkdown/test/primitive/HeadingPrimitiveFunctionTest.kt
+++ b/quarkdown-test/src/test/kotlin/com/quarkdown/test/primitive/HeadingPrimitiveFunctionTest.kt
@@ -1,0 +1,233 @@
+package com.quarkdown.test.primitive
+
+import com.quarkdown.test.util.execute
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Tests for `.extend` applied to Markdown headings via the [com.quarkdown.core.ast.attributes.primitive.PrimitiveFunctionBackedNode]
+ * mechanism, exercising every parameter the [com.quarkdown.core.ast.base.block.Heading] node materializes
+ * into the backing `heading` function call.
+ */
+class HeadingPrimitiveFunctionTest {
+    @Test
+    fun `no extension renders unchanged`() {
+        execute(
+            """
+            .noautopagebreak
+
+            # Hello
+
+            ## Hi
+            """.trimIndent(),
+        ) {
+            assertEquals("<h1>Hello</h1><h2>Hi</h2>", it)
+        }
+    }
+
+    @Test
+    fun `extension wraps every heading`() {
+        execute(
+            """
+            .noautopagebreak
+
+            .extend {heading}
+                .container
+                    .super
+
+            # Hello
+            """.trimIndent(),
+        ) {
+            assertEquals("<div class=\"container\"><h1>Hello</h1></div>", it)
+        }
+    }
+
+    @Test
+    fun `content can be matched and conditionally wrapped`() {
+        execute(
+            """
+            .noautopagebreak
+
+            .extend {heading}
+                content:
+                .if {.content::equals {Hi}}
+                    .container
+                        .super
+                .ifnot {.content::equals {Hi}}
+                    .super
+
+            # Hello
+
+            ## Hi
+
+            ### Hey
+            """.trimIndent(),
+        ) {
+            assertEquals(
+                "<h1>Hello</h1><div class=\"container\"><h2>Hi</h2></div><h3>Hey</h3>",
+                it,
+            )
+        }
+    }
+
+    @Test
+    fun `content can be transformed`() {
+        execute(
+            """
+            .noautopagebreak
+
+            .extend {heading}
+                content:
+                .super content:{.content::plaintext::capitalize}
+
+            # hello world
+            """.trimIndent(),
+        ) {
+            assertEquals("<h1>Hello world</h1>", it)
+        }
+    }
+
+    @Test
+    fun `depth can be read and drive container styling`() {
+        execute(
+            """
+            .noautopagebreak
+
+            .extend {heading}
+                depth:
+                .container background:{hsl(.depth::multiply {20}, 50, 50)} fullwidth:{yes}
+                    .super
+
+            ## Hello
+            """.trimIndent(),
+        ) {
+            assertEquals(
+                "<div class=\"container fullwidth\" style=\"background-color: rgba(191, 148, 63, 1.0);\"><h2>Hello</h2></div>",
+                it,
+            )
+        }
+    }
+
+    @Test
+    fun `depth can be overridden via super`() {
+        execute(
+            """
+            .noautopagebreak
+
+            .extend {heading}
+                .super depth:{4}
+
+            # Hello
+            """.trimIndent(),
+        ) {
+            assertEquals("<h4>Hello</h4>", it)
+        }
+    }
+
+    @Test
+    fun `ref can be set via super`() {
+        execute(
+            """
+            .noautopagebreak
+
+            .extend {heading}
+                .super ref:{my-id}
+
+            ## Hello
+            """.trimIndent(),
+        ) {
+            assertEquals("<h2 id=\"my-id\">Hello</h2>", it)
+        }
+    }
+
+    @Test
+    fun `breakpage can be disabled via super`() {
+        execute(
+            """
+            .extend {heading}
+                .super breakpage:{no}
+
+            # Hello
+            """.trimIndent(),
+        ) {
+            assertEquals("<h1>Hello</h1>", it)
+        }
+    }
+
+    @Test
+    fun `extension reaches headings nested inside a blockquote`() {
+        execute(
+            """
+            .noautopagebreak
+
+            .extend {heading}
+                .container
+                    .super
+
+            > ## Quoted heading
+            """.trimIndent(),
+        ) {
+            assertEquals(
+                "<blockquote><div class=\"container\"><h2>Quoted heading</h2></div></blockquote>",
+                it,
+            )
+        }
+    }
+
+    @Test
+    fun `extension reaches headings nested inside a list item`() {
+        execute(
+            """
+            .noautopagebreak
+
+            .extend {heading}
+                .container
+                    .super
+
+            - ## Item heading
+            """.trimIndent(),
+        ) {
+            assertEquals(
+                "<ul><li><div class=\"container\"><h2>Item heading</h2></div></li></ul>",
+                it,
+            )
+        }
+    }
+
+    @Test
+    fun `extension considers function call as content`() {
+        execute(
+            """
+            .noautopagebreak
+            
+            .extend {heading}
+                content:
+                .container foreground:{.takeif {red} {@lambda .content::plaintext::equals {Hello}}}
+                    .super
+            
+            # Hello
+            
+            # Hi
+            
+            # .capitalize {Hello}
+            
+            # .capitalize {Hi}
+            
+            .var {x} {Hello}
+            
+            # .x
+            
+            .x {Hi}
+            
+            # .x
+            """.trimIndent(),
+        ) {
+            val hello = "<div class=\"container\" style=\"color: rgba(255, 0, 0, 1.0);\"><h1>Hello</h1></div>"
+            val hi = "<div class=\"container\"><h1>Hi</h1></div>"
+            assertEquals(
+                hello + hi + hello + hi + hello + hi,
+                it,
+            )
+        }
+    }
+}


### PR DESCRIPTION
- [X] I have read the [contributing guidelines](https://github.com/iamgio/quarkdown/blob/main/CONTRIBUTING.md).
- [X] I have tested the changes locally.
- [x] An issue for this change exists, and it was discussed with maintainers. This is required for new features and non-trivial changes. If present, append `Closes #ISSUE_NUMBER` at the end of this PR description.
- [x] (Optional) I have added necessary documentation to [`docs`](https://github.com/iamgio/quarkdown/tree/main/docs) and [`CHANGELOG.md`](https://github.com/iamgio/quarkdown/blob/main/CHANGELOG.md)

Closes #369

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Headings now fully support `.extend {heading}` for dynamic transformation, conditional wrapping, depth-based container styling, and `ref` / `breakpage` control.
  * Extension behavior is consistent for headings nested inside blockquotes and list items, including cases where heading content resembles function-call-like markup.
* **Improvements**
  * Equality/matching now also compares values using a comparable plain-text representation, improving reliability of content-based conditions.
  * Heading rendering can be faster when no matching extension is registered.
* **Tests**
  * Added coverage for heading primitive extension scenarios and updated parsing-related assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->