### PR TITLE
feat(primitives): add image primitive

### DIFF
--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/base/inline/Image.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/base/inline/Image.kt
@@ -1,10 +1,18 @@
 package com.quarkdown.core.ast.base.inline
 
+import com.quarkdown.amber.annotations.Diverge
+import com.quarkdown.core.ast.InlineMarkdownContent
 import com.quarkdown.core.ast.attributes.error.ErrorCapableNode
+import com.quarkdown.core.ast.attributes.primitive.PrimitiveFunctionBackedNode
 import com.quarkdown.core.ast.base.LinkNode
 import com.quarkdown.core.ast.base.block.LinkDefinition
 import com.quarkdown.core.ast.quarkdown.reference.CrossReferenceableNode
 import com.quarkdown.core.document.size.Size
+import com.quarkdown.core.function.call.FunctionCallArgument
+import com.quarkdown.core.function.value.BooleanValue
+import com.quarkdown.core.function.value.NoneValue
+import com.quarkdown.core.function.value.ObjectValue
+import com.quarkdown.core.function.value.wrappedAsValue
 import com.quarkdown.core.visitor.node.NodeVisitor
 
 /**
@@ -17,13 +25,14 @@ import com.quarkdown.core.visitor.node.NodeVisitor
  *                         if the media storage is enabled in the context
  */
 class Image(
-    val link: LinkNode,
+    @Diverge val link: LinkNode,
     val width: Size?,
     val height: Size?,
     override val referenceId: String? = null,
     val usesMediaStorage: Boolean = true,
 ) : CrossReferenceableNode,
-    ErrorCapableNode {
+    ErrorCapableNode,
+    PrimitiveFunctionBackedNode {
     /**
      * Any error associated with the link will be surfaced as an error on the image itself.
      */
@@ -31,16 +40,23 @@ class Image(
 
     override fun <T> acceptOnSuccess(visitor: NodeVisitor<T>) = visitor.visit(this)
 
-    /**
-     * Creates a copy of this image with the given [link].
-     */
-    fun copy(link: LinkNode) =
-        Image(
-            link = link,
-            width = width,
-            height = height,
-            referenceId = referenceId,
-            usesMediaStorage = usesMediaStorage,
+    override val backingFunctionName = "image"
+
+    override fun toFunctionCallArguments() =
+        listOf(
+            FunctionCallArgument(name = "url", expression = link.url.wrappedAsValue()),
+            FunctionCallArgument(name = "label", expression = InlineMarkdownContent(link.label).wrappedAsValue()),
+            FunctionCallArgument(
+                name = "title",
+                expression = link.title?.let(::InlineMarkdownContent)?.wrappedAsValue() ?: NoneValue,
+            ),
+            FunctionCallArgument(name = "width", expression = width?.let(::ObjectValue) ?: NoneValue),
+            FunctionCallArgument(name = "height", expression = height?.let(::ObjectValue) ?: NoneValue),
+            FunctionCallArgument(name = "ref", expression = referenceId?.wrappedAsValue() ?: NoneValue),
+            FunctionCallArgument(name = "mediastorage", expression = usesMediaStorage.wrappedAsValue()),
+            // Suppress the default Figure wrap — the parser already wraps the Image in an
+            // ImageFigure when relevant, so .super must return a bare Image to avoid double-figuring.
+            FunctionCallArgument(name = "figure", expression = BooleanValue(false)),
         )
 }
 

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/rewriter/NodeNewChildrenVisitor.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/rewriter/NodeNewChildrenVisitor.kt
@@ -178,7 +178,8 @@ private class NodeNewChildrenVisitor(
             it.children.addAll(newChildren)
         }
 
-    override fun visit(node: Figure<*>) = node
+    @Suppress("UNCHECKED_CAST")
+    override fun visit(node: Figure<*>) = (node as Figure<Node>).diverge(child = newChildren.first())
 
     override fun visit(node: PageBreak) = node
 

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/rendering/NodeRenderer.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/rendering/NodeRenderer.kt
@@ -5,6 +5,7 @@ import com.quarkdown.core.ast.attributes.reference.getDefinition
 import com.quarkdown.core.ast.base.inline.Image
 import com.quarkdown.core.ast.base.inline.Link
 import com.quarkdown.core.ast.base.inline.ReferenceLink
+import com.quarkdown.core.ast.base.inline.diverge
 import com.quarkdown.core.ast.media.getStoredMedia
 import com.quarkdown.core.context.Context
 import com.quarkdown.core.media.passthrough.MediaPassthrough
@@ -55,7 +56,7 @@ abstract class NodeRenderer(
             node.link.getStoredMedia(context)?.path
                 ?: node.link.getResolvedUrl(context).let(::replaceMediaPassthroughPrefix)
 
-        val image = node.copy(link = node.link.copy(url = url))
+        val image = node.diverge(link = node.link.copy(url = url))
         return visitTransformed(image)
     }
 }

--- a/quarkdown-test/src/test/kotlin/com/quarkdown/test/primitive/ImagePrimitiveFunctionTest.kt
+++ b/quarkdown-test/src/test/kotlin/com/quarkdown/test/primitive/ImagePrimitiveFunctionTest.kt
@@ -1,0 +1,133 @@
+package com.quarkdown.test.primitive
+
+import com.quarkdown.test.util.execute
+import com.quarkdown.test.util.getMediaResources
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Tests for `.extend` applied to Markdown images.
+ */
+class ImagePrimitiveFunctionTest {
+    @Test
+    fun `no extension renders unchanged`() {
+        execute("![Alt text](image.jpg)") {
+            assertEquals("<figure><img src=\"image.jpg\" alt=\"Alt text\" /></figure>", it)
+        }
+    }
+
+    @Test
+    fun `extension wraps every image`() {
+        execute(
+            """
+            .extend {image}
+                .container
+                    .super
+
+            ![Alt text](image.jpg)
+            """.trimIndent(),
+        ) {
+            assertEquals(
+                "<figure><div class=\"container\"><img src=\"image.jpg\" alt=\"Alt text\" /></div></figure>",
+                it,
+            )
+        }
+    }
+
+    @Test
+    fun `extension wraps every image via function call syntax`() {
+        execute(
+            """
+            .extend {image}
+                .container
+                    .super
+
+            .image {image.jpg} label:{Alt text}
+            """.trimIndent(),
+        ) {
+            assertEquals(
+                "<div class=\"container\"><figure><img src=\"image.jpg\" alt=\"Alt text\" /></figure></div>",
+                it,
+            )
+        }
+    }
+
+    @Test
+    fun `extension can override url`() {
+        execute(
+            """
+            .extend {image}
+                url:
+                .super url:{{.url}\.new}
+
+            ![Alt text](original.jpg)
+            """.trimIndent(),
+        ) {
+            assertEquals(
+                "<figure><img src=\"original.jpg.new\" alt=\"Alt text\" /></figure>",
+                it,
+            )
+        }
+    }
+
+    @Test
+    fun `url override is reflected in media storage`() {
+        execute(
+            """
+            .extend {image}
+                .super url:{img/icon.png}
+
+            ![Alt text](nonexistent.png)
+            """.trimIndent(),
+            enableMediaStorage = true,
+            outputResourceHook = { group ->
+                val resource = getMediaResources(group).single()
+                assertTrue(resource.name.startsWith("icon"))
+            },
+        ) {
+            assertEquals(1, mediaStorage.all.size)
+            assertTrue("media/icon" in it.toString(), "Rendered URL should be the media path for the overridden file")
+            assertTrue("nonexistent" !in it.toString(), "Original URL must not leak into the output")
+        }
+    }
+
+    @Test
+    fun `extension reaches images nested inside a blockquote`() {
+        execute(
+            """
+            .extend {image}
+                .container
+                    .super
+
+            > ![Alt text](image.jpg)
+            """.trimIndent(),
+        ) {
+            assertEquals(
+                "<blockquote><figure><div class=\"container\"><img src=\"image.jpg\" alt=\"Alt text\" /></div></figure></blockquote>",
+                it,
+            )
+        }
+    }
+
+    @Test
+    fun `extension applies to multiple images independently`() {
+        execute(
+            """
+            .extend {image}
+                .container
+                    .super
+
+            ![First](a.jpg)
+
+            ![Second](b.jpg)
+            """.trimIndent(),
+        ) {
+            assertEquals(
+                "<figure><div class=\"container\"><img src=\"a.jpg\" alt=\"First\" /></div></figure>" +
+                    "<figure><div class=\"container\"><img src=\"b.jpg\" alt=\"Second\" /></div></figure>",
+                it,
+            )
+        }
+    }
+}


### PR DESCRIPTION
- [X] I have read the [contributing guidelines](https://github.com/iamgio/quarkdown/blob/main/CONTRIBUTING.md).
- [X] I have tested the changes locally.
- [ ] An issue for this change exists, and it was discussed with maintainers. This is required for new features and non-trivial changes. If present, append `Closes #ISSUE_NUMBER` at the end of this PR description.
- [ ] (Optional) I have added necessary documentation to [`docs`](https://github.com/iamgio/quarkdown/tree/main/docs) and [`CHANGELOG.md`](https://github.com/iamgio/quarkdown/blob/main/CHANGELOG.md)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Images are now processed as a callable-style primitive, allowing argument-based control of image rendering.
  * Image extensions now apply reliably across cases, including nested content (e.g., blockquotes) and multiple images.

* **Bug Fixes**
  * Image URL overrides now render correctly and remain consistent when media storage is enabled.
  * Figure content updates now replace the image/content as intended.

* **Tests**
  * Added `ImagePrimitiveFunctionTest` covering unchanged rendering, wrapping behavior, function-call syntax, URL overrides, media storage reflections, nested images, and independent multiple-image updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->