### PR TITLE
feat(stdlib): add .match function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 ## [Unreleased]
 
+### Added
+
+&nbsp;
+
+#### [Regex match](https://quarkdown.com/wiki/regex-match)
+
+The new `.match` function finds every substring of inline content that matches a regular expression and replaces each match with the inline content produced by a lambda.
+
+```markdown
+.match {Quarkdown takes its name from quarks} pattern:{[Qq]uark(down|s)?}
+    **.1**
+```
+
+Output:
+
+> **Quarkdown** takes its name from **quarks**
+
+Matches are searched within plain text leaves only, so existing inline structure such as links, emphasis, and code spans is preserved around them. The lambda receives the matched substring as its single argument, available as `.1` (or via a named parameter), and returns the inline content to insert in its place.
+
+&nbsp;
+
 ### Changed
 
 &nbsp;

--- a/docs/_nav.qd
+++ b/docs/_nav.qd
@@ -93,6 +93,7 @@
 - [Mermaid diagrams](mermaid-diagrams.qd)
 
 ###! Text & code
+- [Regex-based styling](regex-match.qd)
 - [Advanced text formatting](text.qd)
 - [Advanced code block](code.qd)
 - [Explicit line breaks](line-breaks.qd)

--- a/docs/regex-match.qd
+++ b/docs/regex-match.qd
@@ -1,0 +1,42 @@
+.docname {Regex-based styling}
+.include {docs}
+
+The **`.match {content} {pattern} {replacement}`** .docslink {quarkdown-stdlib/com.quarkdown.stdlib.module.Text/match.html} function:
+1. finds every substring of inline content that matches a regular expression,
+2. replaces each match with the inline content produced by a [lambda](lambda.qd).
+
+## Basic example
+
+.examplemirror
+    .match {Quarkdown takes its name from quarks} pattern:{[Qq]uark(down|s)?}
+        match:
+        ***.match***
+
+The lambda runs once per matched substring, with its argument referring to the matched text.
+
+.examplemirror prelude:{Using the implicit `\.1` instead of a named parameter:}
+    .match {Hello, world} pattern:{world}
+        ***.1***
+
+## Chained call
+
+`.match` works naturally in a [chain](syntax-of-a-function-call.qd), since `content` is its first parameter.
+
+.examplemirror
+    .var {greeting} {Hello, world}
+
+    .greeting::match {world}
+        **.1**
+
+## Inside a function extension
+
+A common use case is rewriting a function's output through a regex transformation. For example, you can extend `.heading` so every occurrence of certain words is highlighted across all headings in the document:
+
+.examplemirror
+    .extend {heading}
+        content:
+        .super
+            .content::match {[Qq]uark(down|s)?}
+                *.1::uppercase*
+
+    ###! Quarkdown takes its name from quarks

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Text.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Text.kt
@@ -1,5 +1,6 @@
 package com.quarkdown.stdlib
 
+import com.quarkdown.core.ast.InlineContent
 import com.quarkdown.core.ast.InlineMarkdownContent
 import com.quarkdown.core.ast.base.block.Code
 import com.quarkdown.core.ast.base.inline.CodeSpan
@@ -13,12 +14,15 @@ import com.quarkdown.core.function.reflect.annotation.Body
 import com.quarkdown.core.function.reflect.annotation.LikelyBody
 import com.quarkdown.core.function.reflect.annotation.LikelyNamed
 import com.quarkdown.core.function.reflect.annotation.Name
+import com.quarkdown.core.function.value.InlineMarkdownContentValue
 import com.quarkdown.core.function.value.NodeValue
 import com.quarkdown.core.function.value.data.EvaluableString
+import com.quarkdown.core.function.value.data.Lambda
 import com.quarkdown.core.function.value.data.Range
 import com.quarkdown.core.function.value.wrappedAsValue
 import com.quarkdown.core.misc.color.Color
 import com.quarkdown.core.util.node.toPlainText
+import com.quarkdown.stdlib.internal.replaceMatches
 
 /**
  * `Text` stdlib module exporter.
@@ -30,6 +34,7 @@ val Text: QuarkdownModule =
         ::lineBreak,
         ::code,
         ::codeSpan,
+        ::match,
         ::loremIpsum,
     )
 
@@ -137,6 +142,62 @@ fun code(
  */
 @Name("codespan")
 fun codeSpan(text: String) = CodeSpan(text).wrappedAsValue()
+
+/**
+ * Finds every substring of [content] that matches the regular expression [pattern]
+ * and replaces each match with the inline content produced by [replacement].
+ *
+ * Matches are searched within plain text leaves only: existing inline structure
+ * (links, emphasis, code spans, transformed text, etc.) is preserved around the matches.
+ *
+ * The [replacement] lambda receives the matched substring as its single argument
+ * and returns inline content to insert in its place. If [pattern] is empty,
+ * [content] is returned unchanged.
+ *
+ * Example:
+ *
+ * ```
+ * .match {Quarkdown takes its name from quarks} pattern:{[Qq]uark(down|s)?}
+ *     match:
+ *     **.match**
+ * ```
+ *
+ * Output:
+ *
+ * > **Quarkdown** takes its name from **quarks**
+ *
+ * @param content inline content to scan for matches
+ * @param pattern regular expression to match
+ * @param replacement lambda invoked with each matched substring,
+ *                    producing the inline content that replaces it
+ * @return [content] with every match of [pattern] replaced by the output of [replacement]
+ * @throws IllegalArgumentException if [pattern] is not a valid regular expression
+ */
+fun match(
+    content: InlineMarkdownContent,
+    pattern: String,
+    @Body replacement: Lambda,
+): NodeValue {
+    val regex =
+        try {
+            pattern.toRegex()
+        } catch (e: Exception) {
+            throw IllegalArgumentException("Invalid regular expression: $pattern", e)
+        }
+
+    val replacementAction: (String) -> InlineContent = { matched ->
+        replacement
+            .invoke<InlineMarkdownContent, InlineMarkdownContentValue>(
+                matched.wrappedAsValue(),
+            ).unwrappedValue.children
+    }
+    val children =
+        when {
+            pattern.isEmpty() -> content.children
+            else -> content.children.flatMap { it.replaceMatches(regex, replacementAction) }
+        }
+    return InlineMarkdownContent(children).wrappedAsValue()
+}
 
 /**
  * @return a fixed Lorem Ipsum text.

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/internal/RegexMatch.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/internal/RegexMatch.kt
@@ -1,0 +1,52 @@
+package com.quarkdown.stdlib.internal
+
+import com.quarkdown.core.ast.InlineContent
+import com.quarkdown.core.ast.Node
+import com.quarkdown.core.ast.base.TextNode
+import com.quarkdown.core.ast.base.inline.Text
+import com.quarkdown.core.ast.rewriter.withChildren
+
+/**
+ * Recursively walks this node and returns the equivalent inline content where every substring matching [regex]
+ * found within plain [Text] leaves is replaced by the output of [replacement].
+ *
+ * Non-text children are returned unchanged. [TextNode]s are descended into, preserving their structure
+ * around the transformed inner content.
+ *
+ * @param regex pattern to match in plain text leaves
+ * @param replacement maps each matched substring to the inline content that should replace it
+ * @return inline content with matches replaced
+ */
+internal fun Node.replaceMatches(
+    regex: Regex,
+    replacement: (String) -> InlineContent,
+): InlineContent =
+    when (this) {
+        is Text -> this.text.replaceMatches(regex, replacement)
+        is TextNode -> listOf(this.withChildren(this.text.flatMap { it.replaceMatches(regex, replacement) }))
+        else -> listOf(this)
+    }
+
+/**
+ * Splits this string around matches of [regex] and produces inline content where each match is replaced
+ * by [replacement] and the surrounding segments are wrapped in plain [Text] nodes.
+ *
+ * Returns a singleton list containing the original string as a [Text] node if no matches are found.
+ */
+private fun String.replaceMatches(
+    regex: Regex,
+    replacement: (String) -> InlineContent,
+): InlineContent =
+    buildList {
+        var cursor = 0
+        for (match in regex.findAll(this@replaceMatches)) {
+            if (match.range.first > cursor) {
+                add(Text(substring(cursor, match.range.first)))
+            }
+            addAll(replacement(match.value))
+            cursor = match.range.last + 1
+        }
+        if (cursor < length) {
+            add(Text(substring(cursor)))
+        }
+    }

--- a/quarkdown-stdlib/src/test/kotlin/com/quarkdown/stdlib/MatchTest.kt
+++ b/quarkdown-stdlib/src/test/kotlin/com/quarkdown/stdlib/MatchTest.kt
@@ -1,0 +1,161 @@
+package com.quarkdown.stdlib
+
+import com.quarkdown.core.assertNodeEquals
+import com.quarkdown.core.ast.InlineMarkdownContent
+import com.quarkdown.core.ast.dsl.buildInline
+import com.quarkdown.core.ast.quarkdown.inline.TextTransform
+import com.quarkdown.core.ast.quarkdown.inline.TextTransformData
+import com.quarkdown.core.attachMockPipeline
+import com.quarkdown.core.context.MutableContext
+import com.quarkdown.core.flavor.quarkdown.QuarkdownFlavor
+import com.quarkdown.core.function.value.DynamicValue
+import com.quarkdown.core.function.value.data.Lambda
+import com.quarkdown.core.function.value.data.LambdaParameter
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+
+/**
+ * Tests for the `.match` function.
+ */
+class MatchTest {
+    private val context = MutableContext(QuarkdownFlavor)
+
+    @BeforeTest
+    fun setup() {
+        context.attachMockPipeline()
+    }
+
+    /**
+     * @return a lambda that wraps each matched substring in bold inline Markdown,
+     *         producing a `Strong` node around the match
+     */
+    private fun strongLambda(): Lambda =
+        Lambda(context, explicitParameters = listOf(LambdaParameter("m"))) { args, _ ->
+            val matched = args.first().unwrappedValue.toString()
+            DynamicValue("**$matched**")
+        }
+
+    @Test
+    fun `empty content`() {
+        val content = InlineMarkdownContent(emptyList())
+        val result = match(content, "test", strongLambda()).unwrappedValue
+        assertNodeEquals(content, result)
+    }
+
+    @Test
+    fun `empty pattern`() {
+        val content = InlineMarkdownContent(buildInline { text("Hello") })
+        val result = match(content, "", strongLambda()).unwrappedValue
+        assertNodeEquals(content, result)
+    }
+
+    @Test
+    fun `no match`() {
+        val content = InlineMarkdownContent(buildInline { text("Hello") })
+        val result = match(content, "xyz", strongLambda()).unwrappedValue
+        assertNodeEquals(content, result)
+    }
+
+    @Test
+    fun `single match`() {
+        val content = InlineMarkdownContent(buildInline { text("Hello") })
+        val expected =
+            InlineMarkdownContent(
+                buildInline {
+                    text("He")
+                    strong { text("llo") }
+                },
+            )
+        val result = match(content, "llo", strongLambda()).unwrappedValue
+        assertNodeEquals(expected, result)
+    }
+
+    @Test
+    fun `multiple matches`() {
+        val content = InlineMarkdownContent(buildInline { text("Hey hello hey hello") })
+        val expected =
+            InlineMarkdownContent(
+                buildInline {
+                    text("Hey ")
+                    strong { text("hello") }
+                    text(" hey ")
+                    strong { text("hello") }
+                },
+            )
+        val result = match(content, "hello", strongLambda()).unwrappedValue
+        assertNodeEquals(expected, result)
+    }
+
+    @Test
+    fun `regex match`() {
+        val content = InlineMarkdownContent(buildInline { text("abc123def") })
+        val expected =
+            InlineMarkdownContent(
+                buildInline {
+                    text("abc")
+                    strong { text("123") }
+                    text("def")
+                },
+            )
+        val result = match(content, "\\d+", strongLambda()).unwrappedValue
+        assertNodeEquals(expected, result)
+    }
+
+    @Test
+    fun `rich content preserved`() {
+        val content =
+            InlineMarkdownContent(
+                buildInline {
+                    text("Hello ")
+                    emphasis { text("world") }
+                    text(" and ")
+                    +TextTransform(
+                        TextTransformData(variant = TextTransformData.Variant.SMALL_CAPS),
+                        text = buildInline { text("world") },
+                    )
+                },
+            )
+        val expected =
+            InlineMarkdownContent(
+                buildInline {
+                    text("Hello ")
+                    emphasis {
+                        text("wo")
+                        strong { text("rl") }
+                        text("d")
+                    }
+                    text(" and ")
+                    +TextTransform(
+                        TextTransformData(variant = TextTransformData.Variant.SMALL_CAPS),
+                        text =
+                            buildInline {
+                                text("wo")
+                                strong { text("rl") }
+                                text("d")
+                            },
+                    )
+                },
+            )
+        val result = match(content, "rl", strongLambda()).unwrappedValue
+        assertNodeEquals(expected, result)
+    }
+
+    @Test
+    fun `lambda controls replacement node`() {
+        val content = InlineMarkdownContent(buildInline { text("Hello world") })
+        val emphasisLambda =
+            Lambda(context, explicitParameters = listOf(LambdaParameter("m"))) { args, _ ->
+                val matched = args.first().unwrappedValue.toString()
+                DynamicValue("_${matched.uppercase()}_")
+            }
+        val expected =
+            InlineMarkdownContent(
+                buildInline {
+                    text("Hello ")
+                    emphasis { text("WORLD") }
+                },
+            )
+        val result = match(content, "world", emphasisLambda).unwrappedValue
+        assertNodeEquals(expected, result)
+    }
+}

--- a/quarkdown-test/src/test/kotlin/com/quarkdown/test/MatchTest.kt
+++ b/quarkdown-test/src/test/kotlin/com/quarkdown/test/MatchTest.kt
@@ -1,0 +1,95 @@
+package com.quarkdown.test
+
+import com.quarkdown.test.util.execute
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Tests for the `.match` stdlib function in real-pipeline scenarios.
+ */
+class MatchTest {
+    @Test
+    fun `match at block level`() {
+        execute(
+            """
+            .match {This is a test document for testing some text matching features} {te[xs]t(ing)?}
+                match:
+                *.match::uppercase*
+            """.trimIndent(),
+        ) {
+            assertEquals(
+                "This is a <em>TEST</em> document for <em>TESTING</em>" +
+                    " some <em>TEXT</em> matching features",
+                it,
+            )
+        }
+    }
+
+    @Test
+    fun `match in extend body without super`() {
+        execute(
+            """
+            .extend {heading}
+                content:
+                .content::match {te[xs]t(ing)?}
+                    *.1::uppercase*
+
+            #### This is a test for testing some text features
+            """.trimIndent(),
+        ) {
+            assertEquals(
+                "This is a <em>TEST</em> for <em>TESTING</em> some <em>TEXT</em> features",
+                it,
+            )
+        }
+    }
+
+    @Test
+    fun `match inside heading extension`() {
+        execute(
+            """
+            .extend {heading}
+                content:
+                .super
+                    .content::match {te[xs]t(ing)?}
+                        *.1::uppercase*
+
+            #### This is a test document for testing some text matching features
+            """.trimIndent(),
+        ) {
+            assertEquals(
+                "<h4>This is a <em>TEST</em> document for <em>TESTING</em>" +
+                    " some <em>TEXT</em> matching features</h4>",
+                it,
+            )
+        }
+    }
+
+    @Test
+    fun `match inside heading extension nested in user function`() {
+        execute(
+            """
+            .function {myfunction}
+                content:
+                .container
+                    .content
+
+            .myfunction
+                .extend {heading}
+                    content:
+                    .super
+                        .content::match {[Qq]uark(down|s)?}
+                            *.1::uppercase*
+
+                ###! Quarkdown takes its name from quarks
+            """.trimIndent(),
+        ) {
+            assertEquals(
+                "<div class=\"container\">" +
+                    "<h3 data-decorative=\"\"><em>QUARKDOWN</em> takes its name from <em>QUARKS</em></h3>" +
+                    "</div>",
+                it,
+            )
+        }
+    }
+}


### PR DESCRIPTION
- [X] I have read the [contributing guidelines](https://github.com/iamgio/quarkdown/blob/main/CONTRIBUTING.md).
- [X] I have tested the changes locally.
- [ ] An issue for this change exists, and it was discussed with maintainers. This is required for new features and non-trivial changes. If present, append `Closes #ISSUE_NUMBER` at the end of this PR description.
- [ ] (Optional) I have added necessary documentation to [`docs`](https://github.com/iamgio/quarkdown/tree/main/docs) and [`CHANGELOG.md`](https://github.com/iamgio/quarkdown/blob/main/CHANGELOG.md)

Closes #438

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced the inline **`.match`** function to find regex matches in plain-text portions and replace each match via a lambda (matched text passed in), preserving surrounding inline structure such as links, emphasis, and code spans.
* **Documentation**
  * Added documentation and a new navigation entry for **regex-based styling**, including examples and chaining/extension usage.
* **Tests**
  * Added unit and integration coverage for empty inputs, no-match cases, single/multiple replacements, regex matching, and rich inline content preservation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->