### PR TITLE
feat(function): allow body in inline function calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,26 @@ Inline binding keeps working as before, so the following is still valid:
 
 Parameter lookup now performs a single pass over the arguments, improving performance.
 
+&nbsp;
+
+#### Body arguments for inline function calls
+
+Inline function calls now accept body arguments, just like block-level calls do. 
+
+The following is now valid:
+
+```markdown
+.heading depth:{1}
+    .text size:{large}
+        Content
+```
+
+Whereas previously, this was the only valid form:
+
+```markdown
+.heading {.text {Content} size:{large}} depth:{1}
+```
+
 ## [2.3.1] - 2026-06-23
 
 ### Added

--- a/docs/syntax-of-a-function-call.qd
+++ b/docs/syntax-of-a-function-call.qd
@@ -149,7 +149,7 @@ Paragraph 2
 
 ### The body argument
 
-The main difference between inline and block function calls is a special argument called **body argument**. This argument refers to the function's **body parameter**, which is usually the last one in the signature, although some functions designate a different parameter as their body (showing as *Likely body* in its documentation).
+Functions accept up to one **body argument**, which refers to the function's **body parameter**: usually the last one in the signature, although some functions designate a different parameter as their body (showing as *Likely body* in their documentation).
 
 A body argument expands over multiple lines, is not wrapped by brackets, and requires each line to be **indented** by at least two spaces or one tab:
 
@@ -180,23 +180,4 @@ Other functions, block or inline, can be nested inside body arguments:
         The document name is .docname      <!-- Inline -->
 
         .loremipsum                        <!-- Block  -->
-```
-
-### Body arguments and inline calls
-
-When nested inside inline arguments, function calls are always inline. Thus, the following is invalid since body arguments are accepted only in block calls:
-
-```markdown
-.center {
-    .row
-        Hi
-}
-```
-
-While this is valid as `.row` is called within a body argument:
-
-```markdown
-.center
-    .row
-        Hi
 ```

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/lexer/patterns/FunctionCallPatterns.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/lexer/patterns/FunctionCallPatterns.kt
@@ -31,7 +31,7 @@ class FunctionCallPatterns {
                     .withReference("name", FunctionCallGrammar.IDENTIFIER_PATTERN)
                     .build(),
             walker = { data, remaining ->
-                val result = FunctionCallWalkerParser(remaining, allowsBody = false).parse()
+                val result = FunctionCallWalkerParser(remaining, allowsBody = true).parse()
                 WalkedToken(
                     token = FunctionCallToken(data, isBlock = false, walkerResult = result),
                     charsConsumed = result.endIndex,

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/parser/walker/funcall/FunctionCallGrammar.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/parser/walker/funcall/FunctionCallGrammar.kt
@@ -34,8 +34,7 @@ import com.quarkdown.core.parser.walker.funcall.FunctionCallGrammar.Companion.ID
  * as they may represent Markdown content (argument type checking is performed in the function expansion stage of the pipeline instead, see [com.quarkdown.core.function.call.binding]).
  * In order to achieve context-awareness, this grammar is stateful and mutable, as it needs to know whether it is currently parsing the outer 'rigid' syntax or an argument.
  *
- * @param allowsBody whether the function call allows an indented body argument.
- *                   Generally, this is true for block functions, false for inline functions.
+ * @param allowsBody whether the function call allows an indented body argument
  */
 class FunctionCallGrammar(
     private val allowsBody: Boolean,

--- a/quarkdown-core/src/test/kotlin/com/quarkdown/core/LexerTest.kt
+++ b/quarkdown-core/src/test/kotlin/com/quarkdown/core/LexerTest.kt
@@ -331,9 +331,6 @@ class LexerTest {
         assertIs<LineBreakToken>(tokens.next())
         assertIs<PlainTextToken>(tokens.next())
         assertIs<FunctionCallToken>(tokens.next())
-        assertIs<LineBreakToken>(tokens.next())
-        assertIs<PlainTextToken>(tokens.next())
-        assertIs<LineBreakToken>(tokens.next())
         assertIs<PlainTextToken>(tokens.next())
         assertIs<LineBreakToken>(tokens.next())
         assertIs<PlainTextToken>(tokens.next())
@@ -348,10 +345,6 @@ class LexerTest {
         assertIs<PlainTextToken>(tokens.next())
         assertIs<LineBreakToken>(tokens.next())
         assertIs<FunctionCallToken>(tokens.next())
-        assertIs<LineBreakToken>(tokens.next())
-        assertIs<PlainTextToken>(tokens.next())
-        assertIs<LineBreakToken>(tokens.next())
-        assertIs<PlainTextToken>(tokens.next())
 
         assertFalse(tokens.hasNext())
     }

--- a/quarkdown-lsp/src/main/kotlin/com/quarkdown/lsp/tokenizer/FunctionCallTokenizer.kt
+++ b/quarkdown-lsp/src/main/kotlin/com/quarkdown/lsp/tokenizer/FunctionCallTokenizer.kt
@@ -14,6 +14,7 @@ private const val FUNCTION_CALL_ARGUMENT_CONTENT_TOKEN_NAME = "argContent"
 private const val FUNCTION_CALL_INLINE_ARGUMENT_BEGIN_TOKEN_NAME = "argumentBegin"
 private const val FUNCTION_CALL_INLINE_ARGUMENT_END_TOKEN_NAME = "argumentEnd"
 private const val FUNCTION_CALL_INLINE_ARGUMENT_CONTENT_TOKEN_NAME = "argContent"
+private const val FUNCTION_CALL_BODY_ARGUMENT_CONTENT_TOKEN_NAME = "bodyArgContent"
 private const val FUNCTION_CALL_LINE_CONTINUATION_TOKEN_NAME = "lineContinuation"
 
 /**
@@ -59,8 +60,11 @@ class FunctionCallTokenizer {
                             .mapNotNull { match ->
                                 val start = token.data.position.first + match.offset
 
-                                // Enqueuing the tokenization of function call arguments.
-                                if (match.type.name == FUNCTION_CALL_ARGUMENT_CONTENT_TOKEN_NAME) {
+                                // Enqueuing the tokenization of function call arguments,
+                                // including both inline (`{...}`) and indented body arguments.
+                                if (match.type.name == FUNCTION_CALL_ARGUMENT_CONTENT_TOKEN_NAME ||
+                                    match.type.name == FUNCTION_CALL_BODY_ARGUMENT_CONTENT_TOKEN_NAME
+                                ) {
                                     tokenizationQueue += start to match.text
                                 }
 

--- a/quarkdown-lsp/src/test/kotlin/com/quarkdown/lsp/FunctionCallTokenizerTest.kt
+++ b/quarkdown-lsp/src/test/kotlin/com/quarkdown/lsp/FunctionCallTokenizerTest.kt
@@ -162,6 +162,23 @@ class FunctionCallTokenizerTest {
     }
 
     @Test
+    fun `function calls inside body arguments`() {
+        val text =
+            """
+            .outer
+                .inner {arg}
+            """.trimIndent()
+        val calls = tokenizer.getFunctionCalls(text)
+
+        val functionNames =
+            calls.flatMap { call ->
+                call.tokens.filter { it.type == FunctionCallToken.Type.FUNCTION_NAME }.map { it.lexeme }
+            }
+        assertTrue("outer" in functionNames)
+        assertTrue("inner" in functionNames, "nested call inside body was not recognized")
+    }
+
+    @Test
     fun `multiple function calls in text`() {
         val text = "Text .function1 {arg1} more text .function2 param:{value}"
         val calls = tokenizer.getFunctionCalls(text)


### PR DESCRIPTION
- [X] I have read the [contributing guidelines](https://github.com/iamgio/quarkdown/blob/main/CONTRIBUTING.md).
- [X] I have tested the changes locally.
- [ ] An issue for this change exists, and it was discussed with maintainers. This is required for new features and non-trivial changes. If present, append `Closes #ISSUE_NUMBER` at the end of this PR description.
- [ ] (Optional) I have added necessary documentation to [`docs`](https://github.com/iamgio/quarkdown/tree/main/docs) and [`CHANGELOG.md`](https://github.com/iamgio/quarkdown/blob/main/CHANGELOG.md)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Inline function calls can now include a body argument, matching block-level call behavior.
  * Function calls nested inside body arguments are now recognized during tokenization.

* **Documentation**
  * Updated function-call syntax docs and the unreleased changelog to clarify the “up to one body argument” rule, including an updated example.

* **Tests**
  * Adjusted lexer/tokenizer expectations for the updated inline parsing behavior.
  * Added coverage for nested function calls inside body arguments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->