### PR TITLE
docs: add element styling

### DIFF
--- a/docs/_nav.qd
+++ b/docs/_nav.qd
@@ -20,6 +20,8 @@
 - [Document metadata](document-metadata.qd)
   - [Document types](document-types.qd)
 - [Theme](themes.qd)
+- [Element styling](element-styling.qd)
+  - [Styling properties](element-styling-properties.qd)
 - [Fonts](font-configuration.qd)
 - [Page format](page-format.qd)
   - [Multi-column layout](multi-column-layout.qd)
@@ -56,7 +58,6 @@
 ###! Layout
 - [Stacks: rows, columns, grids](stacks.qd)
 - [Container](container.qd)
-- [Element styling](element-styling.qd)
 - [Align](align.qd)
 - [Float](float.qd)
 - [Figure](custom-figure.qd)

--- a/docs/element-styling-properties.qd
+++ b/docs/element-styling-properties.qd
@@ -1,0 +1,28 @@
+.docname {Element styling properties}
+.include {docs}
+
+Several functions, such as [`.container`](container.qd) and [`.heading`](headings.qd), share a common set of styling parameters to customize colors, spacing, borders, and text appearance of the element they produce.
+
+## Parameters
+
+| Parameter                                                                          | Description                                                                           | Accepts                                | Default                                                      |
+|------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------|----------------------------------------|--------------------------------------------------------------|
+| `foreground`                                                                       | Text color.                                                                           | [`Color`](color.qd)                    | Document's default                                           |
+| `background`                                                                       | Background color.                                                                     | [`Color`](color.qd)                    | None                                                         |
+| `border`                                                                           | Border color.                                                                         | [`Color`](color.qd)                    | Browser's default if `borderwidth` is set, none otherwise    |
+| `borderwidth`                                                                      | Border thickness.                                                                     | [`Sizes`](sizes.qd)                    | Browser's default if `border` is set, none otherwise         |
+| `borderstyle`                                                                      | Border type.                                                                          | `normal`, `dashed`, `dotted`, `double` | `normal` if `border` or `borderwidth` is set, none otherwise |
+| `margin`                                                                           | Whitespace outside the element.                                                       | [`Sizes`](sizes.qd)                    | None                                                         |
+| `padding`                                                                          | Whitespace between the border and the content.                                        | [`Sizes`](sizes.qd)                    | None                                                         |
+| `radius`                                                                           | Corner (and border) radius.                                                           | [`Sizes`](sizes.qd)                    | None                                                         |
+| `alignment`                                                                        | Content alignment.                                                                    | `start`, `center`, `end`               | Browser's default                                            |
+| `textalignment`                                                                    | Text alignment.                                                                       | `start`, `center`, `end`, `justify`    | Follows `alignment` if set                                   |
+| `fontsize`, `fontweight`, `fontstyle`, `fontvariant`, `textdecoration`, `textcase` | Text transformation. See [Advanced text formatting](text.qd) for the accepted values. |                                        | None                                                         |
+
+## Example
+
+.examplemirror
+    .container fullwidth:{yes} borderstyle:{dashed} padding:{1cm} fontsize:{medium} fontstyle:{italic} fontvariant:{smallcaps}
+        This is a styled container. Fancy, isn't it?
+
+        Quarkdown can truly give life to complex layouts with ease.

--- a/docs/element-styling.qd
+++ b/docs/element-styling.qd
@@ -1,28 +1,66 @@
 .docname {Element styling}
 .include {docs}
 
-Several functions, such as [`.container`](container.qd) and [`.heading`](headings.qd), share a common set of styling parameters to customize colors, spacing, borders, and text appearance of the element they produce.
+If you've used Typst, you may be familiar with the `#show` directive for styling elements. .br
+Quarkdown provides a similar, powerful mechanism that involves [function extensions](extending-functions.qd), allowing you to customize not only their appearance, but also their behavior and content.
 
-## Parameters
+Several Markdown elements are associated to a special function called *primitive*. For example, headings (`#`, `##`, etc.) are backed by the `.heading` primitive function.
+Extending a primitive allows you to intercept and alter the call itself through `.super`, which invokes the original function with optional overrides.
 
-| Parameter                                                                          | Description                                                                           | Accepts                                | Default                                                      |
-|------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------|----------------------------------------|--------------------------------------------------------------|
-| `foreground`                                                                       | Text color.                                                                           | [`Color`](color.qd)                    | Document's default                                           |
-| `background`                                                                       | Background color.                                                                     | [`Color`](color.qd)                    | None                                                         |
-| `border`                                                                           | Border color.                                                                         | [`Color`](color.qd)                    | Browser's default if `borderwidth` is set, none otherwise    |
-| `borderwidth`                                                                      | Border thickness.                                                                     | [`Sizes`](sizes.qd)                    | Browser's default if `border` is set, none otherwise         |
-| `borderstyle`                                                                      | Border type.                                                                          | `normal`, `dashed`, `dotted`, `double` | `normal` if `border` or `borderwidth` is set, none otherwise |
-| `margin`                                                                           | Whitespace outside the element.                                                       | [`Sizes`](sizes.qd)                    | None                                                         |
-| `padding`                                                                          | Whitespace between the border and the content.                                        | [`Sizes`](sizes.qd)                    | None                                                         |
-| `radius`                                                                           | Corner (and border) radius.                                                           | [`Sizes`](sizes.qd)                    | None                                                         |
-| `alignment`                                                                        | Content alignment.                                                                    | `start`, `center`, `end`               | Browser's default                                            |
-| `textalignment`                                                                    | Text alignment.                                                                       | `start`, `center`, `end`, `justify`    | Follows `alignment` if set                                   |
-| `fontsize`, `fontweight`, `fontstyle`, `fontvariant`, `textdecoration`, `textcase` | Text transformation. See [Advanced text formatting](text.qd) for the accepted values. |                                        | None                                                         |
+> Tip: For a full list of supported primitives, see the [*Primitives*](https://quarkdown.com/docs/quarkdown-stdlib/com.quarkdown.stdlib.module.Primitives/index.html) module.
 
-## Example
+.exampleoutput {.heading {This is red} depth:{2} background:{red} indexed:{no}}
+    .extend {heading}
+        .super background:{red}
 
-.examplemirror
-    .container fullwidth:{yes} borderstyle:{dashed} padding:{1cm} fontsize:{medium} fontstyle:{italic} fontvariant:{smallcaps}
-        This is a styled container. Fancy, isn't it?
+    ## This is red
 
-        Quarkdown can truly give life to complex layouts with ease.
+> Tip: For a list of styling properties supported by most primitives, see [*Styling properties*](element-styling-properties.qd).
+
+## Adaptive styling
+
+As per function extension rules, parameters can be intercepted as well by declaring them with the same name in the wrapper body.
+
+.exampleoutput {
+    .heading {This is red} depth:{2} background:{red} indexed:{no}
+
+    .heading {This is not red} depth:{3} indexed:{no}
+}
+    .extend {heading}
+        depth:
+        .let {.depth::equals {2}}
+            .if {.1}
+                .super background:{red}
+            .ifnot {.1}
+                .super
+        
+
+    ## This is red (depth 2)
+
+    ### This is not red (depth 3)
+
+## Content changes
+
+Intercepted parameters can also be modified on the go. A common use case would be transforming the Markdown content of an element. 
+
+.exampleoutput {.heading {.icon {boxes} *This is a heading*} depth:{2} indexed:{no}} \
+               prelude:{Here we add an [icon](icons.qd) to all headings, and italicize their content. Note that [body arguments](syntax-of-a-function-call.qd#the-body-argument) work with `\.super` normally.}
+    .extend {heading}
+        content:
+        .super
+            .icon {boxes} *.content*
+
+    ## This is a heading
+
+## Pattern matching
+
+Quarkdown supports transforming arbitrary content according to RegEx patterns via the **`.match {content} {pattern} {replacement}`** .docslink {quarkdown-stdlib/com.quarkdown.stdlib.module.Text/match.html} function, which replaces all occurrences of `pattern` within `content` with `replacement`.
+
+.exampleoutput {.heading {*Quarkdown* takes its name from *quarks*} depth:{2} indexed:{no}}
+    .extend {heading}
+        content:
+        .super
+            .content::match {[Qq]uark(down|s)?}
+                *.1*
+
+    ## Quarkdown takes its name from quarks

--- a/docs/pipeline---tree-rewrite.qd
+++ b/docs/pipeline---tree-rewrite.qd
@@ -3,7 +3,7 @@
 
 > Main packages: .repolink {`core.ast.iterator`} {tree/main/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/iterator}, .repolink {`core.pipeline.stages`} {tree/main/quarkdown-core/src/main/kotlin/com/quarkdown/core/pipeline/stages}
 
-Once the queued function calls have been [expanded](pipeline---function-call-expansion.qd), the AST is rewritten in place to apply any show-rules via user-defined [extensions](extending-functions.qd).
+Once the queued function calls have been [expanded](pipeline---function-call-expansion.qd), the AST is rewritten in place to apply any [show-rules](element-styling.qd) via user-defined [extensions](extending-functions.qd).
 
 Several built-in nodes, such as [headings](headings.qd), are *primitive function-backed*: the stdlib exposes functions whose parameters mirror the node's properties. Whenever an `.extend` wrapper is registered for that name, every occurrence of the primitive must be routed through the wrapper.
 

--- a/quarkdown-test/src/test/kotlin/com/quarkdown/test/primitive/HeadingPrimitiveFunctionTest.kt
+++ b/quarkdown-test/src/test/kotlin/com/quarkdown/test/primitive/HeadingPrimitiveFunctionTest.kt
@@ -70,6 +70,23 @@ class HeadingPrimitiveFunctionTest {
     }
 
     @Test
+    fun `content can be matched against pattern`() {
+        execute(
+            """
+            .extend {heading}
+                content:
+                .super
+                    .content::match {[Qq]uark(down|s)?}
+                        *.1*
+            
+            ## Quarkdown takes its name from quarks
+            """.trimIndent(),
+        ) {
+            assertEquals("<h2><em>Quarkdown</em> takes its name from <em>quarks</em></h2>", it)
+        }
+    }
+
+    @Test
     fun `content can be transformed`() {
         execute(
             """
@@ -171,6 +188,25 @@ class HeadingPrimitiveFunctionTest {
             assertEquals(
                 "<h2 style=\"color: rgba(255, 0, 0, 1.0); background-color: rgba(255, 0, 0, 1.0); font-variant: small-caps;\">Hello</h2>" +
                     "<h3 style=\"color: rgba(255, 0, 0, 1.0); font-variant: small-caps;\">Hello</h3>",
+                it,
+            )
+        }
+    }
+
+    @Test
+    fun `icon can be used as content`() {
+        execute(
+            """
+            .extend {heading}
+                content:
+                .super
+                    .icon {boxes} *.content*!
+            
+            ## Heading
+            """.trimIndent(),
+        ) {
+            assertEquals(
+                "<h2><i class=\"icon-image bi bi-boxes\" aria-hidden=\"true\"></i> <em>Heading</em>!</h2>",
                 it,
             )
         }


### PR DESCRIPTION
- [X] I have read the [contributing guidelines](https://github.com/iamgio/quarkdown/blob/main/CONTRIBUTING.md).
- [X] I have tested the changes locally.
- [ ] An issue for this change exists, and it was discussed with maintainers. This is required for new features and non-trivial changes. If present, append `Closes #ISSUE_NUMBER` at the end of this PR description.
- [ ] (Optional) I have added necessary documentation to [`docs`](https://github.com/iamgio/quarkdown/tree/main/docs) and [`CHANGELOG.md`](https://github.com/iamgio/quarkdown/blob/main/CHANGELOG.md)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for shared element styling properties, including borders, spacing, alignment, colors, and text styling.
  * Documented extensible element styling with practical examples for adapting and transforming content.
  * Improved navigation and clarified the documented tree-rewrite process.

* **Tests**
  * Added coverage for pattern-matching heading content.
  * Added coverage for using icons as heading content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->