### PR TITLE
fix(ui): avoid orphan headings as last page nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,12 @@ Thanks @CarmJos!
 
 &nbsp;
 
+#### Orphan headings at the bottom of a page
+
+In `paged` documents, a heading that would otherwise land as the last line of a page is now pushed to the top of the next page, keeping it close to the content it introduces.
+
+&nbsp;
+
 #### `.container`'s `foreground` color not applied to headings
 
 `.container foreground:{color}` now correctly applies to headings.

--- a/quarkdown-html/src/main/scss/components/_heading.scss
+++ b/quarkdown-html/src/main/scss/components/_heading.scss
@@ -22,3 +22,8 @@
     display: none;
   }
 }
+
+#{$headings} {
+  // #549: avoid headings as the last line of a page.
+  break-after: avoid;
+}

--- a/quarkdown-html/src/test/e2e/heading/issue_orphan-last-heading/bulletin.yml
+++ b/quarkdown-html/src/test/e2e/heading/issue_orphan-last-heading/bulletin.yml
@@ -1,0 +1,5 @@
+- issue: 549
+- pr: 554
+- next-release: 2.3.0
+- cause: "`break-after: avoid` not set in _heading.scss"
+- notes: "The #{$headings} selector cannot be nested into .quarkdown, probably because of a pagedjs bug"

--- a/quarkdown-html/src/test/e2e/heading/issue_orphan-last-heading/main.qd
+++ b/quarkdown-html/src/test/e2e/heading/issue_orphan-last-heading/main.qd
@@ -1,0 +1,8 @@
+.doctype {paged}
+.pageformat height:{8cm}
+
+Hello
+
+## Heading
+
+Hey

--- a/quarkdown-html/src/test/e2e/heading/issue_orphan-last-heading/orphan-last-heading.spec.ts
+++ b/quarkdown-html/src/test/e2e/heading/issue_orphan-last-heading/orphan-last-heading.spec.ts
@@ -1,0 +1,29 @@
+import {suite} from "../../quarkdown";
+
+const {test, expect} = suite(__dirname);
+
+test("pushes a trailing heading to the next page", async (page) => {
+    const pages = page.locator(".pagedjs_page");
+    await expect(pages).toHaveCount(2);
+
+    const firstPage = pages.nth(0);
+    const secondPage = pages.nth(1);
+
+    // The heading is on the second page, not stranded at the bottom of the first.
+    await expect(firstPage.locator("h2")).toHaveCount(0);
+    await expect(secondPage.locator("h2")).toHaveCount(1);
+
+    // The first page is not full: it has enough vertical space to fit the heading,
+    // confirming the push was caused by `break-after: avoid` rather than a natural overflow.
+    const firstPageContentBox = await firstPage.locator(".pagedjs_page_content").boundingBox();
+    const firstPageParagraphBox = await firstPage.locator("p").boundingBox();
+    const headingBox = await secondPage.locator("h2").boundingBox();
+
+    expect(firstPageContentBox).not.toBeNull();
+    expect(firstPageParagraphBox).not.toBeNull();
+    expect(headingBox).not.toBeNull();
+
+    const remainingSpace =
+        firstPageContentBox!.y + firstPageContentBox!.height - (firstPageParagraphBox!.y + firstPageParagraphBox!.height);
+    expect(remainingSpace).toBeGreaterThanOrEqual(headingBox!.height);
+});


### PR DESCRIPTION
- [X] I have read the [contributing guidelines](https://github.com/iamgio/quarkdown/blob/main/CONTRIBUTING.md).
- [X] I have tested the changes locally.
- [x] An issue for this change exists, and it was discussed with maintainers. This is required for new features and non-trivial changes. If present, append `Closes #ISSUE_NUMBER` at the end of this PR description.
- [x] (Optional) I have added necessary documentation to [`docs`](https://github.com/iamgio/quarkdown/tree/main/docs) and [`CHANGELOG.md`](https://github.com/iamgio/quarkdown/blob/main/CHANGELOG.md)

Closes #549



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Headings in paged documents are no longer left stranded as the last line on a page. When a heading would otherwise end up at the bottom, it’s pushed to the top of the next page.
* **Tests**
  * Added an end-to-end Playwright fixture to verify the heading/page break behavior with precise page count and layout checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->