### PR TITLE
docs: add reused node styling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@
 
 &nbsp;
 
+#### Full styling options on `.heading`
+
+`.container`'s styling options, such as `foreground`, `background`, `border`, `padding`, and `fontsize`, are now available on `.heading` as well. This allows for full customization without needing to wrap the heading in a container.
+
+```markdown
+.heading {Introduction} depth:{1} background:{blue} radius:{8px}
+```
+
+This plays particularly well with the new primitive extension system:
+
+```markdown
+.extend {heading}
+    content:
+    .super background:{red} foreground:{white} padding:{10px}
+```
+
+The plan is to eventually extend these options to all element types and primitive functions.
+
+&nbsp;
+
 #### [Regex match](https://quarkdown.com/wiki/regex-match)
 
 The new `.match` function finds every substring of inline content that matches a regular expression and replaces each match with the inline content produced by a lambda.

--- a/docs/_nav.qd
+++ b/docs/_nav.qd
@@ -56,6 +56,7 @@
 ###! Layout
 - [Stacks: rows, columns, grids](stacks.qd)
 - [Container](container.qd)
+- [Element styling](element-styling.qd)
 - [Align](align.qd)
 - [Float](float.qd)
 - [Figure](custom-figure.qd)

--- a/docs/container.qd
+++ b/docs/container.qd
@@ -37,28 +37,18 @@ The **`.container`** .docslink {quarkdown-stdlib/com.quarkdown.stdlib.module.Lay
             ##! Right
             Text on right column.
 
+## Container-specific parameters
+
+| Parameter   | Description                                                        | Accepts                 | Default       |
+|-------------|--------------------------------------------------------------------|-------------------------|---------------|
+| `width`     | Box width constraint.                                              | [`Size`](sizes.qd)      | No constraint |
+| `height`    | Box height constraint.                                             | [`Size`](sizes.qd)      | No constraint |
+| `fullwidth` | Whether to take up the parent's full width. Overridden by `width`. | [`Boolean`](boolean.qd) | False         |
+| `classname` | Custom CSS class name.                                             | String                  | None          |
+
 ## Styling
 
-The following optional parameters are available:
-
-| Parameter | Description | Accepts | Default |
-|-----------|-------------|---------|---------|
-| `width` | Box width constraint. | [`Size`](sizes.qd) | No constraint |
-| `height` | Box height constraint. | [`Size`](sizes.qd) | No constraint |
-| `fullwidth` | Whether to take up the parent's full width. Overridden by `width`. | [`Boolean`](boolean.qd) | False |
-| `foreground` | Text color. | [`Color`](color.qd) | Document's default |
-| `background` | Background color. | [`Color`](color.qd) | None |
-| `border` | Border color. | [`Color`](color.qd) | Browser's default if `borderwidth` is set, none otherwise |
-| `borderwidth` | Border size. | [`Sizes`](sizes.qd) | Browser's default if `border` is set, none otherwise |
-| `borderstyle` | Border type. | `normal`, `dashed`, `dotted`, `double` | `normal` if `border` or `borderwidth` is set, none otherwise |
-| `margin ` | Whitespace outside the content. | [`Sizes`](sizes.qd) | None |
-| `padding ` | Whitespace around the content. | [`Sizes`](sizes.qd) | None |
-| `radius` | Corner or border radius. | [`Sizes`](sizes.qd) | None |
-| `alignment` | Content alignment. | `start`, `center`, `end` | Browser's default |
-| `textalignment` | Text alignment. | `start`, `center`, `end`, `justify` | Browser's default |
-| `fontsize`, `fontweight`, `fontstyle`, `fontvariant`, `textdecoration`, `textcase` | Text transformation. See [Advanced text formatting](text.qd) for details. | | None |
-| `classname` | Custom CSS class name. | String | None |
-
+`.container` accepts every option described on [*Element styling*](element-styling.qd), for customizing colors, spacing, borders, and text appearance.
 
 .examplemirror
     .container fullwidth:{yes} borderstyle:{dashed} padding:{1cm} fontsize:{medium} fontstyle:{italic} fontvariant:{smallcaps}

--- a/docs/element-styling.qd
+++ b/docs/element-styling.qd
@@ -1,0 +1,28 @@
+.docname {Element styling}
+.include {docs}
+
+Several functions, such as [`.container`](container.qd) and [`.heading`](headings.qd), share a common set of styling parameters to customize colors, spacing, borders, and text appearance of the element they produce.
+
+## Parameters
+
+| Parameter                                                                          | Description                                                                           | Accepts                                | Default                                                      |
+|------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------|----------------------------------------|--------------------------------------------------------------|
+| `foreground`                                                                       | Text color.                                                                           | [`Color`](color.qd)                    | Document's default                                           |
+| `background`                                                                       | Background color.                                                                     | [`Color`](color.qd)                    | None                                                         |
+| `border`                                                                           | Border color.                                                                         | [`Color`](color.qd)                    | Browser's default if `borderwidth` is set, none otherwise    |
+| `borderwidth`                                                                      | Border thickness.                                                                     | [`Sizes`](sizes.qd)                    | Browser's default if `border` is set, none otherwise         |
+| `borderstyle`                                                                      | Border type.                                                                          | `normal`, `dashed`, `dotted`, `double` | `normal` if `border` or `borderwidth` is set, none otherwise |
+| `margin`                                                                           | Whitespace outside the element.                                                       | [`Sizes`](sizes.qd)                    | None                                                         |
+| `padding`                                                                          | Whitespace between the border and the content.                                        | [`Sizes`](sizes.qd)                    | None                                                         |
+| `radius`                                                                           | Corner (and border) radius.                                                           | [`Sizes`](sizes.qd)                    | None                                                         |
+| `alignment`                                                                        | Content alignment.                                                                    | `start`, `center`, `end`               | Browser's default                                            |
+| `textalignment`                                                                    | Text alignment.                                                                       | `start`, `center`, `end`, `justify`    | Follows `alignment` if set                                   |
+| `fontsize`, `fontweight`, `fontstyle`, `fontvariant`, `textdecoration`, `textcase` | Text transformation. See [Advanced text formatting](text.qd) for the accepted values. |                                        | None                                                         |
+
+## Example
+
+.examplemirror
+    .container fullwidth:{yes} borderstyle:{dashed} padding:{1cm} fontsize:{medium} fontstyle:{italic} fontvariant:{smallcaps}
+        This is a styled container. Fancy, isn't it?
+
+        Quarkdown can truly give life to complex layouts with ease.

--- a/docs/headings.qd
+++ b/docs/headings.qd
@@ -61,4 +61,13 @@ You can assign a custom identifier for [cross-referencing](cross-references.qd):
 .heading {Introduction} depth:{2} ref:{intro}
 ```
 
+## Styling
+
+`.heading` accepts every option described on [Element styling](element-styling.qd), for customizing colors, spacing, borders, and text appearance. 
+
+.examplemirror
+    .heading {Introduction} depth:{2} foreground:{teal} fontvariant:{smallcaps} indexed:{no}
+
+## Decorative headings
+
 See also [Decorative headings](decorative-headings.qd) for headings excluded from numbering and the table of contents.


### PR DESCRIPTION
- [X] I have read the [contributing guidelines](https://github.com/iamgio/quarkdown/blob/main/CONTRIBUTING.md).
- [X] I have tested the changes locally.
- [ ] An issue for this change exists, and it was discussed with maintainers. This is required for new features and non-trivial changes. If present, append `Closes #ISSUE_NUMBER` at the end of this PR description.
- [ ] (Optional) I have added necessary documentation to [`docs`](https://github.com/iamgio/quarkdown/tree/main/docs) and [`CHANGELOG.md`](https://github.com/iamgio/quarkdown/blob/main/CHANGELOG.md)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an “Element styling” guide documenting shared styling options (colors, borders, spacing, radius, alignment, and text formatting).
  * Updated `.heading` documentation to reflect full styling support, including example snippets.
  * Refined `.container` documentation by separating container-specific parameters from shared styling options.
  * Added the new guide to the documentation navigation.
  * Expanded the changelog with the new entry for full `.heading` styling options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->