### PR TITLE
refactor: add InlineMarkdownContent.wrappedAsValue()

### DIFF
--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/base/block/Heading.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/base/block/Heading.kt
@@ -13,10 +13,10 @@ import com.quarkdown.core.ast.base.TextNode
 import com.quarkdown.core.ast.quarkdown.reference.CrossReferenceableNode
 import com.quarkdown.core.function.call.FunctionCallArgument
 import com.quarkdown.core.function.value.BooleanValue
-import com.quarkdown.core.function.value.InlineMarkdownContentValue
 import com.quarkdown.core.function.value.NoneValue
 import com.quarkdown.core.function.value.NumberValue
 import com.quarkdown.core.function.value.StringValue
+import com.quarkdown.core.function.value.wrappedAsValue
 import com.quarkdown.core.visitor.node.NodeVisitor
 
 /**
@@ -68,10 +68,7 @@ class Heading(
     override fun toFunctionCall() =
         "heading" to
             listOf(
-                FunctionCallArgument(
-                    name = "content",
-                    expression = InlineMarkdownContentValue(InlineMarkdownContent(text)),
-                ),
+                FunctionCallArgument(name = "content", expression = InlineMarkdownContent(text).wrappedAsValue()),
                 FunctionCallArgument(name = "depth", expression = NumberValue(depth)),
                 FunctionCallArgument(name = "ref", expression = referenceId?.let(::StringValue) ?: NoneValue),
                 FunctionCallArgument(name = "numbered", expression = BooleanValue(canTrackLocation)),

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/function/value/MarkdownContentValue.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/function/value/MarkdownContentValue.kt
@@ -44,3 +44,8 @@ data class InlineMarkdownContentValue(
      */
     fun asNodeValue(): NodeValue = NodeValue(unwrappedValue)
 }
+
+/**
+ * @return [this] inline Markdown content wrapped into a [InlineMarkdownContentValue]
+ */
+fun InlineMarkdownContent.wrappedAsValue() = InlineMarkdownContentValue(this)

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Text.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Text.kt
@@ -196,7 +196,7 @@ fun match(
             pattern.isEmpty() -> content.children
             else -> content.children.flatMap { it.replaceMatches(regex, replacementAction) }
         }
-    return InlineMarkdownContent(children).wrappedAsValue()
+    return NodeValue(InlineMarkdownContent(children))
 }
 
 /**

--- a/quarkdown-test/src/test/kotlin/com/quarkdown/test/primitive/HeadingPrimitiveFunctionTest.kt
+++ b/quarkdown-test/src/test/kotlin/com/quarkdown/test/primitive/HeadingPrimitiveFunctionTest.kt
@@ -5,9 +5,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 
 /**
- * Tests for `.extend` applied to Markdown headings via the [com.quarkdown.core.ast.attributes.primitive.PrimitiveFunctionBackedNode]
- * mechanism, exercising every parameter the [com.quarkdown.core.ast.base.block.Heading] node materializes
- * into the backing `heading` function call.
+ * Tests for `.extend` applied to Markdown headings.
  */
 class HeadingPrimitiveFunctionTest {
     @Test


### PR DESCRIPTION
- [X] I have read the [contributing guidelines](https://github.com/iamgio/quarkdown/blob/main/CONTRIBUTING.md).
- [X] I have tested the changes locally.
- [ ] An issue for this change exists, and it was discussed with maintainers. This is required for new features and non-trivial changes. If present, append `Closes #ISSUE_NUMBER` at the end of this PR description.
- [ ] (Optional) I have added necessary documentation to [`docs`](https://github.com/iamgio/quarkdown/tree/main/docs) and [`CHANGELOG.md`](https://github.com/iamgio/quarkdown/blob/main/CHANGELOG.md)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal handling of inline markdown content wrapping so heading and text operations produce the same results as before.
  * Added a convenience wrapper for inline markdown content values to standardize how they’re created.
* **Tests**
  * Refreshed the wording in heading primitive test documentation to better match the existing `.extend` coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->