### PR TITLE
feat(cli): add --clean safe guards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased]
 
+### Fixed
+
+&nbsp;
+
+#### Safer `--clean`
+
+The `--clean` flag now refuses to clean the output directory in case it contains source files or git repos, or if it's the filesystem root or home directory. It also stops if the directory would (recursively) contain the source file passed to the command.
+
+&nbsp;
+
 ## [2.3.0] - 2026-06-18
 
 ### Added

--- a/quarkdown-cli/src/main/kotlin/com/quarkdown/cli/exec/ExecuteCommand.kt
+++ b/quarkdown-cli/src/main/kotlin/com/quarkdown/cli/exec/ExecuteCommand.kt
@@ -1,6 +1,7 @@
 package com.quarkdown.cli.exec
 
 import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.core.CliktError
 import com.github.ajalt.clikt.core.ProgramResult
 import com.github.ajalt.clikt.parameters.options.default
 import com.github.ajalt.clikt.parameters.options.flag
@@ -12,6 +13,7 @@ import com.github.ajalt.clikt.parameters.types.int
 import com.quarkdown.cli.CliOptions
 import com.quarkdown.cli.exec.strategy.PipelineExecutionStrategy
 import com.quarkdown.cli.server.DEFAULT_SERVER_PORT
+import com.quarkdown.cli.util.checkCleanSafety
 import com.quarkdown.cli.util.runWithTimeout
 import com.quarkdown.cli.watcher.DirectoryWatcher
 import com.quarkdown.core.TIMEOUT_EXIT_CODE
@@ -274,6 +276,18 @@ abstract class ExecuteCommand(
     override fun run() {
         val cliOptions = this.createCliOptions()
         val pipelineOptions = this.createPipelineOptions(cliOptions)
+
+        // Prevents `--clean` from deleting sensitive directories.
+        if (cliOptions.clean) {
+            cliOptions.outputDirectory?.let { dir ->
+                dir.checkCleanSafety(cliOptions.source)?.let { refusal ->
+                    throw CliktError(
+                        "Refusing to clean output directory '${dir.absolutePath}': ${refusal.message}. " +
+                            "Please pick a different --out directory or omit --clean.",
+                    )
+                }
+            }
+        }
 
         // If pipe mode is enabled, all logging is disabled, so that only the rendered content is printed to stdout.
         if (cliOptions.pipe) {

--- a/quarkdown-cli/src/main/kotlin/com/quarkdown/cli/util/CleanSafety.kt
+++ b/quarkdown-cli/src/main/kotlin/com/quarkdown/cli/util/CleanSafety.kt
@@ -1,0 +1,99 @@
+package com.quarkdown.cli.util
+
+import com.quarkdown.core.util.IOUtils
+import java.io.File
+
+/**
+ * Reason why cleaning a directory is refused for safety.
+ * Combined with `--clean`, accidental targeting of a sensitive directory could result
+ * in irreversible data loss, so the CLI refuses any of these cases up front.
+ */
+sealed interface CleanRefusal {
+    /**
+     * Human-readable explanation of why the directory cannot be cleaned.
+     */
+    val message: String
+
+    /**
+     * The directory is a filesystem root (e.g. `/` on Unix, `C:\` on Windows).
+     */
+    data object FilesystemRoot : CleanRefusal {
+        override val message = "it is a filesystem root"
+    }
+
+    /**
+     * The directory is the user's home directory.
+     */
+    data object HomeDirectory : CleanRefusal {
+        override val message = "it is the user home directory"
+    }
+
+    /**
+     * The directory is the current working directory the CLI was invoked from.
+     */
+    data object WorkingDirectory : CleanRefusal {
+        override val message = "it is the current working directory"
+    }
+
+    /**
+     * The directory looks like the root of a source-controlled project (it contains a `.git` entry).
+     */
+    data object RepositoryRoot : CleanRefusal {
+        override val message = "it looks like a repository"
+    }
+
+    /**
+     * The directory (recursively) contains the main source file of the compilation.
+     * @param source the source file whose deletion would be triggered by cleaning the directory
+     */
+    data class ContainsSourceFile(
+        val source: File,
+    ) : CleanRefusal {
+        override val message = "it contains the source file '${source.absolutePath}'"
+    }
+}
+
+/**
+ * Markers identifying that a directory is the root of a versioned project.
+ * The presence of these inside the candidate directory makes it a [CleanRefusal.RepositoryRoot].
+ */
+private val PROJECT_ROOT_MARKERS = setOf(".git", ".hg", ".svn")
+
+/**
+ * Decides whether [this] directory can be safely wiped by the CLI `--clean` flag.
+ *
+ * Cleaning is refused when the target directory is a sensitive location (filesystem root,
+ * user home, the current working directory, or a project root), or when wiping it would
+ * delete the main [sourceFile] of the compilation.
+ *
+ * @param sourceFile main source file of the compilation, if known
+ * @param homeDirectory user home directory, exposed as a parameter to ease testing
+ * @param workingDirectory current working directory, exposed as a parameter to ease testing
+ * @return `null` if the directory can be cleaned, or a [CleanRefusal] describing why it cannot
+ */
+fun File.checkCleanSafety(
+    sourceFile: File?,
+    homeDirectory: File? = systemDirectory("user.home"),
+    workingDirectory: File? = systemDirectory("user.dir"),
+): CleanRefusal? {
+    val target = this.canonicalFile
+
+    if (target.parentFile == null) return CleanRefusal.FilesystemRoot
+    if (homeDirectory != null && target == homeDirectory) return CleanRefusal.HomeDirectory
+    if (workingDirectory != null && target == workingDirectory) return CleanRefusal.WorkingDirectory
+    if (PROJECT_ROOT_MARKERS.any { File(target, it).exists() }) return CleanRefusal.RepositoryRoot
+
+    if (sourceFile != null && IOUtils.isSubPath(parent = target, child = sourceFile)) {
+        return CleanRefusal.ContainsSourceFile(sourceFile.canonicalFile)
+    }
+
+    return null
+}
+
+/**
+ * @return the canonical directory referenced by the given system [property], or `null` if it cannot be resolved
+ */
+private fun systemDirectory(property: String): File? =
+    runCatching {
+        System.getProperty(property)?.let { File(it).canonicalFile }
+    }.getOrNull()

--- a/quarkdown-cli/src/test/kotlin/com/quarkdown/cli/CompileCommandTest.kt
+++ b/quarkdown-cli/src/test/kotlin/com/quarkdown/cli/CompileCommandTest.kt
@@ -155,6 +155,22 @@ class CompileCommandTest : TempDirectory() {
     }
 
     @Test
+    fun `clean refuses output directory containing source file`() {
+        val sibling = File(directory, "neighbor.txt").apply { writeText("important") }
+        val result =
+            CompileCommand().test(
+                main.absolutePath,
+                "-o",
+                directory.absolutePath,
+                "--clean",
+            )
+        assertEquals(1, result.statusCode)
+        assertTrue(result.stderr.contains("Refusing to clean"), result.stderr)
+        assertTrue(main.exists(), "Source file must not be deleted")
+        assertTrue(sibling.exists(), "Sibling files must not be deleted")
+    }
+
+    @Test
     fun `forbid function overwriting`() {
         val (_, pipelineOptions) = test("--forbid-function-overwriting")
         assertTrue(pipelineOptions.forbidFunctionOverwriting)

--- a/quarkdown-cli/src/test/kotlin/com/quarkdown/cli/util/CleanSafetyTest.kt
+++ b/quarkdown-cli/src/test/kotlin/com/quarkdown/cli/util/CleanSafetyTest.kt
@@ -1,0 +1,113 @@
+package com.quarkdown.cli.util
+
+import com.quarkdown.cli.TempDirectory
+import java.io.File
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+
+/**
+ * Tests for [checkCleanSafety].
+ */
+class CleanSafetyTest : TempDirectory() {
+    private lateinit var sandboxHome: File
+    private lateinit var sandboxCwd: File
+
+    @BeforeTest
+    fun setUp() {
+        reset()
+        sandboxHome = File(directory, "home").apply { mkdirs() }
+        sandboxCwd = File(directory, "cwd").apply { mkdirs() }
+    }
+
+    @AfterTest
+    fun tearDown() {
+        directory.deleteRecursively()
+    }
+
+    private fun File.check(sourceFile: File? = null): CleanRefusal? =
+        checkCleanSafety(
+            sourceFile = sourceFile,
+            homeDirectory = sandboxHome.canonicalFile,
+            workingDirectory = sandboxCwd.canonicalFile,
+        )
+
+    @Test
+    fun `safe directory has no refusal`() {
+        val out = File(directory, "build/output").apply { mkdirs() }
+        assertNull(out.check())
+    }
+
+    @Test
+    fun `filesystem root is refused`() {
+        assertEquals(CleanRefusal.FilesystemRoot, File("/").check())
+    }
+
+    @Test
+    fun `home directory is refused`() {
+        assertEquals(CleanRefusal.HomeDirectory, sandboxHome.check())
+    }
+
+    @Test
+    fun `working directory is refused`() {
+        assertEquals(CleanRefusal.WorkingDirectory, sandboxCwd.check())
+    }
+
+    @Test
+    fun `directory containing a git folder is refused`() {
+        val projectRoot = File(directory, "project").apply { mkdirs() }
+        File(projectRoot, ".git").mkdirs()
+
+        assertEquals(CleanRefusal.RepositoryRoot, projectRoot.check())
+    }
+
+    @Test
+    fun `directory containing a git pointer file is refused`() {
+        val projectRoot = File(directory, "submodule").apply { mkdirs() }
+        File(projectRoot, ".git").writeText("gitdir: ../.git/modules/sub")
+
+        assertEquals(CleanRefusal.RepositoryRoot, projectRoot.check())
+    }
+
+    @Test
+    fun `directory containing the source file is refused`() {
+        val out = File(directory, "out").apply { mkdirs() }
+        val source = File(out, "main.qd").apply { writeText("hello") }
+
+        val refusal = assertIs<CleanRefusal.ContainsSourceFile>(out.check(sourceFile = source))
+        assertEquals(source.canonicalFile, refusal.source)
+    }
+
+    @Test
+    fun `directory containing the source file in a nested directory is refused`() {
+        val out = File(directory, "out").apply { mkdirs() }
+        val nested = File(out, "deep/nested").apply { mkdirs() }
+        val source = File(nested, "main.qd").apply { writeText("hello") }
+
+        val refusal = assertIs<CleanRefusal.ContainsSourceFile>(out.check(sourceFile = source))
+        assertEquals(source.canonicalFile, refusal.source)
+    }
+
+    @Test
+    fun `directory not containing the source file is safe`() {
+        val out = File(directory, "out").apply { mkdirs() }
+        val source = File(directory, "main.qd").apply { writeText("hello") }
+
+        assertNull(out.check(sourceFile = source))
+    }
+
+    @Test
+    fun `sibling directory of source file is safe`() {
+        val sibling = File(directory, "sibling").apply { mkdirs() }
+        val source =
+            File(directory, "other/main.qd").apply {
+                parentFile.mkdirs()
+                writeText("hello")
+            }
+
+        assertNull(sibling.check(sourceFile = source))
+    }
+}


### PR DESCRIPTION
- [X] I have read the [contributing guidelines](https://github.com/iamgio/quarkdown/blob/main/CONTRIBUTING.md).
- [X] I have tested the changes locally.
- [x] An issue for this change exists, and it was discussed with maintainers. This is required for new features and non-trivial changes. If present, append `Closes #ISSUE_NUMBER` at the end of this PR description.
- [x] (Optional) I have added necessary documentation to [`docs`](https://github.com/iamgio/quarkdown/tree/main/docs) and [`CHANGELOG.md`](https://github.com/iamgio/quarkdown/blob/main/CHANGELOG.md)

Closes #556

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced `--clean` safety: it now refuses to delete the output directory when it would target critical locations (filesystem root, home/CWD, repository roots) or would recursively include/overwrite the command’s source files.
* **Tests**
  * Added automated tests to verify refusal behavior and that source/neighbor files remain intact.
* **Documentation**
  * Updated the changelog with an Unreleased entry describing the safer `--clean` flag behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->