### PR TITLE
feat(function): allow non-last body params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 ## [Unreleased]
 
+### Changed
+
+&nbsp;
+
+#### [Body argument binding](https://quarkdown.com/wiki/syntax-of-a-function-call#block-vs-inline-function-calls)
+
+Native functions can now explicitly designate a body parameter. Previously, the body argument of a function call always bound to the last parameter of the function.
+
+Affected functions are `.text` and `.heading`.
+
+This means the following now works as expected:
+
+```markdown
+.text size:{large} weight:{bold}
+    Inline content
+```
+
+Inline binding keeps working as before, so the following is still valid:
+
+```markdown
+.text {Inline content} size:{large} weight:{bold}
+```
+
+#### Optimized argument binding
+
+Parameter lookup now performs a single pass over the arguments, improving performance.
+
 ## [2.3.1] - 2026-06-23
 
 ### Added

--- a/docs/syntax-of-a-function-call.qd
+++ b/docs/syntax-of-a-function-call.qd
@@ -149,7 +149,7 @@ Paragraph 2
 
 ### The body argument
 
-The main difference between inline and block function calls is a special argument called **body argument**. This argument **always** refers to the **last parameter** of the signature (even if named arguments were used).
+The main difference between inline and block function calls is a special argument called **body argument**. This argument refers to the function's **body parameter**, which is usually the last one in the signature, although some functions designate a different parameter as their body (showing as *Likely body* in its documentation).
 
 A body argument expands over multiple lines, is not wrapped by brackets, and requires each line to be **indented** by at least two spaces or one tab:
 

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/function/FunctionParameter.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/function/FunctionParameter.kt
@@ -8,6 +8,7 @@ import kotlin.reflect.KClass
  * @param type expected input value type
  * @param index index of the parameter in the function signature
  * @param isOptional whether the corresponding argument in a function call can be omitted
+ * @param isExplicitlyBody whether the parameter is explicitly reserved for the body argument, even if it's not the last one in the signature
  * @param isInjected whether the corresponding argument in a function call is automatically injected
  *                   and is not to be supplied by the caller.
  * @param isNullable whether the parameter accepts `null` values.
@@ -20,6 +21,7 @@ data class FunctionParameter<T : Any>(
     val type: KClass<T>,
     val index: Int,
     val isOptional: Boolean = false,
+    val isExplicitlyBody: Boolean = false,
     // When a function parameter is loaded from a KFunction via KFunctionAdapter,
     // a parameter is injected if it's annotated with `@Injected`
     val isInjected: Boolean = false,

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/function/call/binding/RegularArgumentsBinder.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/function/call/binding/RegularArgumentsBinder.kt
@@ -34,7 +34,9 @@ class RegularArgumentsBinder(
      * Binds an argument to its corresponding parameter.
      * @param argument argument to bind
      * @param argumentIndex index of the argument in the call
-     * @param parameters available parameters of the called function
+     * @param bindable parameters available for positional and named binding (excludes any parameter reserved for the body argument)
+     * @param byName name-indexed view of [bindable] for O(1) named-argument lookup
+     * @param bodyParameter parameter reserved for the body argument, if any
      * @return the parameter bound to the given argument
      * @throws InvalidArgumentCountException if the number of arguments exceeds the number of parameters
      * @throws UnresolvedParameterException if the argument is named and refers to a non-existent parameter
@@ -43,24 +45,26 @@ class RegularArgumentsBinder(
     private fun findParameter(
         argument: FunctionCallArgument,
         argumentIndex: Int,
-        parameters: List<FunctionParameter<*>>,
+        bindable: List<FunctionParameter<*>>,
+        byName: Map<String, FunctionParameter<*>>,
+        bodyParameter: FunctionParameter<*>?,
     ): FunctionParameter<*> =
         when {
-            // A body parameter is always the last one in the function signature.
+            // A body argument binds to its reserved parameter, or falls back to the last one in the signature.
             argument.isBody -> {
-                parameters.lastOrNull()
+                bodyParameter ?: bindable.lastOrNull()
             }
 
             // A non-body parameter that refers to a parameter by its name.
             argument.isNamed -> {
                 encounteredNamedArgument = true
-                parameters.find { it.name == argument.name }
+                byName[argument.name]
                     ?: throw UnresolvedParameterException(argument, call)
             }
 
             // Non-body, unnamed parameters follow the index and cannot appear after a named argument has been encountered.
             !encounteredNamedArgument -> {
-                parameters.getOrNull(argumentIndex)
+                bindable.getOrNull(argumentIndex)
             }
 
             // Unnamed arguments cannot appear after a named one.
@@ -156,6 +160,22 @@ class RegularArgumentsBinder(
     }
 
     override fun createBindings(parameters: List<FunctionParameter<*>>): ArgumentBindings {
+        // A parameter is reserved for the body argument when it is explicitly marked as such
+        // (see FunctionParameter.isExplicitlyBody) and the call provides a body argument.
+        // The reservation excludes the parameter from positional and named bindings,
+        // so the body argument is its only possible binding source.
+        val bodyParameter: FunctionParameter<*>? =
+            when {
+                call.arguments.any { it.isBody } -> parameters.firstOrNull { it.isExplicitlyBody }
+                else -> null
+            }
+
+        // Parameters available for binding non-body arguments.
+        val bindable = if (bodyParameter == null) parameters else parameters - bodyParameter
+
+        // Name-indexed view of bindable parameters, for O(1) named-argument lookup.
+        val byName = bindable.associateBy { it.name }
+
         // Parameters that have been already bound to arguments.
         val boundParameters = mutableSetOf<FunctionParameter<*>>()
 
@@ -163,7 +183,7 @@ class RegularArgumentsBinder(
             .withIndex()
             .associate { (index, argument) ->
                 // Corresponding parameter.
-                val parameter = findParameter(argument, index, parameters)
+                val parameter = findParameter(argument, index, bindable, byName, bodyParameter)
 
                 // Check if the parameter is already bound.
                 when {

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/function/reflect/KFunctionAdapter.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/function/reflect/KFunctionAdapter.kt
@@ -6,6 +6,7 @@ import com.quarkdown.core.function.call.FunctionCall
 import com.quarkdown.core.function.call.binding.ArgumentBindings
 import com.quarkdown.core.function.call.validate.FunctionCallValidator
 import com.quarkdown.core.function.error.FunctionCallRuntimeException
+import com.quarkdown.core.function.reflect.annotation.Body
 import com.quarkdown.core.function.reflect.annotation.Injected
 import com.quarkdown.core.function.reflect.annotation.Name
 import com.quarkdown.core.function.reflect.annotation.NoAutoArgumentUnwrapping
@@ -55,6 +56,7 @@ class KFunctionAdapter<T : OutputValue<*>>(
                 type = it.type.classifier as KClass<out InputValue<T>>,
                 index = it.index,
                 isOptional = it.isOptional,
+                isExplicitlyBody = it.hasAnnotation<Body>(),
                 isInjected = it.hasAnnotation<Injected>(),
                 isNullable = it.type.isMarkedNullable,
             )

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/function/reflect/annotation/Body.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/function/reflect/annotation/Body.kt
@@ -1,0 +1,12 @@
+package com.quarkdown.core.function.reflect.annotation
+
+/**
+ * When a library function parameter is annotated with `@Body`,
+ * it is marked as the body parameter of the function: a body argument from a function call
+ * always binds to it, regardless of its position in the signature, and the parameter is
+ * excluded from positional and named bindings.
+ *
+ * @see com.quarkdown.core.function.call.binding.RegularArgumentsBinder
+ */
+@Target(AnnotationTarget.VALUE_PARAMETER)
+annotation class Body

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/function/value/data/Lambda.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/function/value/data/Lambda.kt
@@ -17,9 +17,17 @@ import com.quarkdown.core.function.value.factory.ValueFactory
 
 private const val LAMBDA_LIBRARY_NAME = "__lambda-parameters__"
 
+/**
+ * A declared parameter of a [Lambda].
+ * @param name name of the parameter
+ * @param isOptional whether the corresponding argument can be omitted
+ * @param isExplicitlyBody whether the parameter is reserved for the body argument when the lambda
+ *                         is registered as a function (see [com.quarkdown.core.function.FunctionParameter.isExplicitlyBody]).
+ */
 data class LambdaParameter(
     val name: String,
     val isOptional: Boolean = false,
+    val isExplicitlyBody: Boolean = false,
 )
 
 /**

--- a/quarkdown-core/src/test/kotlin/com/quarkdown/core/RegularArgumentsBinderTest.kt
+++ b/quarkdown-core/src/test/kotlin/com/quarkdown/core/RegularArgumentsBinderTest.kt
@@ -1,0 +1,243 @@
+package com.quarkdown.core
+
+import com.quarkdown.core.function.FunctionParameter
+import com.quarkdown.core.function.SimpleFunction
+import com.quarkdown.core.function.call.FunctionCall
+import com.quarkdown.core.function.call.FunctionCallArgument
+import com.quarkdown.core.function.call.binding.RegularArgumentsBinder
+import com.quarkdown.core.function.error.InvalidArgumentCountException
+import com.quarkdown.core.function.error.ParameterAlreadyBoundException
+import com.quarkdown.core.function.error.UnnamedArgumentAfterNamedException
+import com.quarkdown.core.function.error.UnresolvedParameterException
+import com.quarkdown.core.function.value.StringValue
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+/**
+ * Unit tests for [RegularArgumentsBinder]: the component that pairs each function call argument
+ * (positional, named, or body) with its corresponding parameter.
+ */
+class RegularArgumentsBinderTest {
+    private fun param(
+        name: String,
+        index: Int,
+        isExplicitlyBody: Boolean = false,
+    ) = FunctionParameter(name, StringValue::class, index, isExplicitlyBody = isExplicitlyBody)
+
+    private fun bind(
+        parameters: List<FunctionParameter<*>>,
+        arguments: List<FunctionCallArgument>,
+    ): Map<FunctionParameter<*>, FunctionCallArgument> {
+        val function =
+            SimpleFunction(
+                name = "test",
+                parameters = parameters,
+            ) { _, _ -> StringValue("") }
+        return RegularArgumentsBinder(FunctionCall(function, arguments)).createBindings(parameters)
+    }
+
+    private fun Map<FunctionParameter<*>, FunctionCallArgument>.unwrap(parameter: FunctionParameter<*>): Any? =
+        this[parameter]?.value?.unwrappedValue
+
+    @Test
+    fun `positional binding follows parameter order`() {
+        val a = param("a", 0)
+        val b = param("b", 1)
+        val bindings =
+            bind(
+                listOf(a, b),
+                listOf(
+                    FunctionCallArgument(StringValue("x")),
+                    FunctionCallArgument(StringValue("y")),
+                ),
+            )
+        assertEquals("x", bindings.unwrap(a))
+        assertEquals("y", bindings.unwrap(b))
+    }
+
+    @Test
+    fun `named binding ignores argument order`() {
+        val a = param("a", 0)
+        val b = param("b", 1)
+        val bindings =
+            bind(
+                listOf(a, b),
+                listOf(
+                    FunctionCallArgument(StringValue("y"), name = "b"),
+                    FunctionCallArgument(StringValue("x"), name = "a"),
+                ),
+            )
+        assertEquals("x", bindings.unwrap(a))
+        assertEquals("y", bindings.unwrap(b))
+    }
+
+    @Test
+    fun `positional then named binding`() {
+        val a = param("a", 0)
+        val b = param("b", 1)
+        val c = param("c", 2)
+        val bindings =
+            bind(
+                listOf(a, b, c),
+                listOf(
+                    FunctionCallArgument(StringValue("x")),
+                    FunctionCallArgument(StringValue("z"), name = "c"),
+                    FunctionCallArgument(StringValue("y"), name = "b"),
+                ),
+            )
+        assertEquals("x", bindings.unwrap(a))
+        assertEquals("y", bindings.unwrap(b))
+        assertEquals("z", bindings.unwrap(c))
+    }
+
+    @Test
+    fun `unnamed argument after named one throws`() {
+        val a = param("a", 0)
+        val b = param("b", 1)
+        assertFailsWith<UnnamedArgumentAfterNamedException> {
+            bind(
+                listOf(a, b),
+                listOf(
+                    FunctionCallArgument(StringValue("x"), name = "a"),
+                    FunctionCallArgument(StringValue("y")),
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun `unknown parameter name throws`() {
+        val a = param("a", 0)
+        assertFailsWith<UnresolvedParameterException> {
+            bind(
+                listOf(a),
+                listOf(FunctionCallArgument(StringValue("x"), name = "z")),
+            )
+        }
+    }
+
+    @Test
+    fun `too many positional arguments throws`() {
+        val a = param("a", 0)
+        assertFailsWith<InvalidArgumentCountException> {
+            bind(
+                listOf(a),
+                listOf(
+                    FunctionCallArgument(StringValue("x")),
+                    FunctionCallArgument(StringValue("y")),
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun `parameter bound positionally and by name throws`() {
+        val a = param("a", 0)
+        val b = param("b", 1)
+        assertFailsWith<ParameterAlreadyBoundException> {
+            bind(
+                listOf(a, b),
+                listOf(
+                    FunctionCallArgument(StringValue("x")),
+                    FunctionCallArgument(StringValue("y"), name = "a"),
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun `body argument falls back to last parameter when none is marked as body`() {
+        val a = param("a", 0)
+        val last = param("last", 1)
+        val bindings =
+            bind(
+                listOf(a, last),
+                listOf(
+                    FunctionCallArgument(StringValue("x")),
+                    FunctionCallArgument(StringValue("content"), isBody = true),
+                ),
+            )
+        assertEquals("x", bindings.unwrap(a))
+        assertEquals("content", bindings.unwrap(last))
+    }
+
+    @Test
+    fun `body argument binds to explicit body parameter even when not last`() {
+        val a = param("a", 0)
+        val body = param("body", 1, isExplicitlyBody = true)
+        val c = param("c", 2)
+        val bindings =
+            bind(
+                listOf(a, body, c),
+                listOf(
+                    FunctionCallArgument(StringValue("x")),
+                    FunctionCallArgument(StringValue("z")),
+                    FunctionCallArgument(StringValue("content"), isBody = true),
+                ),
+            )
+        assertEquals("x", bindings.unwrap(a))
+        assertEquals("z", bindings.unwrap(c))
+        assertEquals("content", bindings.unwrap(body))
+    }
+
+    @Test
+    fun `explicit body parameter is excluded from positional binding`() {
+        // The body parameter sits at position 0 but is reserved for the body argument,
+        // so positional arguments must skip over it and bind to the remaining parameters.
+        val body = param("body", 0, isExplicitlyBody = true)
+        val a = param("a", 1)
+        val b = param("b", 2)
+        val bindings =
+            bind(
+                listOf(body, a, b),
+                listOf(
+                    FunctionCallArgument(StringValue("x")),
+                    FunctionCallArgument(StringValue("y")),
+                    FunctionCallArgument(StringValue("content"), isBody = true),
+                ),
+            )
+        assertEquals("x", bindings.unwrap(a))
+        assertEquals("y", bindings.unwrap(b))
+        assertEquals("content", bindings.unwrap(body))
+    }
+
+    @Test
+    fun `explicit body parameter is excluded from named binding`() {
+        val a = param("a", 0)
+        val body = param("body", 1, isExplicitlyBody = true)
+        assertFailsWith<UnresolvedParameterException> {
+            bind(
+                listOf(a, body),
+                listOf(
+                    FunctionCallArgument(StringValue("x")),
+                    FunctionCallArgument(StringValue("override"), name = "body"),
+                    FunctionCallArgument(StringValue("content"), isBody = true),
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun `explicit body parameter binds normally when no body argument is provided`() {
+        // Without a body argument, isExplicitlyBody has no effect: the parameter is bindable
+        // by name or position like any other.
+        val a = param("a", 0)
+        val body = param("body", 1, isExplicitlyBody = true)
+        val bindings =
+            bind(
+                listOf(a, body),
+                listOf(
+                    FunctionCallArgument(StringValue("x")),
+                    FunctionCallArgument(StringValue("y"), name = "body"),
+                ),
+            )
+        assertEquals("x", bindings.unwrap(a))
+        assertEquals("y", bindings.unwrap(body))
+    }
+
+    @Test
+    fun `empty arguments and parameters produce empty bindings`() {
+        assertEquals(0, bind(emptyList(), emptyList()).size)
+    }
+}

--- a/quarkdown-core/src/test/kotlin/com/quarkdown/core/StandaloneFunctionTest.kt
+++ b/quarkdown-core/src/test/kotlin/com/quarkdown/core/StandaloneFunctionTest.kt
@@ -21,6 +21,7 @@ import com.quarkdown.core.function.expression.ComposedExpression
 import com.quarkdown.core.function.library.loader.MultiFunctionLibraryLoader
 import com.quarkdown.core.function.library.module.moduleOf
 import com.quarkdown.core.function.reflect.KFunctionAdapter
+import com.quarkdown.core.function.reflect.annotation.Body
 import com.quarkdown.core.function.reflect.annotation.Injected
 import com.quarkdown.core.function.reflect.annotation.NotForDocumentType
 import com.quarkdown.core.function.reflect.annotation.OnlyForDocumentType
@@ -406,6 +407,50 @@ class StandaloneFunctionTest {
             )
 
         assertFailsWith<InvalidArgumentCountException> {
+            invalidCall.execute()
+        }
+    }
+
+    @Suppress("MemberVisibilityCanBePrivate")
+    fun greetWithExplicitBody(
+        @Body content: String,
+        to: String = "you",
+        from: String = "me",
+    ): StringValue = StringValue("Hello $to from $from: $content")
+
+    @Test
+    fun `KFunction with explicit @Body parameter`() {
+        val function = KFunctionAdapter(::greetWithExplicitBody)
+
+        // The body parameter sits first in the signature but a body argument binds to it directly,
+        // while positional arguments fill the remaining parameters in order.
+        val call =
+            FunctionCall(
+                function,
+                arguments =
+                    listOf(
+                        FunctionCallArgument(StringValue("A")),
+                        FunctionCallArgument(StringValue("B")),
+                        FunctionCallArgument(StringValue("hi!"), isBody = true),
+                    ),
+            )
+
+        assertEquals("Hello A from B: hi!", call.execute().unwrappedValue)
+
+        // Naming the reserved body parameter from another argument fails, since it is excluded
+        // from positional and named bindings when a body argument is also present.
+        val invalidCall =
+            FunctionCall(
+                function,
+                arguments =
+                    listOf(
+                        FunctionCallArgument(StringValue("A")),
+                        FunctionCallArgument(StringValue("override"), name = "content"),
+                        FunctionCallArgument(StringValue("hi!"), isBody = true),
+                    ),
+            )
+
+        assertFailsWith<UnresolvedParameterException> {
             invalidCall.execute()
         }
     }

--- a/quarkdown-quarkdoc/src/main/kotlin/com/quarkdown/quarkdoc/dokka/transformers/optional/AdditionalParameterPropertiesTransformer.kt
+++ b/quarkdown-quarkdoc/src/main/kotlin/com/quarkdown/quarkdoc/dokka/transformers/optional/AdditionalParameterPropertiesTransformer.kt
@@ -1,5 +1,6 @@
 package com.quarkdown.quarkdoc.dokka.transformers.optional
 
+import com.quarkdown.core.function.reflect.annotation.Body
 import com.quarkdown.core.function.reflect.annotation.LikelyBody
 import com.quarkdown.core.function.reflect.annotation.LikelyNamed
 import com.quarkdown.core.function.reflect.annotation.Name
@@ -45,7 +46,7 @@ class AdditionalParameterPropertiesTransformer(
         ParameterProperties(
             isOptional = parameter.extra[DefaultValue] != null,
             isLikelyNamed = parameter.hasAnnotation<LikelyNamed>() || parameter.hasAnnotation<Name>(),
-            isLikelyBody = parameter.hasAnnotation<LikelyBody>(),
+            isLikelyBody = parameter.hasAnnotation<LikelyBody>() || parameter.hasAnnotation<Body>(),
         )
 
     /**

--- a/quarkdown-quarkdoc/src/test/kotlin/com/quarkdown/quarkdoc/dokka/AdditionalParameterPropertiesTransformerTest.kt
+++ b/quarkdown-quarkdoc/src/test/kotlin/com/quarkdown/quarkdoc/dokka/AdditionalParameterPropertiesTransformerTest.kt
@@ -1,5 +1,6 @@
 package com.quarkdown.quarkdoc.dokka
 
+import com.quarkdown.core.function.reflect.annotation.Body
 import com.quarkdown.core.function.reflect.annotation.LikelyBody
 import com.quarkdown.core.function.reflect.annotation.LikelyNamed
 import com.quarkdown.quarkdoc.reader.anchors.Anchors
@@ -18,8 +19,17 @@ private const val NAMED_TEXT = "Likely named"
  */
 class AdditionalParameterPropertiesTransformerTest :
     QuarkdocDokkaTest(
-        stringImports = listOf(LikelyBody::class.qualifiedName!!, LikelyNamed::class.qualifiedName!!),
-        stringPaths = listOf(LikelyBody::class.java.packageName + ".QuarkdocAnnotations"),
+        stringImports =
+            listOf(
+                Body::class.qualifiedName!!,
+                LikelyBody::class.qualifiedName!!,
+                LikelyNamed::class.qualifiedName!!,
+            ),
+        stringPaths =
+            listOf(
+                Body::class.java.packageName + ".Body",
+                LikelyBody::class.java.packageName + ".QuarkdocAnnotations",
+            ),
     ) {
     private fun containsAnchor(
         html: String,
@@ -72,6 +82,25 @@ class AdditionalParameterPropertiesTransformerTest :
              * @param x Test
              */
             fun func(@LikelyBody x: Int) = Unit
+            """.trimIndent(),
+            "func",
+        ) {
+            val parameters = getParametersTable(it).text()
+            assertContains(parameters, "x")
+            assertContains(parameters, BODY_TEXT)
+            assertTrue(containsAnchor(it, Anchors.LIKELY_BODY))
+            assertFalse(OPTIONAL_TEXT in parameters)
+        }
+    }
+
+    @Test
+    fun `body parameter via Body annotation`() {
+        test(
+            """
+            /**
+             * @param x Test
+             */
+            fun func(@Body x: Int) = Unit
             """.trimIndent(),
             "func",
         ) {

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Document.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Document.kt
@@ -41,6 +41,7 @@ import com.quarkdown.core.document.size.Sizes
 import com.quarkdown.core.document.tex.TexInfo
 import com.quarkdown.core.function.library.module.QuarkdownModule
 import com.quarkdown.core.function.library.module.moduleOf
+import com.quarkdown.core.function.reflect.annotation.Body
 import com.quarkdown.core.function.reflect.annotation.Injected
 import com.quarkdown.core.function.reflect.annotation.LikelyBody
 import com.quarkdown.core.function.reflect.annotation.LikelyNamed
@@ -1004,7 +1005,7 @@ fun marker(name: InlineMarkdownContent) = Heading.marker(name.children).wrappedA
 @Name("navigation")
 fun navigationContainer(
     role: NavigationContainer.Role? = null,
-    @LikelyBody content: MarkdownContent,
+    @Body content: MarkdownContent,
 ): NodeValue =
     NavigationContainer(
         role,

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Flow.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Flow.kt
@@ -6,6 +6,7 @@ import com.quarkdown.core.context.ScopeContext
 import com.quarkdown.core.function.library.Library
 import com.quarkdown.core.function.library.module.QuarkdownModule
 import com.quarkdown.core.function.library.module.moduleOf
+import com.quarkdown.core.function.reflect.annotation.Body
 import com.quarkdown.core.function.reflect.annotation.Injected
 import com.quarkdown.core.function.reflect.annotation.LikelyBody
 import com.quarkdown.core.function.reflect.annotation.Name
@@ -24,7 +25,7 @@ import com.quarkdown.core.function.value.data.Range
 import com.quarkdown.core.function.value.factory.ValueFactory
 import com.quarkdown.core.function.value.wrappedAsValue
 import com.quarkdown.stdlib.internal.CUSTOM_FUNCTION_LIBRARY_NAME_PREFIX
-import com.quarkdown.stdlib.internal.declareFunction
+import com.quarkdown.stdlib.internal.declareFunctionFromLambda
 import com.quarkdown.stdlib.internal.extendFunction
 
 /**
@@ -291,7 +292,7 @@ fun repeat(
 fun function(
     @Injected context: MutableContext,
     name: String,
-    @LikelyBody body: Lambda,
+    @Body body: Lambda,
 ): VoidValue {
     if (context.attachedPipeline?.options?.forbidFunctionOverwriting == true) {
         val existingFunction = context.getFunctionByName(name)
@@ -302,7 +303,7 @@ fun function(
         }
     }
 
-    declareFunction(context, name, body.explicitParameters) { call, args, _ ->
+    declareFunctionFromLambda(context, name, body.explicitParameters) { call, args, _ ->
         // The final result is evaluated and returned as a dynamic, hence it can be used as any type.
         // The calling context is propagated so that dynamic value references within the lambda body
         // can resolve variables from the calling scope.
@@ -368,7 +369,7 @@ fun function(
 fun extend(
     @Injected context: MutableContext,
     name: String,
-    @LikelyBody body: Lambda,
+    @Body body: Lambda,
 ): VoidValue {
     extendFunction(context, name, body)
     return VoidValue
@@ -489,7 +490,7 @@ fun variable(
  */
 fun let(
     value: DynamicValue,
-    @LikelyBody body: Lambda,
+    @Body body: Lambda,
 ): OutputValue<*> = body.invokeDynamic(value)
 
 /**

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Layout.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Layout.kt
@@ -22,6 +22,7 @@ import com.quarkdown.core.document.size.Size
 import com.quarkdown.core.document.size.Sizes
 import com.quarkdown.core.function.library.module.QuarkdownModule
 import com.quarkdown.core.function.library.module.moduleOf
+import com.quarkdown.core.function.reflect.annotation.Body
 import com.quarkdown.core.function.reflect.annotation.Injected
 import com.quarkdown.core.function.reflect.annotation.LikelyBody
 import com.quarkdown.core.function.reflect.annotation.LikelyNamed
@@ -115,7 +116,7 @@ fun container(
     @LikelyNamed float: Container.FloatAlignment? = null,
     @Name("fullspan") fullColumnSpan: Boolean = false,
     @Name("classname") className: String? = null,
-    @LikelyBody body: MarkdownContent? = null,
+    @Body body: MarkdownContent? = null,
 ) = Container(
     width,
     height,
@@ -148,7 +149,7 @@ fun container(
  */
 fun align(
     alignment: Container.Alignment,
-    @LikelyBody body: MarkdownContent,
+    @Body body: MarkdownContent,
 ) = container(
     fullWidth = true,
     alignment = alignment,
@@ -165,7 +166,7 @@ fun align(
  * @wiki align
  */
 fun center(
-    @LikelyBody body: MarkdownContent,
+    @Body body: MarkdownContent,
 ) = align(Container.Alignment.CENTER, body)
 
 /**
@@ -178,7 +179,7 @@ fun center(
  */
 fun float(
     @LikelyNamed alignment: Container.FloatAlignment,
-    @LikelyBody body: MarkdownContent,
+    @Body body: MarkdownContent,
 ) = container(
     float = alignment,
     body = body,
@@ -220,7 +221,7 @@ fun row(
     @Name("alignment") mainAxisAlignment: Stacked.MainAxisAlignment = Stacked.MainAxisAlignment.START,
     @Name("cross") crossAxisAlignment: Stacked.CrossAxisAlignment = Stacked.CrossAxisAlignment.CENTER,
     @LikelyNamed gap: Size? = null,
-    @LikelyBody body: MarkdownContent,
+    @Body body: MarkdownContent,
 ) = stack(Stacked.Row, mainAxisAlignment, crossAxisAlignment, null, gap, body)
 
 /**
@@ -237,7 +238,7 @@ fun column(
     @Name("alignment") mainAxisAlignment: Stacked.MainAxisAlignment = Stacked.MainAxisAlignment.START,
     @Name("cross") crossAxisAlignment: Stacked.CrossAxisAlignment = Stacked.CrossAxisAlignment.CENTER,
     @LikelyNamed gap: Size? = null,
-    @LikelyBody body: MarkdownContent,
+    @Body body: MarkdownContent,
 ) = stack(Stacked.Column, mainAxisAlignment, crossAxisAlignment, gap, null, body)
 
 /**
@@ -263,7 +264,7 @@ fun grid(
     @LikelyNamed gap: Size? = null,
     @Name("vgap") rowGap: Size? = gap,
     @Name("hgap") columnGap: Size? = gap,
-    @LikelyBody body: MarkdownContent,
+    @Body body: MarkdownContent,
 ) = when {
     columnCount <= 0 -> throw IllegalArgumentException("Column count must be at least 1")
     else -> stack(Stacked.Grid(columnCount), mainAxisAlignment, crossAxisAlignment, rowGap ?: gap, columnGap ?: gap, body)
@@ -279,7 +280,7 @@ fun grid(
  * @wiki landscape-content
  */
 fun landscape(
-    @LikelyBody body: MarkdownContent,
+    @Body body: MarkdownContent,
 ) = Landscape(body.children).wrappedAsValue()
 
 /**
@@ -294,7 +295,7 @@ fun landscape(
  */
 @Name("fullspan")
 fun fullColumnSpan(
-    @LikelyBody body: MarkdownContent,
+    @Body body: MarkdownContent,
 ) = container(fullColumnSpan = true, body = body)
 
 /**
@@ -322,7 +323,7 @@ fun whitespace(
  */
 fun clip(
     clip: Clipped.Clip,
-    @LikelyBody body: MarkdownContent,
+    @Body body: MarkdownContent,
 ) = Clipped(clip, body.children).wrappedAsValue()
 
 /**
@@ -346,7 +347,7 @@ fun box(
     @LikelyNamed padding: Size? = null,
     @Name("background") backgroundColor: Color? = null,
     @Name("foreground") foregroundColor: Color? = null,
-    @LikelyBody body: MarkdownContent,
+    @Body body: MarkdownContent,
 ): NodeValue {
     // Localizes the title according to the box type,
     // if the title is not manually set.
@@ -400,7 +401,7 @@ fun toDo(
 fun collapse(
     title: InlineMarkdownContent,
     @LikelyNamed open: Boolean = false,
-    @LikelyBody body: MarkdownContent,
+    @Body body: MarkdownContent,
 ) = Collapse(title.children, open, body.children).wrappedAsValue()
 
 /**
@@ -446,7 +447,7 @@ fun inlineCollapse(
 fun numbered(
     @LikelyNamed key: String,
     @Name("ref") referenceId: String? = null,
-    @LikelyBody body: Lambda,
+    @Body body: Lambda,
 ): NodeValue {
     val node =
         Numbered(
@@ -480,7 +481,7 @@ fun numbered(
  */
 fun table(
     @Injected context: Context,
-    @LikelyBody subTables: Iterable<Value<String>>,
+    @Body subTables: Iterable<Value<String>>,
 ): NodeValue {
     val columns =
         subTables

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Localization.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Localization.kt
@@ -4,8 +4,8 @@ import com.quarkdown.core.context.Context
 import com.quarkdown.core.context.MutableContext
 import com.quarkdown.core.function.library.module.QuarkdownModule
 import com.quarkdown.core.function.library.module.moduleOf
+import com.quarkdown.core.function.reflect.annotation.Body
 import com.quarkdown.core.function.reflect.annotation.Injected
-import com.quarkdown.core.function.reflect.annotation.LikelyBody
 import com.quarkdown.core.function.reflect.annotation.LikelyNamed
 import com.quarkdown.core.function.reflect.annotation.Name
 import com.quarkdown.core.function.value.DictionaryValue
@@ -34,7 +34,7 @@ val Localization: QuarkdownModule =
 private fun buildLocalizationTable(contents: Map<String, DictionaryValue<OutputValue<String>>>): LocalizationTable =
     contents
         .asSequence()
-        .map { (key, value) ->
+        .associate { (key, value) ->
             // The locale name is the first element of each list item:
             // English <-- this is the locale name
             //   - key1: value1
@@ -47,7 +47,7 @@ private fun buildLocalizationTable(contents: Map<String, DictionaryValue<OutputV
                 value.unwrappedValue.mapValues { (_, value) -> value.unwrappedValue }
 
             locale to entries
-        }.toMap()
+        }
 
 /**
  * Merges two localization tables, giving priority to the new one.
@@ -112,7 +112,7 @@ fun localization(
     @Injected context: MutableContext,
     @Name("name") tableName: String,
     @LikelyNamed merge: Boolean = false,
-    @LikelyBody contents: Map<String, DictionaryValue<OutputValue<String>>>,
+    @Body contents: Map<String, DictionaryValue<OutputValue<String>>>,
 ): VoidValue {
     val tableExists = tableName in context.localizationTables
 

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Mermaid.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Mermaid.kt
@@ -7,7 +7,7 @@ import com.quarkdown.core.ast.quarkdown.block.MermaidDiagram
 import com.quarkdown.core.ast.quarkdown.block.SubdocumentGraph
 import com.quarkdown.core.function.library.module.QuarkdownModule
 import com.quarkdown.core.function.library.module.moduleOf
-import com.quarkdown.core.function.reflect.annotation.LikelyBody
+import com.quarkdown.core.function.reflect.annotation.Body
 import com.quarkdown.core.function.reflect.annotation.LikelyNamed
 import com.quarkdown.core.function.reflect.annotation.Name
 import com.quarkdown.core.function.value.IterableValue
@@ -68,7 +68,7 @@ private fun mermaidFigure(
 fun mermaid(
     @LikelyNamed caption: InlineMarkdownContent? = null,
     @Name("ref") referenceId: String? = null,
-    @LikelyBody code: EvaluableString,
+    @Body code: EvaluableString,
 ) = mermaidFigure(
     caption = caption?.children,
     referenceId = referenceId,
@@ -205,7 +205,7 @@ fun xyChart(
     @Name("yrange") yAxisRange: Range? = null,
     @LikelyNamed caption: InlineMarkdownContent? = null,
     @Name("ref") referenceId: String? = null,
-    @LikelyBody values: Iterable<OutputValue<*>>,
+    @Body values: Iterable<OutputValue<*>>,
 ): NodeValue {
     val lines: List<ChartLine> = extractLines(values)
     val (minY, maxY) = lines.flatten().let { (it.minOrNull() ?: 0.0) to (it.maxOrNull() ?: 1.0) }

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/MiscElements.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/MiscElements.kt
@@ -6,7 +6,7 @@ import com.quarkdown.core.ast.quarkdown.block.FileTree
 import com.quarkdown.core.ast.quarkdown.inline.Keybinding
 import com.quarkdown.core.function.library.module.QuarkdownModule
 import com.quarkdown.core.function.library.module.moduleOf
-import com.quarkdown.core.function.reflect.annotation.LikelyBody
+import com.quarkdown.core.function.reflect.annotation.Body
 import com.quarkdown.core.function.reflect.annotation.Name
 import com.quarkdown.core.function.value.NodeValue
 import com.quarkdown.core.function.value.wrappedAsValue
@@ -45,7 +45,7 @@ val MiscElements: QuarkdownModule =
  */
 @Name("filetree")
 fun fileTree(
-    @LikelyBody content: MarkdownContent,
+    @Body content: MarkdownContent,
 ): NodeValue {
     val rawListNode =
         content.children.firstOrNull() as? ListBlock

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Primitives.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Primitives.kt
@@ -11,8 +11,8 @@ import com.quarkdown.core.context.Context
 import com.quarkdown.core.document.size.Size
 import com.quarkdown.core.function.library.module.QuarkdownModule
 import com.quarkdown.core.function.library.module.moduleOf
+import com.quarkdown.core.function.reflect.annotation.Body
 import com.quarkdown.core.function.reflect.annotation.Injected
-import com.quarkdown.core.function.reflect.annotation.LikelyBody
 import com.quarkdown.core.function.reflect.annotation.LikelyNamed
 import com.quarkdown.core.function.reflect.annotation.Name
 import com.quarkdown.core.function.value.NodeValue
@@ -53,7 +53,7 @@ val Primitives: QuarkdownModule =
  * @throws IllegalArgumentException if [depth] is not in the 1-6 range
  */
 fun heading(
-    content: InlineMarkdownContent,
+    @Body content: InlineMarkdownContent,
     @LikelyNamed depth: Int,
     @Name("ref") customId: String? = null,
     @Name("numbered") canTrackLocation: Boolean = true,
@@ -160,7 +160,7 @@ fun pageBreak() = PageBreak().wrappedAsValue()
 fun figure(
     @LikelyNamed caption: InlineMarkdownContent? = null,
     @Name("ref") referenceId: String? = null,
-    @LikelyBody body: MarkdownContent,
+    @Body body: MarkdownContent,
 ): NodeValue =
     Figure(
         body,

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Slides.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Slides.kt
@@ -8,6 +8,7 @@ import com.quarkdown.core.document.DocumentType
 import com.quarkdown.core.document.slides.Transition
 import com.quarkdown.core.function.library.module.QuarkdownModule
 import com.quarkdown.core.function.library.module.moduleOf
+import com.quarkdown.core.function.reflect.annotation.Body
 import com.quarkdown.core.function.reflect.annotation.LikelyBody
 import com.quarkdown.core.function.reflect.annotation.LikelyNamed
 import com.quarkdown.core.function.reflect.annotation.Name
@@ -67,7 +68,7 @@ fun setSlidesConfiguration(
 @OnlyForDocumentType(DocumentType.SLIDES)
 fun fragment(
     behavior: SlidesFragment.Behavior = SlidesFragment.Behavior.SHOW,
-    @LikelyBody content: MarkdownContent,
+    @Body content: MarkdownContent,
 ) = SlidesFragment(behavior, content.children).wrappedAsValue()
 
 /**

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/TableComputation.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/TableComputation.kt
@@ -8,8 +8,8 @@ import com.quarkdown.core.ast.dsl.buildInline
 import com.quarkdown.core.context.Context
 import com.quarkdown.core.function.library.module.QuarkdownModule
 import com.quarkdown.core.function.library.module.moduleOf
+import com.quarkdown.core.function.reflect.annotation.Body
 import com.quarkdown.core.function.reflect.annotation.Injected
-import com.quarkdown.core.function.reflect.annotation.LikelyBody
 import com.quarkdown.core.function.reflect.annotation.Name
 import com.quarkdown.core.function.value.BooleanValue
 import com.quarkdown.core.function.value.DynamicValue
@@ -157,7 +157,7 @@ private fun reconstructTable(
 fun tableSort(
     @Name("column") columnIndex: Int,
     order: Ordering = Ordering.ASCENDING,
-    @Name("table") @LikelyBody content: MarkdownContent,
+    @Name("table") @Body content: MarkdownContent,
 ): NodeValue {
     val (table, _, values) = findTableColumn(content, columnIndex)
 
@@ -205,7 +205,7 @@ fun tableSort(
 fun tableFilter(
     @Name("column") columnIndex: Int,
     filter: Lambda,
-    @Name("table") @LikelyBody content: MarkdownContent,
+    @Name("table") @Body content: MarkdownContent,
 ): NodeValue {
     val (table, _, values) = findTableColumn(content, columnIndex)
 
@@ -252,7 +252,7 @@ fun tableFilter(
 fun tableCompute(
     @Name("column") columnIndex: Int,
     compute: Lambda,
-    @Name("table") @LikelyBody content: MarkdownContent,
+    @Name("table") @Body content: MarkdownContent,
 ): NodeValue {
     val (table, column, values) = findTableColumn(content, columnIndex)
 
@@ -301,7 +301,7 @@ fun tableCompute(
 @Name("tablecolumn")
 fun tableColumn(
     @Name("column") columnIndex: Int,
-    @Name("of") @LikelyBody content: MarkdownContent,
+    @Name("of") @Body content: MarkdownContent,
 ): IterableValue<OutputValue<*>> {
     val (_, _, values) = findTableColumn(content, columnIndex)
     return OrderedCollectionValue(values.map(::DynamicValue))
@@ -341,14 +341,13 @@ fun tableColumn(
  */
 @Name("tablecolumns")
 fun tableColumns(
-    @Name("of") @LikelyBody content: MarkdownContent,
+    @Name("of") @Body content: MarkdownContent,
 ): IterableValue<IterableValue<out OutputValue<*>>> {
     val table = findTable(content)
-    return table.columns
-        .mapIndexed { index, column ->
-            val (_, _, values) = getTableColumn(table, index + INDEX_STARTS_AT)
-            values.map(::DynamicValue).wrappedAsValue()
-        }.wrappedAsValue()
+    return List(table.columns.size) { index ->
+        val (_, _, values) = getTableColumn(table, index + INDEX_STARTS_AT)
+        values.map(::DynamicValue).wrappedAsValue()
+    }.wrappedAsValue()
 }
 
 /**

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Text.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Text.kt
@@ -9,6 +9,7 @@ import com.quarkdown.core.ast.quarkdown.inline.TextTransform
 import com.quarkdown.core.ast.quarkdown.inline.TextTransformData
 import com.quarkdown.core.function.library.module.QuarkdownModule
 import com.quarkdown.core.function.library.module.moduleOf
+import com.quarkdown.core.function.reflect.annotation.Body
 import com.quarkdown.core.function.reflect.annotation.LikelyBody
 import com.quarkdown.core.function.reflect.annotation.LikelyNamed
 import com.quarkdown.core.function.reflect.annotation.Name
@@ -48,7 +49,7 @@ val Text: QuarkdownModule =
  * @param className CSS class name to apply to the element, if supported by the renderer. None if not specified.
  */
 fun text(
-    text: InlineMarkdownContent,
+    @Body text: InlineMarkdownContent,
     @LikelyNamed size: TextTransformData.Size? = null,
     @LikelyNamed weight: TextTransformData.Weight? = null,
     @LikelyNamed style: TextTransformData.Style? = null,

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/internal/FunctionDefinition.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/internal/FunctionDefinition.kt
@@ -22,9 +22,15 @@ internal const val CUSTOM_FUNCTION_LIBRARY_NAME_PREFIX = "__func__"
 
 /**
  * Registers a custom user-defined function in [context], backing both [function] and [variable].
+ *
+ * This overload accepts already-typed [FunctionParameter]s and preserves them verbatim on the
+ * registered function. It is suited to callers that wrap an existing function and need to keep
+ * the original parameter types (e.g. `InlineMarkdownContent`), rather than collapse everything
+ * to [DynamicValue].
+ *
  * @param context context to register the function in
  * @param name name the function will be callable by
- * @param bodyParameters parameter definitions, typically derived from the body lambda's explicit parameters
+ * @param parameters typed function parameters, used as-is on the registered function
  * @param invoke executed when the function is called. Receives the originating [FunctionCall],
  *               a list of parameter-aligned argument values (with [NoneValue] for unbound optional ones),
  *               and the raw [ArgumentBindings] map
@@ -32,16 +38,9 @@ internal const val CUSTOM_FUNCTION_LIBRARY_NAME_PREFIX = "__func__"
 internal fun declareFunction(
     context: MutableContext,
     name: String,
-    bodyParameters: List<LambdaParameter>,
+    parameters: List<FunctionParameter<*>>,
     invoke: (call: FunctionCall<*>, args: List<Value<*>>, bindings: ArgumentBindings) -> OutputValue<*>,
 ) {
-    // Function parameters.
-    val parameters =
-        bodyParameters.mapIndexed { index, parameter ->
-            FunctionParameter(parameter.name, type = DynamicValue::class, index, parameter.isOptional)
-        }
-
-    // The custom function itself.
     val function =
         SimpleFunction(name, parameters) { bindings, call ->
             // Retrieving arguments from the function call.
@@ -50,8 +49,36 @@ internal fun declareFunction(
 
             invoke(call, args, bindings)
         }
+    context.loadLibrary(Library(CUSTOM_FUNCTION_LIBRARY_NAME_PREFIX + name, setOf(function)))
+}
 
-    // The function is registered and ready to be called.
-    val library = Library(CUSTOM_FUNCTION_LIBRARY_NAME_PREFIX + name, setOf(function))
-    context.loadLibrary(library)
+/**
+ * Registers a custom user-defined function in [context], backing both [function] and [variable].
+ *
+ * This overload accepts [LambdaParameter]s: each becomes a [DynamicValue]-typed [FunctionParameter],
+ * which is appropriate for user-authored `.function`/`.variable` bodies where arguments arrive
+ * as raw Quarkdown text and are evaluated by the user's lambda.
+ *
+ * @param context context to register the function in
+ * @param name name the function will be callable by
+ * @param bodyParameters parameter definitions, typically derived from the body lambda's explicit parameters
+ * @param invoke see the typed overload
+ */
+internal fun declareFunctionFromLambda(
+    context: MutableContext,
+    name: String,
+    bodyParameters: List<LambdaParameter>,
+    invoke: (call: FunctionCall<*>, args: List<Value<*>>, bindings: ArgumentBindings) -> OutputValue<*>,
+) {
+    val parameters =
+        bodyParameters.mapIndexed { index, parameter ->
+            FunctionParameter(
+                name = parameter.name,
+                type = DynamicValue::class,
+                index = index,
+                isOptional = parameter.isOptional,
+                isExplicitlyBody = parameter.isExplicitlyBody,
+            )
+        }
+    declareFunction(context, name, parameters, invoke)
 }

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/internal/FunctionExtension.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/internal/FunctionExtension.kt
@@ -55,7 +55,7 @@ internal fun extendFunction(
 
     context.markFunctionAsExtended(targetName)
 
-    declareFunction(context, targetName, lambdaParameters) { call, args, outerBindings ->
+    declareFunction(context, targetName, wrapperParameters) { call, args, outerBindings ->
         // `super` is exposed as a callable within the body: its explicit arguments override the outer call's bindings.
         val superFunction =
             SimpleFunction(SUPER_NAME, parameters = wrapperParameters) { overrides, _ ->

--- a/quarkdown-test/src/test/kotlin/com/quarkdown/test/HeadingTest.kt
+++ b/quarkdown-test/src/test/kotlin/com/quarkdown/test/HeadingTest.kt
@@ -228,6 +228,18 @@ class HeadingTest {
     }
 
     @Test
+    fun `heading primitive with body argument`() {
+        execute(
+            """
+            .heading depth:{3}
+                Hello
+            """.trimIndent(),
+        ) {
+            assertEquals("<h3>Hello</h3>", it)
+        }
+    }
+
+    @Test
     fun `heading primitive depth out of range`() {
         assertFailsWith<FunctionCallRuntimeException> {
             execute(".heading {Hello} depth:{0}") {}

--- a/quarkdown-test/src/test/kotlin/com/quarkdown/test/TextTest.kt
+++ b/quarkdown-test/src/test/kotlin/com/quarkdown/test/TextTest.kt
@@ -113,6 +113,21 @@ class TextTest {
     }
 
     @Test
+    fun `text with body argument`() {
+        execute(
+            """
+            .text size:{tiny} variant:{smallcaps}
+                small text
+            """.trimIndent(),
+        ) {
+            assertEquals(
+                "<span class=\"size-tiny\" style=\"font-variant: small-caps;\">small text</span>",
+                it,
+            )
+        }
+    }
+
+    @Test
     fun `subscript and superscript`() {
         execute("H{.text {2} script:{sub}}O is water. E = mc{.text {2} script:{sup}}") {
             assertEquals(


### PR DESCRIPTION
- [X] I have read the [contributing guidelines](https://github.com/iamgio/quarkdown/blob/main/CONTRIBUTING.md).
- [X] I have tested the changes locally.
- [ ] An issue for this change exists, and it was discussed with maintainers. This is required for new features and non-trivial changes. If present, append `Closes #ISSUE_NUMBER` at the end of this PR description.
- [ ] (Optional) I have added necessary documentation to [`docs`](https://github.com/iamgio/quarkdown/tree/main/docs) and [`CHANGELOG.md`](https://github.com/iamgio/quarkdown/blob/main/CHANGELOG.md)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for explicitly-designated body parameters in function calls, improving how `.text`, `.heading`, and other layout/stdlib functions bind block-style body arguments even when not last in the signature.
* **Bug Fixes**
  * Corrected body vs. positional/named binding rules, including reserved body parameters, and improved named-argument lookup performance.
* **Documentation**
  * Updated function-call syntax docs and changelog to reflect the new “body parameter” behavior.
* **Tests**
  * Added/expanded unit tests for positional, named, and body-argument binding, including `.text` and `.heading` body-argument rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->