### PR TITLE
feat(nlp): add @Spread

### DIFF
--- a/quarkdown-native-library-processor/src/main/kotlin/com/quarkdown/processor/annotation/Spread.kt
+++ b/quarkdown-native-library-processor/src/main/kotlin/com/quarkdown/processor/annotation/Spread.kt
@@ -1,0 +1,37 @@
+package com.quarkdown.processor.annotation
+
+/**
+ * Marks a parameter of a [QFunction] as a *spread* of a class type: the processor unpacks the
+ * class's primary-constructor parameters into individual wrapper parameters and reconstructs
+ * an instance at the delegation call site via named-argument constructor invocation.
+ *
+ * `@Name` on a component of the spread class is honored the same way it is on top-level
+ * `@QFunction` parameters, so exported names are consistent across the wrapper regardless of
+ * whether a parameter came from the source function directly or from a spread component.
+ *
+ * Example:
+ *
+ * ```
+ * data class Style(
+ *     @Name("foreground") val foregroundColor: String,
+ *     @Name("background") val backgroundColor: String = "white",
+ * )
+ *
+ * @QFunction
+ * fun container(text: String, @Spread style: Style) = ...
+ * ```
+ *
+ * generates:
+ *
+ * ```
+ * public fun container(
+ *     text: String,
+ *     foreground: String,
+ *     background: String = "white",
+ * ): ... =
+ *     container(text = text, style = Style(foregroundColor = foreground, backgroundColor = background))
+ * ```
+ */
+@Target(AnnotationTarget.VALUE_PARAMETER)
+@Retention(AnnotationRetention.SOURCE)
+annotation class Spread

--- a/quarkdown-native-library-processor/src/main/kotlin/com/quarkdown/processor/discovery/AnnotationExtractor.kt
+++ b/quarkdown-native-library-processor/src/main/kotlin/com/quarkdown/processor/discovery/AnnotationExtractor.kt
@@ -39,5 +39,5 @@ internal object AnnotationExtractor {
     }
 
     /** Simple-name matches skipped from propagation because the processor handles them itself. */
-    private val SKIP_SHORT_NAMES = setOf("Name", "QFunction")
+    private val SKIP_SHORT_NAMES = setOf("Name", "QFunction", "Spread")
 }

--- a/quarkdown-native-library-processor/src/main/kotlin/com/quarkdown/processor/discovery/ModuleDescriber.kt
+++ b/quarkdown-native-library-processor/src/main/kotlin/com/quarkdown/processor/discovery/ModuleDescriber.kt
@@ -1,9 +1,11 @@
 package com.quarkdown.processor.discovery
 
+import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.google.devtools.ksp.symbol.KSFile
 import com.google.devtools.ksp.symbol.KSFunctionDeclaration
 import com.google.devtools.ksp.symbol.KSValueParameter
 import com.quarkdown.processor.annotation.QFunction
+import com.quarkdown.processor.annotation.Spread
 import com.quarkdown.processor.model.FunctionDescriptor
 import com.quarkdown.processor.model.ModuleDescriptor
 import com.quarkdown.processor.model.ParameterDescriptor
@@ -64,6 +66,13 @@ internal object ModuleDescriber {
                 ctx.logger.error("Cannot resolve return type of '$originalName'.", function)
                 return null
             }
+
+        // Record every parameter's export up-front so the rename map is complete before any
+        // default expression on this function is extracted.
+        function.parameters.forEach { param ->
+            val paramOriginal = param.name?.asString() ?: return@forEach
+            ctx.mappings.record(param, param.quarkdownName() ?: paramOriginal)
+        }
         val parameters = function.parameters.map { describe(it, ctx) ?: return null }
 
         return FunctionDescriptor(
@@ -86,14 +95,75 @@ internal object ModuleDescriber {
                 ctx.logger.error("Unnamed parameter in @QFunction is not supported.", parameter)
                 return null
             }
-        val exportedName = parameter.quarkdownName() ?: originalName
-        ctx.mappings.record(parameter, exportedName)
-        return ParameterDescriptor(
+        if (parameter.hasAnnotation<Spread>()) {
+            return describeSpread(originalName, parameter, ctx)
+        }
+        return ParameterDescriptor.Plain(
             originalName = originalName,
-            exportedName = exportedName,
+            exportedName = ctx.mappings.exportedName(parameter) ?: originalName,
             type = parameter.type.resolve(),
             defaultExpression = DefaultValueExtractor.extract(parameter, ctx),
             sourceAnnotations = AnnotationExtractor.ForParameter.extract(parameter, ctx),
+        )
+    }
+
+    /**
+     * Expands a `@Spread` parameter into one [ParameterDescriptor.Plain] per member of its
+     * class's primary constructor.
+     *
+     * Records every component's exported name into the shared [NameMappings] before describing
+     * any of them, so a component default that references a sibling under its exported name
+     * (see [DefaultValueExtractor]) resolves against a complete rename map rather than a
+     * partially-built one.
+     */
+    private fun describeSpread(
+        outerName: String,
+        parameter: KSValueParameter,
+        ctx: DiscoveryContext,
+    ): ParameterDescriptor.Spread {
+        val classDeclaration =
+            parameter.type.resolve().declaration as? KSClassDeclaration
+                ?: error("@Spread parameter '$outerName' must reference a class type")
+        val primary =
+            classDeclaration.primaryConstructor
+                ?: error(
+                    "@Spread class '${classDeclaration.qualifiedName?.asString()}' must have a primary constructor",
+                )
+
+        // Two-pass registration: components may reference each other in default expressions,
+        // and the rename map must be complete before any component is described.
+        primary.parameters.forEach { component ->
+            val componentOriginal = component.name?.asString() ?: return@forEach
+            ctx.mappings.record(component, component.quarkdownName() ?: componentOriginal)
+        }
+        val components = primary.parameters.map { describePlainComponent(it, ctx) }
+
+        return ParameterDescriptor.Spread(
+            originalName = outerName,
+            dataClassFqn =
+                classDeclaration.qualifiedName?.asString()
+                    ?: error("@Spread parameter '$outerName' references an unresolvable class type"),
+            components = components,
+            sourceAnnotations = AnnotationExtractor.ForParameter.extract(parameter, ctx),
+        )
+    }
+
+    /**
+     * Describes a single primary-constructor parameter of a spread class as a wrapper-level
+     * [ParameterDescriptor.Plain]. Uses the same extractors as top-level parameters, so
+     * `@Name`, defaults, and propagated annotations follow the same rules.
+     */
+    private fun describePlainComponent(
+        component: KSValueParameter,
+        ctx: DiscoveryContext,
+    ): ParameterDescriptor.Plain {
+        val original = component.name?.asString() ?: error("Unnamed @Spread component parameter is not supported")
+        return ParameterDescriptor.Plain(
+            originalName = original,
+            exportedName = ctx.mappings.exportedName(component) ?: original,
+            type = component.type.resolve(),
+            defaultExpression = DefaultValueExtractor.extract(component, ctx),
+            sourceAnnotations = AnnotationExtractor.ForParameter.extract(component, ctx),
         )
     }
 }

--- a/quarkdown-native-library-processor/src/main/kotlin/com/quarkdown/processor/discovery/NameMappings.kt
+++ b/quarkdown-native-library-processor/src/main/kotlin/com/quarkdown/processor/discovery/NameMappings.kt
@@ -50,6 +50,11 @@ internal class NameMappings {
     fun exportedName(function: KSFunctionDeclaration): String? = functionExports[keyOf(function)]
 
     /**
+     * Returns the recorded exported name of [parameter], or `null` when [parameter] was never recorded.
+     */
+    fun exportedName(parameter: KSValueParameter): String? = keyOf(parameter)?.let { parameterExports[it] }
+
+    /**
      * Returns an original-name -> exported-name map for every parameter of [function] whose
      * export renamed it. Parameters that are unchanged (or unrecorded) are omitted so callers
      * can use `Map.get` semantics without post-filtering.

--- a/quarkdown-native-library-processor/src/main/kotlin/com/quarkdown/processor/generation/ModuleCodeGenerator.kt
+++ b/quarkdown-native-library-processor/src/main/kotlin/com/quarkdown/processor/generation/ModuleCodeGenerator.kt
@@ -84,23 +84,51 @@ class ModuleCodeGenerator(
     }
 
     private fun StringBuilder.appendWrapper(function: FunctionDescriptor) {
-        val parameters = function.parameters.joinToString(", ", transform = ::renderParameter)
+        val signatureEntries = function.parameters.flatMap { it.signatureContributions() }
+        val parameters = signatureEntries.joinToString(", ", transform = ::renderPlain)
         val returnType = KSTypeRenderer.render(function.returnType)
-        val delegateArguments =
-            function.parameters.joinToString(", ") {
-                "${it.originalName.backtick()} = ${it.exportedName.backtick()}"
-            }
+        val delegateArguments = function.parameters.joinToString(", ", transform = ::renderDelegation)
         function.sourceAnnotations?.let { appendLine("\t$it") }
         appendLine("\tpublic fun ${function.exportedName.backtick()}($parameters): $returnType =")
         appendLine("\t\t${function.qualifiedName.backtickLastSegment()}($delegateArguments)")
     }
 
-    private fun renderParameter(parameter: ParameterDescriptor): String {
-        // Parameter annotations (@Injected, @Body, @LikelyNamed, ...) precede the declaration.
+    /**
+     * Wrapper parameters this descriptor puts on the generated function's signature:
+     * plain parameters contribute themselves; spread parameters contribute their components,
+     * so a data-class parameter turns into one wrapper parameter per constructor member.
+     */
+    private fun ParameterDescriptor.signatureContributions(): List<ParameterDescriptor.Plain> =
+        when (this) {
+            is ParameterDescriptor.Plain -> listOf(this)
+            is ParameterDescriptor.Spread -> components
+        }
+
+    private fun renderPlain(parameter: ParameterDescriptor.Plain): String {
         val annotations = parameter.sourceAnnotations?.let { "$it " } ?: ""
         val signature = "$annotations${parameter.exportedName.backtick()}: ${KSTypeRenderer.render(parameter.type)}"
         return parameter.defaultExpression?.let { "$signature = $it" } ?: signature
     }
+
+    /**
+     * Delegation argument for one source-level parameter: `original = exported` for a plain
+     * parameter, and `original = FQN(componentOriginal = componentExported, ...)` for a spread
+     * one, so the source function receives a reconstructed data-class instance.
+     */
+    private fun renderDelegation(parameter: ParameterDescriptor): String =
+        when (parameter) {
+            is ParameterDescriptor.Plain -> {
+                "${parameter.originalName.backtick()} = ${parameter.exportedName.backtick()}"
+            }
+
+            is ParameterDescriptor.Spread -> {
+                val reconstruction =
+                    parameter.components.joinToString(", ") {
+                        "${it.originalName.backtick()} = ${it.exportedName.backtick()}"
+                    }
+                "${parameter.originalName.backtick()} = ${parameter.dataClassFqn.backtickLastSegment()}($reconstruction)"
+            }
+        }
 
     private companion object {
         const val QUARKDOWN_MODULE_FQN = "com.quarkdown.core.function.library.module.QuarkdownModule"

--- a/quarkdown-native-library-processor/src/main/kotlin/com/quarkdown/processor/model/ModuleDescriptor.kt
+++ b/quarkdown-native-library-processor/src/main/kotlin/com/quarkdown/processor/model/ModuleDescriptor.kt
@@ -49,18 +49,56 @@ data class FunctionDescriptor(
 )
 
 /**
- * A single parameter of an exported [FunctionDescriptor].
+ * A parameter of an exported [FunctionDescriptor].
  *
- * @param originalName Kotlin parameter name on the source function
- * @param exportedName name to use on the generated wrapper, possibly rewritten by `@Name`
- * @param type the resolved parameter type
- * @param defaultExpression verbatim source text of the parameter's default value, or `null` when the parameter has no default
- * @param sourceAnnotations verbatim source text of parameter-level annotations to propagate to the wrapper
+ * Sealed so that each variant represents a distinct contribution to the wrapper:
+ * - [Plain] maps 1:1 to the source function's parameter list;
+ * - [Spread] expands a class type into one wrapper parameter per constructor member and
+ *   rebuilds the instance at the delegation call site.
+ *
+ * The code generator flat-maps every parameter to its Plain contributions when assembling the
+ * wrapper's signature and switches on the concrete variant when assembling the delegation.
  */
-data class ParameterDescriptor(
-    val originalName: String,
-    val exportedName: String,
-    val type: KSType,
-    val defaultExpression: String?,
-    val sourceAnnotations: String?,
-)
+sealed class ParameterDescriptor {
+    /** Kotlin parameter name on the source function (the name used as the delegation argument label). */
+    abstract val originalName: String
+
+    /** Verbatim source text of parameter-level annotations to propagate to the wrapper, or `null` when none apply. */
+    abstract val sourceAnnotations: String?
+
+    /**
+     * A plain parameter: exactly one entry in the source function's parameter list, exactly one
+     * entry in the wrapper's parameter list.
+     *
+     * @param originalName Kotlin parameter name on the source function
+     * @param exportedName name to use on the generated wrapper, possibly rewritten by `@Name`
+     * @param type the resolved parameter type
+     * @param defaultExpression verbatim source text of the parameter's default value, or `null` when the parameter has no default
+     * @param sourceAnnotations verbatim source text of parameter-level annotations to propagate to the wrapper
+     */
+    data class Plain(
+        override val originalName: String,
+        val exportedName: String,
+        val type: KSType,
+        val defaultExpression: String?,
+        override val sourceAnnotations: String?,
+    ) : ParameterDescriptor()
+
+    /**
+     * A spread parameter: the source function declared one parameter of a class type marked with
+     * `@Spread`; the wrapper exposes one [Plain] per primary-constructor member of that class
+     * and reconstructs an instance via named-argument constructor invocation at the delegation.
+     *
+     * @param originalName Kotlin parameter name of the outer spread parameter on the source function
+     * @param dataClassFqn fully qualified name of the class being spread, used to emit the reconstruction call
+     * @param components one [Plain] per primary-constructor parameter of the spread class, in declaration order
+     * @param sourceAnnotations verbatim source text of the outer parameter's annotations
+     *                          (the processor filters `@Spread` out; anything else is retained but currently not emitted since the outer parameter itself is not part of the wrapper signature)
+     */
+    data class Spread(
+        override val originalName: String,
+        val dataClassFqn: String,
+        val components: List<Plain>,
+        override val sourceAnnotations: String?,
+    ) : ParameterDescriptor()
+}

--- a/quarkdown-native-library-processor/src/test/kotlin/com/quarkdown/processor/fixtures/SpreadParameter.kt
+++ b/quarkdown-native-library-processor/src/test/kotlin/com/quarkdown/processor/fixtures/SpreadParameter.kt
@@ -1,0 +1,33 @@
+@file:QModule
+
+package com.quarkdown.processor.fixtures
+
+import com.quarkdown.core.function.reflect.annotation.LikelyNamed
+import com.quarkdown.core.function.reflect.annotation.Name
+import com.quarkdown.core.function.value.VoidValue
+import com.quarkdown.processor.annotation.QFunction
+import com.quarkdown.processor.annotation.QModule
+import com.quarkdown.processor.annotation.Spread
+
+/*
+ * Fixture: `@Spread` expands a data class into wrapper parameters. Covers:
+ * - `@Name` rewriting on spread components,
+ * - a component-level default value,
+ * - an `@LikelyNamed` annotation on a component that must propagate to the wrapper,
+ * - a plain sibling parameter that must interleave in declaration order (plain before spread),
+ * - a component default that references a renamed sibling
+ *   (`color = foregroundColor` -> `color = foreground` in the wrapper).
+ */
+
+data class Style(
+    @Name("foreground") val foregroundColor: String,
+    @Name("background") val backgroundColor: String = "white",
+    @LikelyNamed val opacity: Double = 1.0,
+    val color: String = foregroundColor,
+)
+
+@QFunction
+fun withSpreadStyle(
+    text: String,
+    @Spread style: Style,
+) = VoidValue

--- a/quarkdown-native-library-processor/src/test/kotlin/com/quarkdown/processor/integration/SpreadParameterTest.kt
+++ b/quarkdown-native-library-processor/src/test/kotlin/com/quarkdown/processor/integration/SpreadParameterTest.kt
@@ -1,0 +1,69 @@
+package com.quarkdown.processor.integration
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertContains
+import kotlin.test.assertFalse
+
+/**
+ * `@Spread` expansion: the wrapper's parameter list absorbs the class's members and the
+ * delegation call reconstructs the class via named-argument constructor invocation.
+ */
+class SpreadParameterTest {
+    private val source by lazy { GeneratedFiles.sourceOf("SpreadParameter") }
+
+    @Test
+    fun `outer spread parameter does not appear in the wrapper signature`() {
+        // No entry for the outer `style: Style` parameter itself.
+        assertFalse(
+            "`style`: " in source,
+            "outer @Spread parameter must be replaced by its components, not carried through:\n$source",
+        )
+    }
+
+    @Test
+    fun `each spread component becomes a wrapper parameter under its exported name`() {
+        // `@Name("foreground") val foregroundColor` -> wrapper param `foreground`
+        assertContains(source, "`foreground`: kotlin.String")
+        // `@Name("background") val backgroundColor = "white"` -> wrapper param `background`
+        assertContains(source, "`background`: kotlin.String = \"white\"")
+        // `@LikelyNamed val opacity = 1.0` -> wrapper param `opacity` with propagated annotation
+        assertContains(source, "@LikelyNamed `opacity`: kotlin.Double = 1.0")
+    }
+
+    @Test
+    fun `plain siblings survive alongside spread components in declaration order`() {
+        assertContains(source, "`text`: kotlin.String")
+        // The spread expansion happens where the outer parameter sat, so the wrapper reads
+        // text -> foreground -> background -> opacity in that order.
+        val textIdx = source.indexOf("`text`: kotlin.String")
+        val foregroundIdx = source.indexOf("`foreground`: kotlin.String")
+        val opacityIdx = source.indexOf("`opacity`: kotlin.Double")
+        check(textIdx in 0 until foregroundIdx) { "text should appear before spread components" }
+        check(foregroundIdx in 0 until opacityIdx) { "spread components should be in declaration order" }
+    }
+
+    @Test
+    fun `delegation reconstructs the data class via named-argument constructor call`() {
+        // outer name -> original data-class-parameter names -> exported wrapper param names
+        assertContains(
+            source,
+            "`style` = com.quarkdown.processor.fixtures.`Style`(" +
+                "`foregroundColor` = `foreground`, " +
+                "`backgroundColor` = `background`, " +
+                "`opacity` = `opacity`, " +
+                "`color` = `color`)",
+        )
+    }
+
+    @Test
+    fun `spread component default referencing a renamed sibling is rewritten to the exported name`() {
+        // Source: `val color: String = foregroundColor` where `foregroundColor` was renamed
+        // to `foreground` via `@Name`. The wrapper's default must track the rename.
+        assertContains(source, "`color`: kotlin.String = foreground")
+    }
+
+    @Test
+    fun `Spread marker itself is filtered from the wrapper`() {
+        assertFalse("@Spread" in source, "@Spread should not leak into the generated wrapper")
+    }
+}

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Layout.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Layout.kt
@@ -38,6 +38,40 @@ import com.quarkdown.core.misc.color.Color
 import com.quarkdown.core.util.node.toPlainText
 import com.quarkdown.processor.annotation.QFunction
 import com.quarkdown.processor.annotation.QModule
+import com.quarkdown.processor.annotation.Spread
+
+/**
+ * @param foregroundColor text color. Default if unset
+ * @param backgroundColor background color. Transparent if unset
+ * @param borderColor border color. Default if unset and [borderWidth] is set
+ * @param borderWidth border width. Default if unset and [borderColor] is set
+ * @param borderStyle border style. Normal (solid) if unset and [borderColor] or [borderWidth] is set
+ * @param margin whitespace outside the content. None if unset
+ * @param padding whitespace around the content. None if unset
+ * @param cornerRadius corner (and border) radius. None if unset
+ * @param fontSize relative font size of the text. Normal if unset
+ * @param fontWeight font weight of the text. Normal if unset
+ * @param fontStyle font style of the text. Normal if unset
+ * @param fontVariant font variant of the text. Normal if unset
+ * @param textDecoration text decoration of the text. None if unset
+ * @param textCase text case of the text. Normal if unset
+ */
+data class StyleOptions(
+    @Name("foreground") val foregroundColor: Color? = null,
+    @Name("background") val backgroundColor: Color? = null,
+    @Name("border") val borderColor: Color? = null,
+    @Name("borderwidth") val borderWidth: Sizes? = null,
+    @Name("borderstyle") val borderStyle: Container.BorderStyle? = null,
+    @Name("margin") val margin: Sizes? = null,
+    @Name("padding") val padding: Sizes? = null,
+    @Name("radius") val cornerRadius: Sizes? = null,
+    @Name("fontsize") val fontSize: TextTransformData.Size? = null,
+    @Name("fontweight") val fontWeight: TextTransformData.Weight? = null,
+    @Name("fontstyle") val fontStyle: TextTransformData.Style? = null,
+    @Name("fontvariant") val fontVariant: TextTransformData.Variant? = null,
+    @Name("textdecoration") val textDecoration: TextTransformData.Decoration? = null,
+    @Name("textcase") val textCase: TextTransformData.Case? = null,
+)
 
 /**
  * A general-purpose container that groups content.
@@ -47,22 +81,8 @@ import com.quarkdown.processor.annotation.QModule
  * @param width width of the container. No constraint if unset
  * @param height height of the container. No constraint if unset
  * @param fullWidth whether the container should take up the full width of the parent. Overridden by [width]. False if unset
- * @param foregroundColor text color. Default if unset
- * @param backgroundColor background color. Transparent if unset
- * @param borderColor border color. Default if unset and [borderWidth] is set
- * @param borderWidth border width. Default if unset and [borderColor] is set
- * @param borderStyle border style. Normal (solid) if unset and [borderColor] or [borderWidth] is set
- * @param margin whitespace outside the content. None if unset
- * @param padding whitespace around the content. None if unset
- * @param cornerRadius corner (and border) radius. None if unset
  * @param alignment alignment of the content. Default if unset
  * @param textAlignment alignment of the text. [alignment] if unset
- * @param fontSize relative font size of the text. Normal if unset
- * @param fontWeight font weight of the text. Normal if unset
- * @param fontStyle font style of the text. Normal if unset
- * @param fontVariant font variant of the text. Normal if unset
- * @param textDecoration text decoration of the text. None if unset
- * @param textCase text case of the text. Normal if unset
  * @param float floating position of the container within the parent. Not floating if unset
  * @param fullColumnSpan whether the container should span across all columns in a multi-column layout. False if unset
  * @param className CSS class name to apply to the container, if supported by the renderer. None if unset
@@ -74,42 +94,29 @@ import com.quarkdown.processor.annotation.QModule
 fun container(
     @LikelyNamed width: Size? = null,
     @LikelyNamed height: Size? = null,
-    @Name("fullwidth") fullWidth: Boolean = false,
-    @Name("foreground") foregroundColor: Color? = null,
-    @Name("background") backgroundColor: Color? = null,
-    @Name("border") borderColor: Color? = null,
-    @Name("borderwidth") borderWidth: Sizes? = null,
-    @Name("borderstyle") borderStyle: Container.BorderStyle? = null,
-    @Name("margin") margin: Sizes? = null,
-    @Name("padding") padding: Sizes? = null,
-    @Name("radius") cornerRadius: Sizes? = null,
     @LikelyNamed alignment: Container.Alignment? = null,
     @Name("textalignment") textAlignment: Container.TextAlignment? = alignment?.let(Container.TextAlignment::fromAlignment),
-    @Name("fontsize") fontSize: TextTransformData.Size? = null,
-    @Name("fontweight") fontWeight: TextTransformData.Weight? = null,
-    @Name("fontstyle") fontStyle: TextTransformData.Style? = null,
-    @Name("fontvariant") fontVariant: TextTransformData.Variant? = null,
-    @Name("textdecoration") textDecoration: TextTransformData.Decoration? = null,
-    @Name("textcase") textCase: TextTransformData.Case? = null,
+    @Name("fullwidth") fullWidth: Boolean = false,
     @LikelyNamed float: Container.FloatAlignment? = null,
     @Name("fullspan") fullColumnSpan: Boolean = false,
     @Name("classname") className: String? = null,
+    @Spread style: StyleOptions = StyleOptions(),
     @Body body: MarkdownContent? = null,
 ) = Container(
     width,
     height,
     fullWidth,
-    foregroundColor,
-    backgroundColor,
-    borderColor,
-    borderWidth,
-    borderStyle,
-    margin,
-    padding,
-    cornerRadius,
+    style.foregroundColor,
+    style.backgroundColor,
+    style.borderColor,
+    style.borderWidth,
+    style.borderStyle,
+    style.margin,
+    style.padding,
+    style.cornerRadius,
     alignment,
     textAlignment,
-    TextTransformData(fontSize, fontWeight, fontStyle, textDecoration, textCase, fontVariant),
+    TextTransformData(style.fontSize, style.fontWeight, style.fontStyle, style.textDecoration, style.textCase, style.fontVariant),
     float,
     fullColumnSpan,
     className,


### PR DESCRIPTION
- [X] I have read the [contributing guidelines](https://github.com/iamgio/quarkdown/blob/main/CONTRIBUTING.md).
- [X] I have tested the changes locally.
- [ ] An issue for this change exists, and it was discussed with maintainers. This is required for new features and non-trivial changes. If present, append `Closes #ISSUE_NUMBER` at the end of this PR description.
- [ ] (Optional) I have added necessary documentation to [`docs`](https://github.com/iamgio/quarkdown/tree/main/docs) and [`CHANGELOG.md`](https://github.com/iamgio/quarkdown/blob/main/CHANGELOG.md)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `StyleOptions` and updated `container` to accept a single `@Spread style: StyleOptions = StyleOptions()` parameter, grouping colors, borders, spacing, and text transforms.
  * Added `@Spread` parameter expansion in generated wrappers, flattening class fields into wrapper parameters and reconstructing the original instance at the call site.
* **Bug Fixes**
  * Improved exported-name preservation (including for default expressions) and propagated parameter annotations for spread components.
  * Ensured the literal `@Spread` marker is not emitted in generated wrapper sources.
* **Tests**
  * Added integration coverage for `@Spread` parameter behavior and ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->