### PR TITLE
fix(ui): let container's color prop override any node's color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,12 +24,6 @@ Thanks @gggeon96!
 
 &nbsp;
 
-#### [LSP] Embeddable language server
-
-The Quarkdown language server API now allows the LSP to be embedded in custom hosts and run across multiple instances inside a single JVM, thanks to customizable IO streams and pluggable hooks.
-
-&nbsp;
-
 ### Changed
 
 &nbsp;
@@ -91,13 +85,19 @@ Thanks @CarmJos!
 
 &nbsp;
 
-#### [Security] Fixed native content injection via string manipulation
+#### `.container`'s `foreground` color not applied to headings
+
+`.container foreground:{color}` now correctly applies to headings.
+
+&nbsp;
+
+#### [Security] Native content injection via string manipulation
 
 Fixed an issue that allowed string->string functions to let unsanitized HTML through, even when the `native-content` permission was not granted.
 
 &nbsp;
 
-#### Fixed `.extend` on functions with injected parameters
+#### `.extend` on functions with injected parameters
 
 The `.extend` function now maps parameters correctly when wrapping native functions that feature `@Injected` parameters, such as document metadata functions. 
 

--- a/quarkdown-html/src/main/scss/components/_container.scss
+++ b/quarkdown-html/src/main/scss/components/_container.scss
@@ -24,6 +24,10 @@
     }
   }
 
+  &[style*="color"] > :not([style*="color"]) {
+    color: inherit !important;
+  }
+
   > .stack {
     width: 100%;
     height: 100%;

--- a/quarkdown-html/src/test/e2e/container/color-inherit/color-inherit.spec.ts
+++ b/quarkdown-html/src/test/e2e/container/color-inherit/color-inherit.spec.ts
@@ -1,0 +1,48 @@
+import {getComputedColor} from "../../__util/css";
+import {suite} from "../../quarkdown";
+
+const {test, expect} = suite(__dirname);
+
+test("forces direct children to inherit the container color", async (page) => {
+    const containers = page.locator(".container");
+    const outerContainer = containers.nth(0);
+
+    const red = await getComputedColor(page, "#ff0000");
+
+    // Heading, paragraph and list inside the colored container all inherit red,
+    // overriding their default theme colors.
+    await expect(outerContainer.locator("h1")).toHaveCSS("color", red);
+    await expect(outerContainer.locator("p")).toHaveCSS("color", red);
+    await expect(outerContainer.locator("ul")).toHaveCSS("color", red);
+
+    // The container itself carries the foreground color as an inline style.
+    await expect(outerContainer).toHaveCSS("color", red);
+});
+
+test("preserves default theme colors outside of a colored container", async (page) => {
+    const standaloneHeading = page.locator("h1").first();
+    const standaloneParagraph = page.locator("p").first();
+
+    const headingColor = await getComputedColor(page, "var(--qd-heading-color)");
+    const mainColor = await getComputedColor(page, "var(--qd-main-color)");
+
+    // The standalone heading keeps the theme's heading color, distinct from main text.
+    await expect(standaloneHeading).toHaveCSS("color", headingColor);
+    await expect(standaloneParagraph).toHaveCSS("color", mainColor);
+    expect(headingColor).not.toBe(mainColor);
+});
+
+test("preserves the inner container color when nested", async (page) => {
+    const containers = page.locator(".container");
+    const innerContainer = containers.nth(2);
+
+    const blue = await getComputedColor(page, "#0000ff");
+
+    // The inner container's own foreground color is preserved,
+    // not overridden by the outer container's color rule.
+    await expect(innerContainer).toHaveCSS("color", blue);
+
+    // Children of the inner container inherit blue, not the outer red.
+    await expect(innerContainer.locator("h1")).toHaveCSS("color", blue);
+    await expect(innerContainer.locator("p")).toHaveCSS("color", blue);
+});

--- a/quarkdown-html/src/test/e2e/container/color-inherit/main.qd
+++ b/quarkdown-html/src/test/e2e/container/color-inherit/main.qd
@@ -1,0 +1,20 @@
+.theme {galactic}
+
+# Standalone heading
+
+Standalone paragraph.
+
+- Standalone list item
+
+.container fullwidth:{yes} foreground:{#ff0000}
+    # Inside heading
+
+    Inside paragraph.
+
+    - Inside list item
+
+.container fullwidth:{yes} foreground:{#ff0000}
+    .container fullwidth:{yes} foreground:{#0000ff}
+        # Nested heading
+
+        Nested paragraph.


### PR DESCRIPTION
- [x] I have read the [contributing guidelines](https://github.com/iamgio/quarkdown/blob/main/CONTRIBUTING.md).
- [x] I have tested the changes locally.
- [ ] An issue for this change exists, and it was discussed with maintainers. This is required for new features and non-trivial changes. If present, append `Closes #ISSUE_NUMBER` at the end of this PR description.
- [x] (Optional) I have added necessary documentation to [`docs`](https://github.com/iamgio/quarkdown/tree/main/docs) and [`CHANGELOG.md`](https://github.com/iamgio/quarkdown/blob/main/CHANGELOG.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed color styling not properly applying to headings within containers
  * Fixed extend functionality with injected parameters
  * Patched security vulnerability related to unsanitized content injection

<!-- end of auto-generated comment: release notes by coderabbit.ai -->