### PR TITLE
feat: add first class styling to heading

### DIFF
--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/base/block/Heading.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/base/block/Heading.kt
@@ -9,6 +9,8 @@ import com.quarkdown.core.ast.attributes.localization.LocalizedKind
 import com.quarkdown.core.ast.attributes.localization.LocalizedKindKeys
 import com.quarkdown.core.ast.attributes.location.LocationTrackableNode
 import com.quarkdown.core.ast.attributes.primitive.PrimitiveFunctionBackedNode
+import com.quarkdown.core.ast.attributes.style.NodeStyle
+import com.quarkdown.core.ast.attributes.style.StylableNode
 import com.quarkdown.core.ast.base.TextNode
 import com.quarkdown.core.ast.quarkdown.reference.CrossReferenceableNode
 import com.quarkdown.core.function.call.FunctionCallArgument
@@ -40,11 +42,13 @@ class Heading(
     val canBreakPage: Boolean = true,
     override val canTrackLocation: Boolean = true,
     val excludeFromTableOfContents: Boolean = false,
+    override val style: NodeStyle = NodeStyle(),
 ) : TextNode,
     Identifiable,
     LocationTrackableNode,
     CrossReferenceableNode,
     LocalizedKind,
+    StylableNode,
     PrimitiveFunctionBackedNode {
     override fun <T> accept(visitor: NodeVisitor<T>) = visitor.visit(this)
 

--- a/quarkdown-html/src/main/kotlin/com/quarkdown/rendering/html/HtmlTagBuilder.kt
+++ b/quarkdown-html/src/main/kotlin/com/quarkdown/rendering/html/HtmlTagBuilder.kt
@@ -1,10 +1,12 @@
 package com.quarkdown.rendering.html
 
 import com.quarkdown.core.ast.Node
+import com.quarkdown.core.ast.attributes.style.NodeStyle
 import com.quarkdown.core.rendering.tag.TagBuilder
 import com.quarkdown.core.rendering.tag.tagBuilder
 import com.quarkdown.core.util.indent
 import com.quarkdown.rendering.html.css.CssBuilder
+import com.quarkdown.rendering.html.css.all
 import com.quarkdown.rendering.html.css.css
 import com.quarkdown.rendering.html.node.BaseHtmlNodeRenderer
 
@@ -86,6 +88,22 @@ class HtmlTagBuilder(
      * @see com.quarkdown.rendering.html.css.css
      */
     fun style(init: CssBuilder.() -> Unit) = optionalAttribute("style", css(init).takeUnless { it.isEmpty() })
+
+    /**
+     * Applies a [NodeStyle] via the `style` attribute to this tag.
+     * The attribute is _not_ added if the generated CSS string is empty.
+     * @param style the style to apply
+     * @param init additional CSS builder initialization
+     * @return this for concatenation
+     * @see com.quarkdown.rendering.html.css.css
+     */
+    fun style(
+        style: NodeStyle,
+        init: CssBuilder.() -> Unit = {},
+    ) = style {
+        init()
+        all(style)
+    }
 
     /**
      * Applies a single class name via the `class` attribute to this tag.

--- a/quarkdown-html/src/main/kotlin/com/quarkdown/rendering/html/node/QuarkdownHtmlNodeRenderer.kt
+++ b/quarkdown-html/src/main/kotlin/com/quarkdown/rendering/html/node/QuarkdownHtmlNodeRenderer.kt
@@ -78,7 +78,6 @@ import com.quarkdown.core.util.kebabCaseName
 import com.quarkdown.rendering.html.HtmlIdentifierProvider
 import com.quarkdown.rendering.html.HtmlIdentifierProvider.Companion.sanitizeId
 import com.quarkdown.rendering.html.HtmlTagBuilder
-import com.quarkdown.rendering.html.css.all
 import com.quarkdown.rendering.html.css.asCSS
 import com.quarkdown.rendering.html.css.textTransform
 
@@ -210,11 +209,10 @@ class QuarkdownHtmlNodeRenderer(
 
             +node.children
 
-            style {
+            style(node.style) {
                 "width" value node.width
                 "height" value node.height
                 "float" value node.float
-                all(node.style)
             }
         }
 
@@ -639,6 +637,7 @@ class QuarkdownHtmlNodeRenderer(
                     ?.getId(node),
             ).optionalAttribute("data-decorative", "".takeIf { node.isDecorative })
             .withLocationLabel(node)
+            .style(node.style)
             .build()
     }
 

--- a/quarkdown-html/src/test/e2e/heading/styling/main.qd
+++ b/quarkdown-html/src/test/e2e/heading/styling/main.qd
@@ -1,0 +1,7 @@
+.extend {heading}
+    depth:
+    .super foreground:{#ff0000} background:{#00ff00} \
+           fontweight:{bold} fontstyle:{italic} fontvariant:{smallcaps} \
+           textdecoration:{underline}
+
+## Styled heading

--- a/quarkdown-html/src/test/e2e/heading/styling/styling.spec.ts
+++ b/quarkdown-html/src/test/e2e/heading/styling/styling.spec.ts
@@ -1,0 +1,18 @@
+import {getComputedColor} from "../../__util/css";
+import {suite} from "../../quarkdown";
+
+const {test, expect} = suite(__dirname);
+
+test("applies multiple inline styles to a heading", async (page) => {
+    const heading = page.locator("h2").first();
+
+    const red = await getComputedColor(page, "#ff0000");
+    const green = await getComputedColor(page, "#00ff00");
+
+    await expect(heading).toHaveCSS("color", red);
+    await expect(heading).toHaveCSS("background-color", green);
+    await expect(heading).toHaveCSS("font-weight", "700");
+    await expect(heading).toHaveCSS("font-style", "italic");
+    await expect(heading).toHaveCSS("font-variant-caps", "small-caps");
+    await expect(heading).toHaveCSS("text-decoration-line", "underline");
+});

--- a/quarkdown-html/src/test/kotlin/com/quarkdown/rendering/html/HtmlNodeRendererTest.kt
+++ b/quarkdown-html/src/test/kotlin/com/quarkdown/rendering/html/HtmlNodeRendererTest.kt
@@ -529,6 +529,20 @@ class HtmlNodeRendererTest {
         assertEquals(out.next(), Heading(2, listOf(Text("Foo bar"))).render(autoPageBreak))
         assertEquals(out.next(), Heading(3, listOf(Text("Foo bar"))).render(autoPageBreak))
         assertEquals(out.next(), Heading(4, listOf(Text("Foo bar"))).render(autoPageBreak))
+
+        // Styling.
+        assertEquals(
+            out.next(),
+            Heading(
+                2,
+                listOf(Text("Foo bar")),
+                style =
+                    NodeStyle(
+                        foregroundColor = Color(255, 0, 0),
+                        textTransform = TextTransformData(variant = TextTransformData.Variant.SMALL_CAPS),
+                    ),
+            ).render(),
+        )
     }
 
     private fun listItems() =

--- a/quarkdown-html/src/test/resources/rendering/block/heading.html
+++ b/quarkdown-html/src/test/resources/rendering/block/heading.html
@@ -81,3 +81,9 @@
 <h4 id="foo-bar">
     Foo bar
 </h4>
+
+---
+
+<h2 id="foo-bar" style="color: rgba(255, 0, 0, 1.0); font-variant: small-caps;">
+    Foo bar
+</h2>

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Primitives.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Primitives.kt
@@ -19,6 +19,7 @@ import com.quarkdown.core.function.value.wrappedAsValue
 import com.quarkdown.processor.annotation.Name
 import com.quarkdown.processor.annotation.QFunction
 import com.quarkdown.processor.annotation.QModule
+import com.quarkdown.processor.annotation.Spread
 
 /**
  * Creates a heading with fine-grained control over its behavior.
@@ -50,6 +51,7 @@ fun heading(
     @Name("numbered") canTrackLocation: Boolean = true,
     @Name("indexed") includeInTableOfContents: Boolean = true,
     @Name("breakpage") canBreakPage: Boolean = true,
+    @Spread style: StyleOptions = StyleOptions(),
 ): NodeValue {
     require(depth in Heading.MIN_DEPTH..Heading.MAX_DEPTH) {
         "Heading depth must be between ${Heading.MIN_DEPTH} and ${Heading.MAX_DEPTH}, but got $depth."
@@ -62,6 +64,7 @@ fun heading(
         canBreakPage = canBreakPage,
         canTrackLocation = canTrackLocation,
         excludeFromTableOfContents = !includeInTableOfContents,
+        style = style.toNodeStyle(),
     ).let(::NodeValue)
 }
 

--- a/quarkdown-test/src/test/kotlin/com/quarkdown/test/HeadingTest.kt
+++ b/quarkdown-test/src/test/kotlin/com/quarkdown/test/HeadingTest.kt
@@ -126,6 +126,18 @@ class HeadingTest {
     }
 
     @Test
+    fun `heading primitive with styling`() {
+        execute(".heading {Hello} depth:{2} foreground:{red} background:{blue} fontsize:{small}") {
+            assertEquals(
+                "<h2 style=\"color: rgba(255, 0, 0, 1.0); " +
+                    "background-color: rgba(0, 0, 255, 1.0); " +
+                    "font-size: var(--qd-size-small, 1em);\">Hello</h2>",
+                it,
+            )
+        }
+    }
+
+    @Test
     fun `duplicate auto identifiers are disambiguated`() {
         execute(
             """

--- a/quarkdown-test/src/test/kotlin/com/quarkdown/test/primitive/HeadingPrimitiveFunctionTest.kt
+++ b/quarkdown-test/src/test/kotlin/com/quarkdown/test/primitive/HeadingPrimitiveFunctionTest.kt
@@ -154,6 +154,29 @@ class HeadingPrimitiveFunctionTest {
     }
 
     @Test
+    fun `styling can be applied via super`() {
+        execute(
+            """
+            .extend {heading}
+                depth:
+                .super foreground:{red} \
+                       background:{.takeif {red} {@lambda .depth::islower than:{3}}} \
+                       fontvariant:{smallcaps}
+
+            ## Hello
+            
+            ### Hello
+            """.trimIndent(),
+        ) {
+            assertEquals(
+                "<h2 style=\"color: rgba(255, 0, 0, 1.0); background-color: rgba(255, 0, 0, 1.0); font-variant: small-caps;\">Hello</h2>" +
+                    "<h3 style=\"color: rgba(255, 0, 0, 1.0); font-variant: small-caps;\">Hello</h3>",
+                it,
+            )
+        }
+    }
+
+    @Test
     fun `extension reaches headings nested inside a blockquote`() {
         execute(
             """


### PR DESCRIPTION
- [X] I have read the [contributing guidelines](https://github.com/iamgio/quarkdown/blob/main/CONTRIBUTING.md).
- [X] I have tested the changes locally.
- [ ] An issue for this change exists, and it was discussed with maintainers. This is required for new features and non-trivial changes. If present, append `Closes #ISSUE_NUMBER` at the end of this PR description.
- [ ] (Optional) I have added necessary documentation to [`docs`](https://github.com/iamgio/quarkdown/tree/main/docs) and [`CHANGELOG.md`](https://github.com/iamgio/quarkdown/blob/main/CHANGELOG.md)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Headings can now carry inline styling (foreground/background, font weight/style/variant, text decoration, and typography effects).
  * The heading primitive now accepts styling options directly.
  * HTML rendering applies heading and container styles more consistently, emitting expected inline styles on the correct elements.

* **Tests**
  * Added and extended unit and end-to-end coverage for styled headings, including conditional styling by heading depth.
  * Updated HTML fixtures and assertions to match the new inline `style` output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->