### PR TITLE
ci(workflow): add GHCR publishing on tag

### DIFF
--- a/.github/workflows/gradle-deploy.yml
+++ b/.github/workflows/gradle-deploy.yml
@@ -161,7 +161,7 @@ jobs:
         version: ${{ github.ref_name }}
         committer_token: ${{ secrets.COMMITTER_TOKEN }}
 
-  publish:
+  image-publish:
     if: github.ref_type == 'tag'
     runs-on: ubuntu-latest
     needs: [test]

--- a/.github/workflows/gradle-deploy.yml
+++ b/.github/workflows/gradle-deploy.yml
@@ -82,6 +82,12 @@ jobs:
     - name: Echo output files
       run: ls -d "$PWD/build/"* && ls build/distributions
 
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v4
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v4
+
     - name: Login to GitHub Container Registry
       if: github.ref == 'refs/heads/main' || github.ref_type == 'tag'
       uses: docker/login-action@v4
@@ -96,6 +102,7 @@ jobs:
       with:
         context: .
         push: true
+        platforms: linux/amd64,linux/arm64
         tags: |
           ghcr.io/${{ github.repository }}:${{ github.ref_name }}
           ${{ github.ref_type == 'tag' && format('ghcr.io/{0}:latest', github.repository) || '' }}

--- a/.github/workflows/gradle-deploy.yml
+++ b/.github/workflows/gradle-deploy.yml
@@ -82,12 +82,6 @@ jobs:
     - name: Echo output files
       run: ls -d "$PWD/build/"* && ls build/distributions
 
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v4
-
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v4
-
     - name: Login to GitHub Container Registry
       if: github.ref == 'refs/heads/main' || github.ref_type == 'tag'
       uses: docker/login-action@v4
@@ -102,7 +96,7 @@ jobs:
       with:
         context: .
         push: true
-        platforms: linux/amd64,linux/arm64
+        platforms: linux/amd64
         tags: |
           ghcr.io/${{ github.repository }}:${{ github.ref_name }}
           ${{ github.ref_type == 'tag' && format('ghcr.io/{0}:latest', github.repository) || '' }}

--- a/.github/workflows/gradle-deploy.yml
+++ b/.github/workflows/gradle-deploy.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test]
     permissions:
-      contents: read
+      contents: write
       packages: write
 
     steps:

--- a/.github/workflows/gradle-deploy.yml
+++ b/.github/workflows/gradle-deploy.yml
@@ -83,7 +83,7 @@ jobs:
       run: ls -d "$PWD/build/"* && ls build/distributions
 
     - name: Login to GitHub Container Registry
-      if: github.ref_type == 'tag'
+      if: github.ref == 'refs/heads/main' || github.ref_type == 'tag'
       uses: docker/login-action@v4
       with:
         registry: ghcr.io
@@ -91,14 +91,14 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Build and push Docker image
-      if: github.ref_type == 'tag'
+      if: github.ref == 'refs/heads/main' || github.ref_type == 'tag'
       uses: docker/build-push-action@v7
       with:
         context: .
         push: true
         tags: |
           ghcr.io/${{ github.repository }}:${{ github.ref_name }}
-          ghcr.io/${{ github.repository }}:latest
+          ${{ github.ref_type == 'tag' && format('ghcr.io/{0}:latest', github.repository) || '' }}
 
     - name: Deploy wiki
       if: github.ref_type == 'tag'

--- a/.github/workflows/gradle-deploy.yml
+++ b/.github/workflows/gradle-deploy.yml
@@ -22,7 +22,6 @@ jobs:
     needs: [test]
     permissions:
       contents: write
-      packages: write
 
     steps:
     - uses: iamgio/quarkdown/.github/actions/setup-environment@main
@@ -81,25 +80,6 @@ jobs:
 
     - name: Echo output files
       run: ls -d "$PWD/build/"* && ls build/distributions
-
-    - name: Login to GitHub Container Registry
-      if: github.ref == 'refs/heads/main' || github.ref_type == 'tag'
-      uses: docker/login-action@v4
-      with:
-        registry: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-
-    - name: Build and push Docker image
-      if: github.ref == 'refs/heads/main' || github.ref_type == 'tag'
-      uses: docker/build-push-action@v7
-      with:
-        context: .
-        push: true
-        platforms: linux/amd64
-        tags: |
-          ghcr.io/${{ github.repository }}:${{ github.ref_name }}
-          ${{ github.ref_type == 'tag' && format('ghcr.io/{0}:latest', github.repository) || '' }}
 
     - name: Deploy wiki
       if: github.ref_type == 'tag'
@@ -180,6 +160,36 @@ jobs:
       with:
         version: ${{ github.ref_name }}
         committer_token: ${{ secrets.COMMITTER_TOKEN }}
+
+  publish:
+    if: github.ref_type == 'tag'
+    runs-on: ubuntu-latest
+    needs: [test]
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v4
+
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v4
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Build and push Docker image
+      uses: docker/build-push-action@v7
+      with:
+        context: .
+        push: true
+        tags: |
+          ghcr.io/${{ github.repository }}:${{ github.ref_name }}
+          ghcr.io/${{ github.repository }}:latest
 
   dependency-submission:
 

--- a/.github/workflows/gradle-deploy.yml
+++ b/.github/workflows/gradle-deploy.yml
@@ -20,6 +20,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     needs: [test]
+    permissions:
+      contents: read
+      packages: write
 
     steps:
     - uses: iamgio/quarkdown/.github/actions/setup-environment@main
@@ -78,6 +81,24 @@ jobs:
 
     - name: Echo output files
       run: ls -d "$PWD/build/"* && ls build/distributions
+
+    - name: Login to GitHub Container Registry
+      if: github.ref_type == 'tag'
+      uses: docker/login-action@v4
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Build and push Docker image
+      if: github.ref_type == 'tag'
+      uses: docker/build-push-action@v7
+      with:
+        context: .
+        push: true
+        tags: |
+          ghcr.io/${{ github.repository }}:${{ github.ref_name }}
+          ghcr.io/${{ github.repository }}:latest
 
     - name: Deploy wiki
       if: github.ref_type == 'tag'

--- a/.github/workflows/gradle-deploy.yml
+++ b/.github/workflows/gradle-deploy.yml
@@ -174,6 +174,10 @@ jobs:
       with:
         persist-credentials: false
 
+    # Writes the new version (tag name without the leading 'v') to version.txt
+    - name: Bump version
+      run: printf "%s" "${GITHUB_REF_NAME#v}" > version.txt
+
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v4
 

--- a/.github/workflows/gradle-deploy.yml
+++ b/.github/workflows/gradle-deploy.yml
@@ -171,6 +171,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v4

--- a/.github/workflows/gradle-deploy.yml
+++ b/.github/workflows/gradle-deploy.yml
@@ -189,6 +189,7 @@ jobs:
       with:
         context: .
         push: true
+        platforms: linux/amd64
         tags: |
           ghcr.io/${{ github.repository }}:${{ github.ref_name }}
           ghcr.io/${{ github.repository }}:latest

--- a/.github/workflows/gradle-deploy.yml
+++ b/.github/workflows/gradle-deploy.yml
@@ -184,15 +184,24 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
+    - name: Docker metadata
+      id: meta
+      uses: docker/metadata-action@v6
+      with:
+        images: ghcr.io/${{ github.repository }}
+        tags: |
+          type=semver,pattern={{version}}
+          type=semver,pattern={{major}}.{{minor}}
+          type=semver,pattern={{major}}
+
     - name: Build and push Docker image
       uses: docker/build-push-action@v7
       with:
         context: .
         push: true
         platforms: linux/amd64
-        tags: |
-          ghcr.io/${{ github.repository }}:${{ github.ref_name }}
-          ghcr.io/${{ github.repository }}:latest
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
 
   dependency-submission:
 


### PR DESCRIPTION
- [X] I have read the [contributing guidelines](https://github.com/iamgio/quarkdown/blob/main/CONTRIBUTING.md).
- [X] I have tested the changes locally.
- [ ] An issue for this change exists, and it was discussed with maintainers. This is required for new features and non-trivial changes. If present, append `Closes #ISSUE_NUMBER` at the end of this PR description.
- [ ] (Optional) I have added necessary documentation to [`docs`](https://github.com/iamgio/quarkdown/tree/main/docs) and [`CHANGELOG.md`](https://github.com/iamgio/quarkdown/blob/main/CHANGELOG.md)

---

## Description

Add Docker image publishing to GitHub Container Registry (GHCR) with multi-architecture support.

### Changes
- Added `docker/login-action` step to authenticate with `ghcr.io`
- Added `docker/build-push-action` step to build and push the Docker image
- Added `docker/setup-qemu-action` and `docker/setup-buildx-action` for multi-arch builds
- Added `packages: write` permission to the `build` job via YAML override (least privilege)

### Behavior
- **On push to `main`** → Publishes `ghcr.io/iamgio/quarkdown:main`
- **On release tag** (e.g., `v2.3.0`) → Publishes both:
  - `ghcr.io/iamgio/quarkdown:v2.3.0`
  - `ghcr.io/iamgio/quarkdown:latest`

### Architecture Support
Images are built natively for both platforms:
- `linux/amd64` (Intel/AMD servers)
- `linux/arm64` (Apple Silicon, AWS Graviton, Raspberry Pi)

Docker automatically serves the correct architecture based on the user's platform.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores / Infrastructure**
  * Updated the automated deployment workflow to define explicit job-level GitHub permissions for deployments.
  * Added a dedicated publish step that runs only for tag builds (after tests) and pushes Docker images to the GitHub Container Registry.
  * Docker images are now tagged with the current ref name, and tag builds additionally publish a `latest` tag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->