### PR TITLE
refactor: move primitive wrapping from parsing to new rewrite stage

### DIFF
--- a/docs/_nav.qd
+++ b/docs/_nav.qd
@@ -148,6 +148,7 @@
   - [Lexing](pipeline---lexing.qd)
   - [Parsing](pipeline---parsing.qd)
   - [Function call expansion](pipeline---function-call-expansion.qd)
+  - [Tree rewrite](pipeline---tree-rewrite.qd)
   - [Tree traversal](pipeline---tree-traversal.qd)
   - [Rendering](pipeline---rendering.qd)
   - [Post-rendering](pipeline---post-rendering.qd)

--- a/docs/pipeline---tree-rewrite.qd
+++ b/docs/pipeline---tree-rewrite.qd
@@ -1,0 +1,12 @@
+.docname {Pipeline - Tree rewrite}
+.include {docs}
+
+> Main packages: .repolink {`core.ast.iterator`} {tree/main/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/iterator}, .repolink {`core.pipeline.stages`} {tree/main/quarkdown-core/src/main/kotlin/com/quarkdown/core/pipeline/stages}
+
+Once the queued function calls have been [expanded](pipeline---function-call-expansion.qd), the AST is rewritten in place to apply any show-rules via user-defined [extensions](extending-functions.qd).
+
+Several built-in nodes, such as [headings](headings.qd), are *primitive function-backed*: the stdlib exposes functions whose parameters mirror the node's properties. Whenever an `.extend` wrapper is registered for that name, every occurrence of the primitive must be routed through the wrapper.
+
+The tree rewrite stage walks the AST depth-first and, for each primitive whose backing function has been extended, replaces the node with an equivalent function call.
+
+As an optimization, the whole stage is skipped when no extension is registered in the document, which is the common case.

--- a/docs/pipeline.qd
+++ b/docs/pipeline.qd
@@ -6,9 +6,10 @@ When you supply an input file to Quarkdown, it undergoes a process of elaboratio
 1. [**Lexing**](pipeline---lexing.qd)
 2. [**Parsing**](pipeline---parsing.qd)
 3. [**Function call expansion**](pipeline---function-call-expansion.qd)
-4. [**Tree traversal**](pipeline---tree-traversal.qd)
-5. [**Rendering**](pipeline---rendering.qd)
-6. [**Post-rendering**](pipeline---post-rendering.qd)
+4. [**Tree rewrite**](pipeline---tree-rewrite.qd)
+5. [**Tree traversal**](pipeline---tree-traversal.qd)
+6. [**Rendering**](pipeline---rendering.qd)
+7. [**Post-rendering**](pipeline---post-rendering.qd)
 
 
 

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/attributes/primitive/PrimitiveFunctionBackedNode.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/attributes/primitive/PrimitiveFunctionBackedNode.kt
@@ -1,54 +1,30 @@
 package com.quarkdown.core.ast.attributes.primitive
 
 import com.quarkdown.core.ast.Node
-import com.quarkdown.core.ast.quarkdown.FunctionCallNode
-import com.quarkdown.core.context.MutableContext
 import com.quarkdown.core.function.call.FunctionCallArgument
 
 /**
- * A node backed by a primitive function: the node is wrapped into a call to
- * that function, so any `.extend` registered for the function name is applied to the node's rendering.
+ * A node backed by a primitive function: the node can be wrapped into a call to that function,
+ * so any `.extend` registered for the function name is applied to the node's rendering.
  *
  * For example, a `Heading` is backed by `.heading`, so wrapping `.extend {heading}` affects both
  * `.heading {...}` calls and Markdown `#` syntax. See stdlib's `Primitives` module for more primitive functions.
  *
- * The wrapped call carries the original node as its delegator, allowing the expander to skip the
- * function-call machinery entirely when no extension is registered for the backing function.
+ * The wrapping is performed by [com.quarkdown.core.ast.iterator.AstRewriter] during the
+ * [com.quarkdown.core.pipeline.stages.TreeRewriteStage], and only happens when the backing
+ * function has actually been extended.
  *
- * @see com.quarkdown.core.pipeline.stages.ParsingStage
+ * @see com.quarkdown.core.pipeline.stages.TreeRewriteStage
  */
 interface PrimitiveFunctionBackedNode : Node {
     /**
-     * Materializes this node's properties into the arguments of the backing function call.
-     * Argument names must match the parameter names of the function identified by name.
-     * @return a pair of the function name, from a loaded library, and a list of arguments to call it with
+     * The name of the function that backs this node, from a loaded library.
      */
-    fun toFunctionCall(): Pair<String, List<FunctionCallArgument>>
-}
+    val backingFunctionName: String
 
-/**
- * If [this] node is a [PrimitiveFunctionBackedNode], returns a [FunctionCallNode] that wraps it
- * (with the original node as its delegator) and registers the call on [context] for later expansion;
- * otherwise returns [this] unchanged.
- *
- * Called from every spot that produces freshly parsed nodes so that primitive wrapping reaches
- * nested content too (e.g. a heading inside a blockquote or list), not just top-level children.
- *
- * @param context context that the new call is parsed under and registered for expansion in
- * @param isBlock whether the wrap is being applied within a block-level parse, carried into the
- *                resulting [FunctionCallNode] so the expander picks the right value->node mapper
- */
-internal fun Node.wrapIfPrimitive(
-    context: MutableContext,
-    isBlock: Boolean,
-): Node {
-    if (this !is PrimitiveFunctionBackedNode) return this
-    val (name, arguments) = toFunctionCall()
-    return FunctionCallNode(
-        context = context,
-        name = name,
-        arguments = arguments,
-        isBlock = isBlock,
-        delegator = this,
-    ).also(context::register)
+    /**
+     * Materializes this node's properties into the arguments of the backing function call.
+     * Argument names must match the parameter names of the function identified by [backingFunctionName].
+     */
+    fun toFunctionCallArguments(): List<FunctionCallArgument>
 }

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/base/block/Heading.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/base/block/Heading.kt
@@ -65,16 +65,18 @@ class Heading(
     override val referenceId: String?
         get() = this.customId
 
-    override fun toFunctionCall() =
-        "heading" to
-            listOf(
-                FunctionCallArgument(name = "content", expression = InlineMarkdownContent(text).wrappedAsValue()),
-                FunctionCallArgument(name = "depth", expression = NumberValue(depth)),
-                FunctionCallArgument(name = "ref", expression = referenceId?.let(::StringValue) ?: NoneValue),
-                FunctionCallArgument(name = "numbered", expression = BooleanValue(canTrackLocation)),
-                FunctionCallArgument(name = "indexed", expression = BooleanValue(!excludeFromTableOfContents)),
-                FunctionCallArgument(name = "breakpage", expression = BooleanValue(canBreakPage)),
-            )
+    override val backingFunctionName: String
+        get() = "heading"
+
+    override fun toFunctionCallArguments() =
+        listOf(
+            FunctionCallArgument(name = "content", expression = InlineMarkdownContent(text).wrappedAsValue()),
+            FunctionCallArgument(name = "depth", expression = NumberValue(depth)),
+            FunctionCallArgument(name = "ref", expression = referenceId?.let(::StringValue) ?: NoneValue),
+            FunctionCallArgument(name = "numbered", expression = BooleanValue(canTrackLocation)),
+            FunctionCallArgument(name = "indexed", expression = BooleanValue(!excludeFromTableOfContents)),
+            FunctionCallArgument(name = "breakpage", expression = BooleanValue(canBreakPage)),
+        )
 
     companion object {
         /**

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/iterator/AstIterator.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/iterator/AstIterator.kt
@@ -1,14 +1,18 @@
 package com.quarkdown.core.ast.iterator
 
-import com.quarkdown.core.ast.NestableNode
+import com.quarkdown.core.ast.AstRoot
 
 /**
  * An iterator that runs through the nodes of an AST.
+ *
+ * @param T result produced by [traverse]. Pure visitors that mutate context or fire hooks
+ *          typically use [Unit]; rewriters that produce a transformed tree use [AstRoot].
  */
-interface AstIterator {
+interface AstIterator<T> {
     /**
-     * Runs the iterator from the given root node,
-     * traversing the node tree and visiting each node.
+     * Runs the iterator from the given root node, traversing the node tree and visiting each node.
+     * @param root root of the AST to traverse
+     * @return the result of the traversal, whose semantics depend on the iterator
      */
-    fun traverse(root: NestableNode)
+    fun traverse(root: AstRoot): T
 }

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/iterator/AstRewriter.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/iterator/AstRewriter.kt
@@ -1,0 +1,112 @@
+package com.quarkdown.core.ast.iterator
+
+import com.quarkdown.core.ast.AstRoot
+import com.quarkdown.core.ast.NestableNode
+import com.quarkdown.core.ast.Node
+import com.quarkdown.core.ast.attributes.primitive.PrimitiveFunctionBackedNode
+import com.quarkdown.core.ast.quarkdown.FunctionCallNode
+import com.quarkdown.core.ast.rewriter.withChildren
+import com.quarkdown.core.context.MutableContext
+import com.quarkdown.core.context.errorHandler
+import com.quarkdown.core.function.call.FunctionCallNodeExpander
+import com.quarkdown.core.pipeline.error.PipelineErrorHandler
+
+/**
+ * An [AstIterator] that walks the AST and replaces every [PrimitiveFunctionBackedNode] whose
+ * backing function has been wrapped via `.extend` with an equivalent [FunctionCallNode].
+ * It queues the synthesized calls on the context, and finally expands them in one pass so the rewritten
+ * tree is ready for rendering.
+ *
+ * The traversal recurses into the children of [FunctionCallNode]s whose backing function is
+ * *not* extended (for example, the `.tableofcontents` call output contains a "Table of Contents"
+ * heading that should also pick up `.extend {heading}`). [FunctionCallNode]s whose backing
+ * function *is* extended are treated as opaque: their children are the wrapper's chosen output
+ * and must not be re-rewritten — otherwise the `.super` heading inside an `.extend {heading}`
+ * wrapper would be wrapped over and over.
+ *
+ * @param context context to resolve extensions against and to register synthesized calls in
+ * @param errorHandler strategy used by the expander to handle errors raised by wrappers.
+ *                     Defaults to the error handler of the pipeline currently attached to [context];
+ *                     fails fast if neither is available
+ * @see com.quarkdown.core.pipeline.stages.TreeRewriteStage
+ */
+class AstRewriter(
+    private val context: MutableContext,
+    errorHandler: PipelineErrorHandler = requireNotNull(context.errorHandler) { "AstRewriter requires a pipeline error handler" },
+) : AstIterator<AstRoot> {
+    private val expander = FunctionCallNodeExpander(context, errorHandler)
+
+    override fun traverse(root: AstRoot): AstRoot {
+        val rewritten = rewriteSubtree(root) as AstRoot
+        expander.expandAll()
+        return rewritten
+    }
+
+    /**
+     * Recursively rewrites [parent] and its descendants. Returns [parent] unchanged when no
+     * descendant required rewriting; otherwise returns a copy carrying the rewritten children.
+     */
+    private fun rewriteSubtree(parent: NestableNode): NestableNode {
+        if (parent.children.isEmpty()) return parent
+
+        var changed = false
+        val newChildren =
+            parent.children.map { child ->
+                rewriteChild(child).also {
+                    if (it !== child) changed = true
+                }
+            }
+
+        return if (changed) {
+            parent.withChildren(newChildren) as NestableNode
+        } else {
+            parent
+        }
+    }
+
+    /**
+     * Rewrites a single [child], deciding which of the four cases applies:
+     * wrap an extended primitive, leave an already-expanded extension wrapper opaque,
+     * recurse into anything else nestable, or pass leaves through unchanged.
+     */
+    private fun rewriteChild(child: Node): Node =
+        when (child) {
+            // Extended primitive: wrap into a call, expanded later.
+            is PrimitiveFunctionBackedNode if context.isFunctionExtended(child.backingFunctionName) -> {
+                val withRewrittenChildren =
+                    if (child is NestableNode) {
+                        rewriteSubtree(child) as PrimitiveFunctionBackedNode
+                    } else {
+                        child
+                    }
+                synthesize(withRewrittenChildren)
+            }
+
+            // Already-expanded: don't descend.
+            is FunctionCallNode if context.isFunctionExtended(child.name) -> {
+                child
+            }
+
+            // Recurse normally.
+            is NestableNode -> {
+                rewriteSubtree(child)
+            }
+
+            // Leaf.
+            else -> {
+                child
+            }
+        }
+
+    /**
+     * Materializes [node] as a [FunctionCallNode] referencing the same backing function
+     * and registers it on [context] so the next [FunctionCallNodeExpander.expandAll] picks it up.
+     */
+    private fun synthesize(node: PrimitiveFunctionBackedNode): FunctionCallNode =
+        FunctionCallNode(
+            context = context,
+            name = node.backingFunctionName,
+            arguments = node.toFunctionCallArguments(),
+            isBlock = true,
+        ).also(context::register)
+}

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/iterator/ObservableAstIterator.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/iterator/ObservableAstIterator.kt
@@ -1,6 +1,6 @@
 package com.quarkdown.core.ast.iterator
 
-import com.quarkdown.core.ast.NestableNode
+import com.quarkdown.core.ast.AstRoot
 import com.quarkdown.core.ast.Node
 import com.quarkdown.core.util.node.flattenedChildren
 
@@ -8,7 +8,7 @@ import com.quarkdown.core.util.node.flattenedChildren
  * An iterator that performs a DFS traversal through the nodes of an AST,
  * allowing the registration of observers that will be notified when a node of a certain type is visited.
  */
-class ObservableAstIterator : AstIterator {
+class ObservableAstIterator : AstIterator<Unit> {
     /**
      * Hooks that will be called when a node of a certain type is visited.
      */
@@ -71,7 +71,7 @@ class ObservableAstIterator : AstIterator {
             hook.attach(this)
         }
 
-    override fun traverse(root: NestableNode) {
+    override fun traverse(root: AstRoot) {
         root.flattenedChildren().forEach { node ->
             hooks.forEach { hook -> hook(node) }
         }

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/quarkdown/FunctionCallNode.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/quarkdown/FunctionCallNode.kt
@@ -15,10 +15,6 @@ import com.quarkdown.core.visitor.node.NodeVisitor
  * @param name name of the function to call
  * @param arguments arguments to call the function with
  * @param isBlock whether this function call is an isolated block (opposite: inline)
- * @param delegator if this call was synthesized at parse time from a primitive Markdown node
- *                  (see [com.quarkdown.core.ast.attributes.primitive.PrimitiveFunctionBackedNode]), the original node.
- *                  When set, the expander falls back to rendering this node directly if no `.extend`
- *                  has been registered for [name], skipping function dispatch overhead
  * @param sourceText if available, the source code of the whole function call
  * @param sourceRange if available, the range of the function call in the source code
  */
@@ -27,7 +23,6 @@ class FunctionCallNode(
     val name: String,
     val arguments: List<FunctionCallArgument>,
     val isBlock: Boolean,
-    val delegator: Node? = null,
     val sourceText: CharSequence? = null,
     val sourceRange: IntRange? = null,
 ) : NestableNode,

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/rewriter/NodeNewChildrenVisitor.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/rewriter/NodeNewChildrenVisitor.kt
@@ -130,7 +130,8 @@ private class NodeNewChildrenVisitor(
 
     override fun visit(node: Paragraph) = node.diverge(newChildren)
 
-    override fun visit(node: BlockQuote) = node.diverge(newChildren)
+    // BlockQuote exposes content + attribution as children
+    override fun visit(node: BlockQuote) = node.diverge(newChildren.take(node.content.size))
 
     override fun visit(node: BlankNode) = node
 
@@ -170,7 +171,12 @@ private class NodeNewChildrenVisitor(
 
     override fun visit(node: Strikethrough) = node.diverge(newChildren)
 
-    override fun visit(node: FunctionCallNode) = node
+    // FunctionCallNode's children are a mutable list.
+    override fun visit(node: FunctionCallNode) =
+        node.also {
+            it.children.clear()
+            it.children.addAll(newChildren)
+        }
 
     override fun visit(node: Figure<*>) = node
 

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/context/BaseContext.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/context/BaseContext.kt
@@ -89,6 +89,8 @@ open class BaseContext(
 
     override fun isFunctionExtended(name: String): Boolean = false
 
+    override fun hasFunctionsExtended(): Boolean = false
+
     override fun resolve(call: FunctionCallNode): FunctionCall<*>? {
         val function = getFunctionByName(call.name)
 

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/context/Context.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/context/Context.kt
@@ -116,6 +116,12 @@ interface Context : PermissionHolder {
     fun isFunctionExtended(name: String): Boolean
 
     /**
+     * Whether any function has been wrapped via an `.extend` call visible from this context.
+     * Used for optimization of [com.quarkdown.core.ast.attributes.primitive.PrimitiveFunctionBackedNode].
+     */
+    fun hasFunctionsExtended(): Boolean
+
+    /**
      * @param call function call node to get a function call from
      * @return a new function call that [call] references to, with [call]'s arguments,
      * or `null` if [call] references to an unknown function

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/context/MutableContext.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/context/MutableContext.kt
@@ -47,11 +47,9 @@ open class MutableContext(
 
     private val extendedFunctionNames: MutableSet<String> = mutableSetOf()
 
-    /**
-     * Whether a function with [name] has been wrapped via an `.extend` call visible from this context.
-     * Used for optimization of [com.quarkdown.core.ast.attributes.primitive.PrimitiveFunctionBackedNode].
-     */
     override fun isFunctionExtended(name: String): Boolean = name in extendedFunctionNames
+
+    override fun hasFunctionsExtended(): Boolean = extendedFunctionNames.isNotEmpty()
 
     /**
      * Marks [name] as extended in this context.

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/context/SharedContext.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/context/SharedContext.kt
@@ -32,5 +32,7 @@ open class SharedContext(
 
     override fun isFunctionExtended(name: String): Boolean = parent.isFunctionExtended(name)
 
+    override fun hasFunctionsExtended(): Boolean = parent.hasFunctionsExtended()
+
     override fun markFunctionAsExtended(name: String) = parent.markFunctionAsExtended(name)
 }

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/context/SubdocumentContext.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/context/SubdocumentContext.kt
@@ -59,4 +59,6 @@ open class SubdocumentContext(
      * stay local and don't propagate back to the main document's context.
      */
     override fun isFunctionExtended(name: String): Boolean = super.isFunctionExtended(name) || parent.isFunctionExtended(name)
+
+    override fun hasFunctionsExtended(): Boolean = super.hasFunctionsExtended() || parent.hasFunctionsExtended()
 }

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/flavor/TreeIteratorFactory.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/flavor/TreeIteratorFactory.kt
@@ -1,5 +1,6 @@
 package com.quarkdown.core.flavor
 
+import com.quarkdown.core.ast.AstRoot
 import com.quarkdown.core.ast.iterator.AstIterator
 import com.quarkdown.core.context.MutableContext
 
@@ -11,7 +12,14 @@ import com.quarkdown.core.context.MutableContext
 interface TreeIteratorFactory {
     /**
      * @param context the context of the document
-     * @return the default tree iterator
+     * @return the default tree iterator, used to visit the AST and run side-effecting hooks (e.g. reference resolution, presence detection)
      */
-    fun default(context: MutableContext): AstIterator
+    fun default(context: MutableContext): AstIterator<Unit>
+
+    /**
+     * @param context the context of the document
+     * @return a tree iterator that produces a rewritten [AstRoot],
+     *         used by [com.quarkdown.core.pipeline.stages.TreeRewriteStage] to apply user-defined show-rules
+     */
+    fun rewriter(context: MutableContext): AstIterator<AstRoot>
 }

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/flavor/base/BaseMarkdownTreeIteratorFactory.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/flavor/base/BaseMarkdownTreeIteratorFactory.kt
@@ -1,5 +1,7 @@
 package com.quarkdown.core.flavor.base
 
+import com.quarkdown.core.ast.AstRoot
+import com.quarkdown.core.ast.iterator.AstIterator
 import com.quarkdown.core.ast.iterator.ObservableAstIterator
 import com.quarkdown.core.context.MutableContext
 import com.quarkdown.core.context.hooks.HeadingIdentifierDeduplicationHook
@@ -37,4 +39,12 @@ class BaseMarkdownTreeIteratorFactory : TreeIteratorFactory {
             // Allows loading math libraries (e.g. KaTeX)
             // if at least one math block is present.
             .attach(MathPresenceHook(context))
+
+    /**
+     * Base Markdown has no notion of function extensions, so the rewriter is a no-op that returns the input tree unchanged.
+     */
+    override fun rewriter(context: MutableContext): AstIterator<AstRoot> =
+        object : AstIterator<AstRoot> {
+            override fun traverse(root: AstRoot) = root
+        }
 }

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/flavor/quarkdown/QuarkdownTreeIteratorFactory.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/flavor/quarkdown/QuarkdownTreeIteratorFactory.kt
@@ -1,5 +1,6 @@
 package com.quarkdown.core.flavor.quarkdown
 
+import com.quarkdown.core.ast.iterator.AstRewriter
 import com.quarkdown.core.ast.iterator.ObservableAstIterator
 import com.quarkdown.core.context.MutableContext
 import com.quarkdown.core.context.hooks.MediaStorerHook
@@ -30,4 +31,6 @@ class QuarkdownTreeIteratorFactory : TreeIteratorFactory {
                     attach(MediaStorerHook(context))
                 }
             }
+
+    override fun rewriter(context: MutableContext) = AstRewriter(context)
 }

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/function/call/FunctionCallNodeExpander.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/function/call/FunctionCallNodeExpander.kt
@@ -34,14 +34,6 @@ class FunctionCallNodeExpander(
             return
         }
 
-        // Fast path: a call to a Node's primitive function (delegated by such node, see PrimitiveFunctionBacked) whose
-        // backing function has not been extended (see .extend) renders directly from the original node, skipping the reflection-based function dispatch entirely.
-        val delegator = node.delegator
-        if (delegator != null && !node.context.isFunctionExtended(node.name)) {
-            node.children += delegator
-            return
-        }
-
         try {
             // The function call node is used to retrieve its corresponding function call.
             // By resolving it from the node's context instead of the root one,

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/lexer/Token.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/lexer/Token.kt
@@ -1,8 +1,5 @@
 package com.quarkdown.core.lexer
 
-import com.quarkdown.core.ast.Node
-import com.quarkdown.core.ast.attributes.primitive.wrapIfPrimitive
-import com.quarkdown.core.context.MutableContext
 import com.quarkdown.core.visitor.token.TokenVisitor
 
 /**
@@ -26,23 +23,4 @@ abstract class Token(
  * @param visitor the visitor to visit for each token.
  * @return a lazy sequence of results from each visit
  */
-private fun <T> Sequence<Token>.acceptAll(visitor: TokenVisitor<T>): Sequence<T> = this.map { it.accept(visitor) }
-
-/**
- * Like the generic [acceptAll], but specialized to [Node] output: each parsed node is also passed
- * through [wrapIfPrimitive], so primitive nodes (e.g. [com.quarkdown.core.ast.base.block.Heading])
- * are wrapped into a [com.quarkdown.core.ast.quarkdown.FunctionCallNode] backed by their stdlib
- * function, both at the top level (see [com.quarkdown.core.pipeline.stages.ParsingStage]) and inside
- * nested content (see [com.quarkdown.core.parser.BlockTokenParser]).
- *
- * @param visitor parser to visit each token with
- * @param context context the wrapped calls are registered under
- * @param isBlock whether the produced nodes belong in a block-level position; carried into the
- *                resulting wrap so the expander selects the right value→node mapper
- * @return a lazy sequence of parsed nodes, with primitives wrapped as function calls
- */
-fun Sequence<Token>.acceptAll(
-    visitor: TokenVisitor<Node>,
-    context: MutableContext,
-    isBlock: Boolean,
-): Sequence<Node> = acceptAll(visitor).map { it.wrapIfPrimitive(context, isBlock) }
+fun <T> Sequence<Token>.acceptAll(visitor: TokenVisitor<T>): Sequence<T> = this.map { it.accept(visitor) }

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/parser/BlockTokenParser.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/parser/BlockTokenParser.kt
@@ -69,15 +69,12 @@ class BlockTokenParser(
     private val context: MutableContext,
 ) : BlockTokenVisitor<Node> {
     /**
-     * @return the parsed content of the tokenization from [this] lexer.
-     *         Nested [com.quarkdown.core.ast.attributes.primitive.PrimitiveFunctionBackedNode]s
-     *         (e.g. a heading inside a blockquote or list) are wrapped here too, mirroring the
-     *         top-level wrap done by [com.quarkdown.core.pipeline.stages.ParsingStage].
+     * @return the parsed content of the tokenization from [this] lexer
      */
     private fun Lexer.tokenizeAndParse(): List<Node> =
         this
             .tokenize()
-            .acceptAll(context.flavor.parserFactory.newParser(context), context, isBlock = true)
+            .acceptAll(context.flavor.parserFactory.newParser(context))
             .toList()
 
     /**

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/parser/InlineTokenParser.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/parser/InlineTokenParser.kt
@@ -83,7 +83,7 @@ class InlineTokenParser(
     private fun Lexer.tokenizeAndParse(): List<Node> =
         this
             .tokenize()
-            .acceptAll(context.flavor.parserFactory.newParser(context), context, isBlock = false)
+            .acceptAll(context.flavor.parserFactory.newParser(context))
             .toList()
 
     /**

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/pipeline/PipelineChainFactory.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/pipeline/PipelineChainFactory.kt
@@ -14,6 +14,7 @@ import com.quarkdown.core.pipeline.stages.ParsingStage
 import com.quarkdown.core.pipeline.stages.PostRenderingStage
 import com.quarkdown.core.pipeline.stages.RenderingStage
 import com.quarkdown.core.pipeline.stages.ResourceGenerationStage
+import com.quarkdown.core.pipeline.stages.TreeRewriteStage
 import com.quarkdown.core.pipeline.stages.TreeTraversalStage
 import com.quarkdown.core.rendering.RenderingComponents
 
@@ -40,6 +41,7 @@ object PipelineChainFactory {
             ParsingStage then
             AttributesUpdateStage(preferredMediaStorageOptions = renderingComponents.postRenderer.preferredMediaStorageOptions) then
             FunctionCallExpansionStage then
+            TreeRewriteStage then
             TreeTraversalStage then
             RenderingStage(renderingComponents.nodeRenderer) thenOptionally
             PostRenderingStage(renderingComponents.postRenderer).takeIf { options.wrapOutput } then

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/pipeline/PipelineHooks.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/pipeline/PipelineHooks.kt
@@ -10,7 +10,10 @@ import com.quarkdown.core.pipeline.output.OutputResource
  * @param afterRegisteringLibraries action to run after the libraries have been registered and are ready to be looked up (libraries as arguments)
  * @param afterLexing action to run after the tokens have been produced (output tokens as arguments)
  * @param afterParsing action to run after the AST has been generated (root as an argument)
- * @param afterExpanding action to run after the queued function calls have been expanded (root as an argument)
+ * @param afterExpanding action to run after the source-level function call queue has been expanded (root as an argument).
+ *                       Further expansion may still happen during [afterTreeRewrite] if any `.extend` was registered:
+ *                       use that hook when the consumer needs to observe the fully rewritten tree
+ * @param afterTreeRewrite action to run after the AST rewrite has been completed (root as an argument)
  * @param afterTreeTraversal action to run after the produced AST has been visited
  * @param afterRendering action to run after the rendered output code has been generated (output code as an argument)
  * @param afterPostRendering action to run after the rendered output code has been manipulated (e.g. wrapped) (output code as an argument)
@@ -24,6 +27,7 @@ data class PipelineHooks(
     val afterLexing: Pipeline.(Sequence<Token>) -> Unit = {},
     val afterParsing: Pipeline.(AstRoot) -> Unit = {},
     val afterExpanding: Pipeline.(AstRoot) -> Unit = {},
+    val afterTreeRewrite: Pipeline.(AstRoot) -> Unit = {},
     val afterTreeTraversal: Pipeline.(AstRoot) -> Unit = {},
     val afterRendering: Pipeline.(CharSequence) -> Unit = {},
     val afterPostRendering: Pipeline.(CharSequence) -> Unit = {},

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/pipeline/stages/ParsingStage.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/pipeline/stages/ParsingStage.kt
@@ -2,7 +2,6 @@ package com.quarkdown.core.pipeline.stages
 
 import com.quarkdown.core.ast.AstRoot
 import com.quarkdown.core.ast.Node
-import com.quarkdown.core.ast.attributes.primitive.PrimitiveFunctionBackedNode
 import com.quarkdown.core.lexer.Token
 import com.quarkdown.core.lexer.acceptAll
 import com.quarkdown.core.pipeline.PipelineHooks
@@ -15,15 +14,6 @@ import com.quarkdown.core.visitor.token.TokenVisitor
  *
  * This stage takes a sequence of tokens (produced by the [LexingStage]) as input and
  * produces an [AstRoot] as output.
- *
- * The AST represents the hierarchical structure of the document and is used by
- * subsequent stages for further processing and rendering.
- *
- * Primitive Markdown nodes that implement [PrimitiveFunctionBackedNode] (e.g. headings) are wrapped here
- * into a [com.quarkdown.core.ast.quarkdown.FunctionCallNode] that delegates to their backing stdlib function. When the document
- * later wraps that function via `.extend`, the wrapper sees the node's properties as named
- * arguments and can override them; when it does not, the `FunctionCallNode` short-circuits and
- * renders the original node directly with no reflection overhead.
  */
 object ParsingStage : PipelineStage<Sequence<Token>, AstRoot> {
     override val hook = PipelineHooks::afterParsing
@@ -36,10 +26,7 @@ object ParsingStage : PipelineStage<Sequence<Token>, AstRoot> {
             data.context.flavor.parserFactory
                 .newParser(data.context)
 
-        val nodes =
-            input
-                .acceptAll(parser, data.context, isBlock = true)
-                .toList()
+        val nodes = input.acceptAll(parser).toList()
 
         return AstRoot(children = nodes)
     }

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/pipeline/stages/TreeRewriteStage.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/pipeline/stages/TreeRewriteStage.kt
@@ -1,0 +1,36 @@
+package com.quarkdown.core.pipeline.stages
+
+import com.quarkdown.core.ast.AstRoot
+import com.quarkdown.core.pipeline.PipelineHooks
+import com.quarkdown.core.pipeline.stage.PipelineStage
+import com.quarkdown.core.pipeline.stage.SharedPipelineData
+
+/**
+ * Pipeline stage that rewrites the AST after function call expansion to apply user-defined
+ * extensions to Markdown primitives.
+ *
+ * Primitive nodes that implement [com.quarkdown.core.ast.attributes.primitive.PrimitiveFunctionBackedNode]
+ * (e.g. headings) are wrapped into a [com.quarkdown.core.ast.quarkdown.FunctionCallNode] whenever
+ * their backing function has been wrapped via `.extend`, then immediately expanded so the
+ * wrapper output replaces the original primitive. This is the mechanism that lets `.extend {heading}`
+ * affect both `.heading {...}` calls and plain `#` Markdown syntax.
+ *
+ * As an optimization, the rewrite is skipped entirely when no extension is registered in the context,
+ * which is the common case.
+ *
+ * @see com.quarkdown.core.ast.iterator.AstRewriter for the underlying traversal logic
+ */
+object TreeRewriteStage : PipelineStage<AstRoot, AstRoot> {
+    override val hook = PipelineHooks::afterTreeRewrite
+
+    override fun process(
+        input: AstRoot,
+        data: SharedPipelineData,
+    ): AstRoot {
+        if (!data.context.hasFunctionsExtended()) return input
+
+        return data.context.flavor.treeIteratorFactory
+            .rewriter(data.context)
+            .traverse(input)
+    }
+}

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/util/node/NodeUtils.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/util/node/NodeUtils.kt
@@ -55,7 +55,6 @@ fun List<Node>?.group(): AstRoot = AstRoot(this.orEmpty())
  */
 fun NestableNode.flattenedChildren(): Sequence<Node> =
     sequence {
-        // DFS traversal.
         for (child in children) {
             yield(child)
             if (child is NestableNode) {

--- a/quarkdown-core/src/test/kotlin/com/quarkdown/core/AstRewriterTest.kt
+++ b/quarkdown-core/src/test/kotlin/com/quarkdown/core/AstRewriterTest.kt
@@ -1,0 +1,207 @@
+package com.quarkdown.core
+
+import com.quarkdown.core.ast.AstRoot
+import com.quarkdown.core.ast.InlineMarkdownContent
+import com.quarkdown.core.ast.Node
+import com.quarkdown.core.ast.base.block.BlockQuote
+import com.quarkdown.core.ast.base.block.Heading
+import com.quarkdown.core.ast.base.block.Paragraph
+import com.quarkdown.core.ast.base.inline.Text
+import com.quarkdown.core.ast.iterator.AstRewriter
+import com.quarkdown.core.ast.quarkdown.FunctionCallNode
+import com.quarkdown.core.ast.quarkdown.block.Container
+import com.quarkdown.core.context.MutableContext
+import com.quarkdown.core.flavor.quarkdown.QuarkdownFlavor
+import com.quarkdown.core.function.library.LibraryRegistrant
+import com.quarkdown.core.function.library.loader.MultiFunctionLibraryLoader
+import com.quarkdown.core.function.library.module.moduleOf
+import com.quarkdown.core.function.reflect.annotation.Body
+import com.quarkdown.core.function.reflect.annotation.Name
+import com.quarkdown.core.function.value.NodeValue
+import com.quarkdown.core.util.node.toPlainText
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+/**
+ * Tests for [AstRewriter]: ensures Markdown primitives implementing
+ * [com.quarkdown.core.ast.attributes.primitive.PrimitiveFunctionBackedNode]
+ * are wrapped into [FunctionCallNode]s exactly when their backing function has been
+ * marked as extended in the context, and that the surrounding tree is preserved.
+ */
+class AstRewriterTest {
+    private lateinit var context: MutableContext
+    private lateinit var rewriter: AstRewriter
+
+    @Suppress("MemberVisibilityCanBePrivate")
+    @Name("heading")
+    fun heading(
+        @Body content: InlineMarkdownContent,
+        depth: Int,
+        @Name("ref") ref: String? = null,
+        @Name("numbered") numbered: Boolean = true,
+        @Name("indexed") indexed: Boolean = true,
+        @Name("breakpage") breakpage: Boolean = true,
+    ): NodeValue =
+        NodeValue(
+            BlockQuote(
+                content =
+                    listOf(
+                        Heading(
+                            depth = depth,
+                            text = content.children,
+                            customId = ref,
+                            canBreakPage = breakpage,
+                            canTrackLocation = numbered,
+                            excludeFromTableOfContents = !indexed,
+                        ),
+                    ),
+            ),
+        )
+
+    @BeforeTest
+    fun setup() {
+        context = MutableContext(QuarkdownFlavor)
+        // Required by FunctionCallNodeExpander.errorHandler!! within AstRewriter.
+        context.attachMockPipeline()
+
+        val library = MultiFunctionLibraryLoader("lib").load(moduleOf(::heading))
+        LibraryRegistrant(context).registerAll(listOf(library))
+
+        rewriter = AstRewriter(context)
+    }
+
+    private fun newHeading() = Heading(depth = 2, text = listOf(Text("Hello")))
+
+    @Test
+    fun `no extensions leaves all primitives untouched`() {
+        val original = AstRoot(listOf(newHeading()))
+        val result = rewriter.traverse(original)
+
+        // No "heading" has been marked extended, so the rewriter must not swap the primitive.
+        assertEquals(1, result.children.size)
+        val child = result.children.single()
+        assertIs<Heading>(child)
+        assertEquals("Hello", child.text.toPlainText())
+    }
+
+    @Test
+    fun `non-primitive nodes are preserved`() {
+        val paragraph = Paragraph(listOf(Text("Just text")))
+        val original = AstRoot(listOf(paragraph))
+        val result = rewriter.traverse(original)
+
+        val child = assertIs<Paragraph>(result.children.single())
+        assertEquals("Just text", child.text.toPlainText())
+    }
+
+    @Test
+    fun `extended primitive at root is wrapped and expanded`() {
+        context.markFunctionAsExtended("heading")
+
+        val original = AstRoot(listOf(newHeading()))
+        val result = rewriter.traverse(original)
+
+        // The primitive must have been replaced by a FunctionCallNode for "heading"...
+        val call = assertIs<FunctionCallNode>(result.children.single())
+        assertEquals("heading", call.name)
+
+        // ...and that call must have been expanded by the rewriter (i.e. children populated).
+        val expanded = assertIs<BlockQuote>(call.children.single())
+        val wrappedHeading = assertIs<Heading>(expanded.content.single())
+        assertEquals(2, wrappedHeading.depth)
+        assertEquals("Hello", wrappedHeading.text.toPlainText())
+    }
+
+    @Test
+    fun `unextended primitive remains even when other functions are extended`() {
+        context.markFunctionAsExtended("someOtherFunction")
+
+        val original = AstRoot(listOf(newHeading()))
+        val result = rewriter.traverse(original)
+
+        // The "heading" function isn't extended here, so the primitive must be left alone.
+        assertIs<Heading>(result.children.single())
+    }
+
+    @Test
+    fun `extension reaches primitives nested inside a container`() {
+        context.markFunctionAsExtended("heading")
+
+        val original =
+            AstRoot(
+                listOf(
+                    Container(children = listOf(newHeading())),
+                ),
+            )
+        val result = rewriter.traverse(original)
+
+        // The outer Container is preserved...
+        val container = assertIs<Container>(result.children.single())
+        // ...but the nested Heading must have been wrapped and expanded.
+        val call = assertIs<FunctionCallNode>(container.children.single())
+        assertEquals("heading", call.name)
+        assertTrue(call.children.isNotEmpty(), "Nested call must be expanded too")
+    }
+
+    @Test
+    fun `extension reaches deeply nested primitives`() {
+        context.markFunctionAsExtended("heading")
+
+        val original =
+            AstRoot(
+                listOf(
+                    Container(
+                        children =
+                            listOf(
+                                Container(children = listOf(newHeading())),
+                            ),
+                    ),
+                ),
+            )
+        val result = rewriter.traverse(original)
+
+        val outer = assertIs<Container>(result.children.single())
+        val inner = assertIs<Container>(outer.children.single())
+        val call = assertIs<FunctionCallNode>(inner.children.single())
+        assertEquals("heading", call.name)
+        assertTrue(call.children.isNotEmpty())
+    }
+
+    @Test
+    fun `mixed extended and non-primitive children are handled independently`() {
+        context.markFunctionAsExtended("heading")
+
+        val paragraph = Paragraph(listOf(Text("Plain")))
+        val heading = newHeading()
+        val original = AstRoot(listOf(paragraph, heading))
+        val result = rewriter.traverse(original)
+
+        assertEquals(2, result.children.size)
+        // The paragraph passes through unchanged (no nested primitives, no function call).
+        val rewrittenParagraph = assertIs<Paragraph>(result.children[0])
+        assertEquals("Plain", rewrittenParagraph.text.toPlainText())
+        // The heading is wrapped into a function call.
+        val call = assertIs<FunctionCallNode>(result.children[1])
+        assertEquals("heading", call.name)
+    }
+
+    @Test
+    fun `unextended primitive is preserved structurally when other functions are extended`() {
+        // Extend some unrelated name so that the rewriter still runs the traversal.
+        context.markFunctionAsExtended("someOtherFunction")
+
+        val heading = newHeading()
+        val original = AstRoot(listOf(heading))
+        val result = rewriter.traverse(original)
+
+        val child: Node = result.children.single()
+        // The rewriter may rebuild nodes via withChildren, so identity is not guaranteed,
+        // but the underlying primitive type and its data must be preserved verbatim.
+        val rewritten = assertIs<Heading>(child)
+        assertEquals(heading.depth, rewritten.depth)
+        assertEquals(heading.text.toPlainText(), rewritten.text.toPlainText())
+    }
+}

--- a/quarkdown-core/src/test/kotlin/com/quarkdown/core/BibliographyCitationResolutionTest.kt
+++ b/quarkdown-core/src/test/kotlin/com/quarkdown/core/BibliographyCitationResolutionTest.kt
@@ -1,6 +1,6 @@
 package com.quarkdown.core
 
-import com.quarkdown.core.ast.NestableNode
+import com.quarkdown.core.ast.AstRoot
 import com.quarkdown.core.ast.Node
 import com.quarkdown.core.ast.attributes.reference.getDefinition
 import com.quarkdown.core.ast.dsl.buildBlock
@@ -60,7 +60,7 @@ class BibliographyCitationResolutionTest {
     private fun traverse(root: Node) {
         ObservableAstIterator()
             .attach(BibliographyCitationResolverHook(context))
-            .traverse(root as NestableNode)
+            .traverse(root as AstRoot)
     }
 
     @Test

--- a/quarkdown-core/src/test/kotlin/com/quarkdown/core/BlockParserTest.kt
+++ b/quarkdown-core/src/test/kotlin/com/quarkdown/core/BlockParserTest.kt
@@ -76,13 +76,6 @@ class BlockParserTest {
         }
 
     /**
-     * Strips the primitive-function wrap added by the parser so tests can keep asserting on the
-     * underlying node (e.g. a heading inside a list item) instead of the synthetic [FunctionCallNode]
-     * that backs it.
-     */
-    private fun Node.unwrapPrimitive(): Node = (this as? FunctionCallNode)?.delegator ?: this
-
-    /**
      * @param node parent node
      * @param childIndex index of the text child
      * @return text content of the [childIndex]-th child
@@ -90,7 +83,7 @@ class BlockParserTest {
     private fun rawText(
         node: NestableNode,
         childIndex: Int = 0,
-    ): String = (node.children[childIndex].unwrapPrimitive() as TextNode).rawText
+    ): String = (node.children[childIndex] as TextNode).rawText
 
     @Test
     fun paragraph() {
@@ -835,7 +828,7 @@ class BlockParserTest {
 
             with(items.next()) {
                 assertIs<ListItem>(this)
-                assertIs<Heading>(children[0].unwrapPrimitive())
+                assertIs<Heading>(children[0])
                 assertEquals("Heading", rawText(this))
             }
             with(items.next()) {
@@ -845,7 +838,7 @@ class BlockParserTest {
             }
             with(items.next()) {
                 assertIs<ListItem>(this)
-                assertIs<Heading>(children[0].unwrapPrimitive())
+                assertIs<Heading>(children[0])
                 assertEquals("Heading", rawText(this, childIndex = 0))
                 assertIs<Paragraph>(children[1])
                 assertEquals("Some paragraph", rawText(this, childIndex = 1))

--- a/quarkdown-core/src/test/kotlin/com/quarkdown/core/CrossReferenceResolutionTest.kt
+++ b/quarkdown-core/src/test/kotlin/com/quarkdown/core/CrossReferenceResolutionTest.kt
@@ -1,6 +1,6 @@
 package com.quarkdown.core
 
-import com.quarkdown.core.ast.NestableNode
+import com.quarkdown.core.ast.AstRoot
 import com.quarkdown.core.ast.Node
 import com.quarkdown.core.ast.attributes.reference.getDefinition
 import com.quarkdown.core.ast.base.block.Code
@@ -34,7 +34,7 @@ class CrossReferenceResolutionTest {
             .attach(LocationAwarenessHook(context))
             .attach(LocationAwareLabelStorerHook(context))
             .attach(CrossReferenceResolverHook(context))
-            .traverse(root as NestableNode)
+            .traverse(root as AstRoot)
     }
 
     @Test

--- a/quarkdown-core/src/test/kotlin/com/quarkdown/core/FootnoteResolutionTest.kt
+++ b/quarkdown-core/src/test/kotlin/com/quarkdown/core/FootnoteResolutionTest.kt
@@ -1,6 +1,6 @@
 package com.quarkdown.core
 
-import com.quarkdown.core.ast.NestableNode
+import com.quarkdown.core.ast.AstRoot
 import com.quarkdown.core.ast.Node
 import com.quarkdown.core.ast.attributes.reference.getDefinition
 import com.quarkdown.core.ast.base.block.FootnoteDefinition
@@ -45,7 +45,7 @@ class FootnoteResolutionTest {
     private fun traverse(root: Node) {
         ObservableAstIterator()
             .attach(FootnoteResolverHook(context))
-            .traverse(root as NestableNode)
+            .traverse(root as AstRoot)
     }
 
     @Test

--- a/quarkdown-core/src/test/kotlin/com/quarkdown/core/LinkUrlResolverTest.kt
+++ b/quarkdown-core/src/test/kotlin/com/quarkdown/core/LinkUrlResolverTest.kt
@@ -1,6 +1,6 @@
 package com.quarkdown.core
 
-import com.quarkdown.core.ast.NestableNode
+import com.quarkdown.core.ast.AstRoot
 import com.quarkdown.core.ast.Node
 import com.quarkdown.core.ast.attributes.link.getResolvedUrl
 import com.quarkdown.core.ast.base.block.LinkDefinition
@@ -72,7 +72,7 @@ class LinkUrlResolverTest {
     ) {
         ObservableAstIterator()
             .attach(LinkUrlResolverHook(context))
-            .traverse(root as NestableNode)
+            .traverse(root as AstRoot)
     }
 
     @Test

--- a/quarkdown-core/src/test/kotlin/com/quarkdown/core/NumberingTest.kt
+++ b/quarkdown-core/src/test/kotlin/com/quarkdown/core/NumberingTest.kt
@@ -1,7 +1,6 @@
 package com.quarkdown.core
 
 import com.quarkdown.core.ast.AstRoot
-import com.quarkdown.core.ast.NestableNode
 import com.quarkdown.core.ast.attributes.location.LocationTrackableNode
 import com.quarkdown.core.ast.attributes.location.getLocation
 import com.quarkdown.core.ast.attributes.location.getLocationLabel
@@ -27,7 +26,7 @@ import kotlin.test.assertEquals
  */
 class NumberingTest {
     private fun getLabels(
-        tree: NestableNode,
+        tree: AstRoot,
         numbering: DocumentNumbering,
     ): List<String> {
         val context = MutableContext(QuarkdownFlavor)

--- a/quarkdown-core/src/test/kotlin/com/quarkdown/core/SubdocumentRegistrationTest.kt
+++ b/quarkdown-core/src/test/kotlin/com/quarkdown/core/SubdocumentRegistrationTest.kt
@@ -1,6 +1,6 @@
 package com.quarkdown.core
 
-import com.quarkdown.core.ast.NestableNode
+import com.quarkdown.core.ast.AstRoot
 import com.quarkdown.core.ast.Node
 import com.quarkdown.core.ast.base.inline.Link
 import com.quarkdown.core.ast.base.inline.SubdocumentLink
@@ -67,7 +67,7 @@ class SubdocumentRegistrationTest {
             context.sharedSubdocumentsData.copy(graph = context.sharedSubdocumentsData.graph.addVertex(Subdocument.Root))
         ObservableAstIterator()
             .attach(SubdocumentRegistrationHook(context))
-            .traverse(root as NestableNode)
+            .traverse(root as AstRoot)
     }
 
     @Test
@@ -216,7 +216,7 @@ class SubdocumentRegistrationTest {
 
         ObservableAstIterator()
             .attach(SubdocumentRegistrationHook(noPermissionsContext))
-            .traverse(root as NestableNode)
+            .traverse(root as AstRoot)
 
         assertEquals(
             1,

--- a/quarkdown-test/src/test/kotlin/com/quarkdown/test/MatchTest.kt
+++ b/quarkdown-test/src/test/kotlin/com/quarkdown/test/MatchTest.kt
@@ -64,32 +64,4 @@ class MatchTest {
             )
         }
     }
-
-    @Test
-    fun `match inside heading extension nested in user function`() {
-        execute(
-            """
-            .function {myfunction}
-                content:
-                .container
-                    .content
-
-            .myfunction
-                .extend {heading}
-                    content:
-                    .super
-                        .content::match {[Qq]uark(down|s)?}
-                            *.1::uppercase*
-
-                ###! Quarkdown takes its name from quarks
-            """.trimIndent(),
-        ) {
-            assertEquals(
-                "<div class=\"container\">" +
-                    "<h3 data-decorative=\"\"><em>QUARKDOWN</em> takes its name from <em>QUARKS</em></h3>" +
-                    "</div>",
-                it,
-            )
-        }
-    }
 }

--- a/quarkdown-test/src/test/kotlin/com/quarkdown/test/primitive/HeadingPrimitiveFunctionTest.kt
+++ b/quarkdown-test/src/test/kotlin/com/quarkdown/test/primitive/HeadingPrimitiveFunctionTest.kt
@@ -1,5 +1,6 @@
 package com.quarkdown.test.primitive
 
+import com.quarkdown.test.util.DEFAULT_OPTIONS
 import com.quarkdown.test.util.execute
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -187,6 +188,40 @@ class HeadingPrimitiveFunctionTest {
         ) {
             assertEquals(
                 "<ul><li><div class=\"container\"><h2>Item heading</h2></div></li></ul>",
+                it,
+            )
+        }
+    }
+
+    @Test
+    fun `extension reaches the generated nodes`() {
+        execute(
+            """
+            .doclang {en}
+
+            .extend {heading}
+                content:
+                .container
+                    .super
+
+            # a
+
+            ## b
+
+            .tableofcontents
+            """.trimIndent(),
+            DEFAULT_OPTIONS.copy(enableAutomaticIdentifiers = true),
+        ) {
+            assertEquals(
+                "<div class=\"container\"><h1 class=\"page-break\" id=\"a\">a</h1></div>" +
+                    "<div class=\"container\"><h2 id=\"b\">b</h2></div>" +
+                    "<div class=\"container\">" +
+                    "<h1 class=\"page-break\" id=\"table-of-contents\">Table of Contents</h1>" +
+                    "</div>" +
+                    "<nav role=\"table-of-contents\" data-role=\"table-of-contents\"><ol>" +
+                    "<li data-target-id=\"a\" data-depth=\"1\"><a href=\"#a\">a</a>" +
+                    "<ol><li data-target-id=\"b\" data-depth=\"2\"><a href=\"#b\">b</a></li></ol></li>" +
+                    "</ol></nav>",
                 it,
             )
         }


### PR DESCRIPTION
- [X] I have read the [contributing guidelines](https://github.com/iamgio/quarkdown/blob/main/CONTRIBUTING.md).
- [X] I have tested the changes locally.
- [ ] An issue for this change exists, and it was discussed with maintainers. This is required for new features and non-trivial changes. If present, append `Closes #ISSUE_NUMBER` at the end of this PR description.
- [ ] (Optional) I have added necessary documentation to [`docs`](https://github.com/iamgio/quarkdown/tree/main/docs) and [`CHANGELOG.md`](https://github.com/iamgio/quarkdown/blob/main/CHANGELOG.md)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a **Tree rewrite** pipeline stage that applies user extensions (e.g., `.extend {heading}`) to extended built-in primitives before traversal and rendering, including generated Table of Contents headings.
  * Added an **afterTreeRewrite** lifecycle hook to observe the fully rewritten AST.
* **Bug Fixes**
  * Improved primitive extension wrapping/expansion through nested structures while leaving unextended primitives unchanged.
* **Documentation**
  * Updated pipeline docs and added a dedicated **Tree rewrite** page to explain the stage.
* **Tests**
  * Added/updated coverage for tree rewriting and extension reach (including generated nodes).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->