### PR TITLE
fix(ci): add OCI index-level annotations and preserve Dockerfile labels

### DIFF
--- a/.github/workflows/gradle-deploy.yml
+++ b/.github/workflows/gradle-deploy.yml
@@ -197,6 +197,14 @@ jobs:
           type=semver,pattern={{version}}
           type=semver,pattern={{major}}.{{minor}}
           type=semver,pattern={{major}}
+        labels: |
+          org.opencontainers.image.licenses=GPL-3.0-only AND AGPL-3.0-only
+        annotations: |
+          org.opencontainers.image.title=Quarkdown Docker image
+          org.opencontainers.image.description=Versatile Markdown-based typsetting system.
+          org.opencontainers.image.url=https://quarkdown.com
+      env:
+        DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest,index
 
     - name: Build and push Docker image
       uses: docker/build-push-action@v7
@@ -206,6 +214,7 @@ jobs:
         platforms: linux/amd64
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
+        annotations: ${{ steps.meta.outputs.annotations }}
 
   dependency-submission:
 

--- a/.github/workflows/gradle-deploy.yml
+++ b/.github/workflows/gradle-deploy.yml
@@ -201,7 +201,7 @@ jobs:
           org.opencontainers.image.licenses=GPL-3.0-only AND AGPL-3.0-only
         annotations: |
           org.opencontainers.image.title=Quarkdown Docker image
-          org.opencontainers.image.description=Versatile Markdown-based typsetting system.
+          org.opencontainers.image.description=Versatile Markdown-based typesetting system.
           org.opencontainers.image.url=https://quarkdown.com
       env:
         DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest,index

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ ENTRYPOINT ["quarkdown"]
 
 LABEL org.opencontainers.image.vendor="Quarkdown"
 LABEL org.opencontainers.image.title="Quarkdown Docker image"
-LABEL org.opencontainers.image.description="Versatile Markdown-based typsetting system."
+LABEL org.opencontainers.image.description="Versatile Markdown-based typesetting system."
 LABEL org.opencontainers.image.authors="Giorgio Garofalo (iamgio) <info@quarkdown.com>"
 LABEL org.opencontainers.image.url="https://quarkdown.com"
 LABEL org.opencontainers.image.source="https://github.com/iamgio/quarkdown"


### PR DESCRIPTION
- [X] I have read the [contributing guidelines](https://github.com/iamgio/quarkdown/blob/main/CONTRIBUTING.md).
- [X] I have tested the changes locally.
- [ ] An issue for this change exists, and it was discussed with maintainers. This is required for new features and non-trivial changes. If present, append `Closes #ISSUE_NUMBER` at the end of this PR description.
- [ ] (Optional) I have added necessary documentation to [`docs`](https://github.com/iamgio/quarkdown/tree/main/docs) and [`CHANGELOG.md`](https://github.com/iamgio/quarkdown/blob/main/CHANGELOG.md)

---

### Summary

Fixes two issues with the Docker image build workflow:
1. Dockerfile `LABEL` values being overwritten by `docker/metadata-action` defaults
2. ghcr.io package description not showing due to missing OCI index-level annotations

### Changes

- **`labels` input**: Added override for `org.opencontainers.image.licenses` to preserve the Dockerfile value (`GPL-3.0-only AND AGPL-3.0-only`) instead of the metadata-action default (`GPL-3.0`)
- **`annotations` input**: Set `title`, `description`, `url` so annotations match the Dockerfile values
- **`DOCKER_METADATA_ANNOTATIONS_LEVELS`**: Set to `manifest,index` so annotations are emitted at both levels (ghcr.io requires index-level)
- **`annotations` in build step**: Pass `${{ steps.meta.outputs.annotations }}` to `docker/build-push-action`

### Before vs After

| Label | Before (v2.3.1) | After (v2.3.5) |
|-------|-----------------|----------------|
| `licenses` | GPL-3.0 | **GPL-3.0-only AND AGPL-3.0-only** |
| ghcr.io description | Empty | **Shows correctly** |

### Testing

- Verified `licenses` label matches Dockerfile value for the images built.
- ghcr.io description now displays for newer images


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the Docker publish pipeline to emit standardized OCI image metadata (licenses, title, description, and URL) and apply the generated annotations during image build/push.
* **Bug Fixes**
  * Corrected a misspelling in the Docker image’s description label to ensure accurate image metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->