### PR TITLE
feat(stdlib): add .extend optional condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,29 @@
 
 &nbsp;
 
-#### Full styling options on `.heading`
+#### [Element styling](https://quarkdown.com/wiki/element-styling) (show-rules)
+
+> [!NOTE]
+> This feature is experimental.
+
+When `.extend` is applied to a function of the [*Primitives* module](https://quarkdown.com/docs/quarkdown-stdlib/com.quarkdown.stdlib.module.Primitives/index.html), its new behavior is reflected on its Markdown counterpart. For example, extending the `.heading` function affects the `# Heading` Markdown element.
+
+This is one of the biggest milestones for Quarkdown, on par with Typst's `#show` rules.
+
+```markdown
+.extend {heading}
+    content:
+    .super foreground:{blue}
+        *.content*
+
+## A heading <!-- Renders blue and italic -->
+```
+
+This release ships with a handful of primitives as an experimental feature. The plan is to eventually have every Markdown element type backed by a primitive function.
+
+&nbsp;
+
+#### [Full styling options on `.heading`](https://quarkdown.com/wiki/element-styling-properties)
 
 `.container`'s styling options, such as `foreground`, `background`, `border`, `padding`, and `fontsize`, are now available on `.heading` as well. This allows for full customization without needing to wrap the heading in a container.
 
@@ -22,7 +44,16 @@ This plays particularly well with the new primitive extension system:
     .super background:{red} foreground:{white} padding:{10px}
 ```
 
-The plan is to eventually extend these options to all element types and primitive functions.
+&nbsp;
+
+#### [Conditional `.extend`](https://quarkdown.com/wiki/extending-functions)
+
+`.extend`'s new `where` parameter defines a condition to meet. If not met, the behavior falls back to the original function definition.
+
+```markdown
+.extend {heading} where:{@lambda depth: .depth::islower than:{3}}
+    .super background:{teal}
+```
 
 &nbsp;
 
@@ -39,7 +70,16 @@ Output:
 
 > **Quarkdown** takes its name from **quarks**
 
-Matches are searched within plain text leaves only, so existing inline structure such as links, emphasis, and code spans is preserved around them. The lambda receives the matched substring as its single argument, available as `.1` (or via a named parameter), and returns the inline content to insert in its place.
+This is particularly useful for element styling:
+
+```markdown
+.extend {heading}
+    content:
+    .content::match {[Qq]uark(down|s)?}
+        *.1*
+
+## Quarkdown takes its name from quarks
+```
 
 &nbsp;
 

--- a/docs/extending-functions.qd
+++ b/docs/extending-functions.qd
@@ -1,7 +1,12 @@
 .docname {Extending functions}
 .include {docs}
 
-You can extend any previously-declared function using the **`.extend`** .docslink {quarkdown-stdlib/com.quarkdown.stdlib.module.Flow/extend.html} function within a scope. The extension wraps the original function, letting you transform, decorate, or replace its output without losing the original definition.
+Function extension is a powerful feature that lets you transform, decorate, or replace a function's behavior.
+
+.box 
+    This is the backbone of the [element styling](element-styling.qd) engine, when the extended function is a [Markdown primitive](primitives.qd), such as [`.heading`](headings.qd). See its page for more details about extending Markdown elements.
+
+You can extend any previously-declared function using the **`.extend`** .docslink {quarkdown-stdlib/com.quarkdown.stdlib.module.Flow/extend.html} function within a scope. The extension wraps the original function without losing the original definition.
 
 .examplemirror
     .function {greet}
@@ -19,45 +24,9 @@ Within the wrapper body, the original function is exposed as **`.super`**. Calli
 
 ## Parameters
 
-The wrapper body is a [lambda](lambda.qd). Its explicit parameters, if any, must match the names of the original function's parameters and let you read the arguments the caller passed.
+The wrapper body is a [lambda](lambda.qd). Its explicit parameters, if any, must match the names of the original function's parameters and let you intercept the arguments the caller passed.
 
-.examplemirror prelude:{The output may depend on an argument's value:}
-    .function {greet}
-        name:
-        Hello, .name!
-
-    .extend {greet}
-        name:
-        .if {.name::equals {world}}
-            .super::uppercase
-        .ifnot {.name::equals {world}}
-            .super
-
-    .greet {world}
-
-    .greet {John}
-
-All wrapper parameters are always optional. You only need to declare the parameters you actually use in the body.
-
-.examplemirror prelude:{Built-in functions can be extended:}
-    .extend {heading}
-        depth:
-        .let {.depth::islower than:{4}}
-            .if {.1}
-                .container background:{teal} fullwidth:{yes}
-                    .super
-            .ifnot {.1}
-                .super
-
-    .heading {H2} depth:{2} indexed:{no}
-
-    .heading {H3} depth:{3} indexed:{no}
-
-    .heading {H4} depth:{4} indexed:{no}
-
-## Overriding arguments
-
-Because `.super` is the original function itself, it accepts the same arguments. Any argument you pass overrides the one the wrapper was called with, while everything you leave out falls through unchanged. This lets the wrapper invoke the original with adjusted inputs.
+Because `.super` is the original function itself, it accepts the same arguments. Any argument you pass overrides the one the wrapper was called with, while everything you leave out falls through unchanged.
 
 .examplemirror
     .function {greet}
@@ -80,3 +49,51 @@ Because `.super` is the original function itself, it accepts the same arguments.
         .super greeting:{.greeting::uppercase}
 
     .greet {Hello} {world}
+
+All wrapper parameters are always optional. You only need to declare the parameters you actually use in the body.
+
+.examplemirror 
+    .function {greet}
+        greeting name surname:
+        .greeting, .name .surname!
+
+    .extend {greet}
+        name:
+        .super name:{.name::uppercase}
+
+    .greet {Hello} name:{John} surname:{Doe}
+
+## Conditional extension
+
+An optional `where` [inline lambda](lambda.qd) parameter lets you define a condition that, if not met at call time, lets the whole call fall back to the original definition. Its parameters follow the same rules as the body lambda.
+
+.examplemirror
+    .function {greet}
+        greeting name:
+        .greeting, .name!
+
+    .extend {greet} where:{@lambda name: .name::equals {world}}
+        greeting:
+        .super greeting:{.greeting::uppercase}
+
+    .greet {Hello} {world}
+
+    .greet {Hello} {John}
+
+.exampleoutput {
+    .heading {H2} depth:{2} indexed:{no} background:{teal}
+    
+    .heading {H3} depth:{3} indexed:{no} background:{teal}
+    
+    .heading {H4} depth:{4} indexed:{no}
+} \
+               prelude:{Built-in functions, such as [`\.heading`](headings.qd), can be extended. See [*Element styling*](element-styling.qd) for more details.}
+    .extend {heading} where:{@lambda depth: .depth::islower than:{4}}
+        content:
+        .super background:{teal}
+
+    ## H2
+
+    ## H3
+
+    ## H4

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/function/value/data/Lambda.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/function/value/data/Lambda.kt
@@ -165,9 +165,9 @@ open class Lambda(
      * @param V **wrapped** value type (which wraps [T]) to convert the resulting dynamic value to
      * @return the result of the lambda action, as a statically typed value
      */
-    inline fun <reified T, reified V : Value<T>> invoke(vararg values: Value<*>): V {
+    inline fun <reified T, reified V : Value<T>> invoke(values: List<Value<*>>): V {
         // Invoke the lambda action and convert the result to a static type.
-        val result = invokeDynamic(*values)
+        val result = invokeDynamic(values)
 
         return when (result) {
             is V -> result
@@ -177,4 +177,6 @@ open class Lambda(
         } as? V
             ?: throw IllegalArgumentException("Unexpected lambda result: expected ${V::class}, found ${result::class}")
     }
+
+    inline fun <reified T, reified V : Value<T>> invoke(vararg values: Value<*>): V = invoke<T, V>(values.toList())
 }

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Flow.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Flow.kt
@@ -349,7 +349,30 @@ fun function(
  *
  * > Output: `Hello, JOHN`
  *
+ * If [condition] is defined, it is checked against every function call.
+ * If the condition is not met, the call falls back to the original function definition.
+ * The following snippets have identical behavior:
+ *
+ * - ```
+ *   .extend {greet} where:{@lambda name: .name::equals {World}}
+ *       name:
+ *       .super::uppercase
+ *   ```
+ *
+ * - ```
+ *   .extend {greet}
+ *       name:
+ *       .if {.name::equals {World}}
+ *           .super::uppercase
+ *       .ifnot {.name::equals {World}}
+ *           .super
+ *   ```
+ *
+ * Function extension is the backbone of element styling, when extending primitive functions such as [heading].
+ *
  * @param name name of the existing function to extend
+ * @param condition optional condition to meet. Takes the same parameters as [body].
+ *                  If the condition is not met, the call falls back to the original function definition
  * @param body wrapper content. Its explicit parameters, if any, must match the original function's
  *             parameter names. `.super` is implicitly available within the body
  * @throws IllegalArgumentException if no function named [name] exists, or if any explicit parameter
@@ -360,9 +383,10 @@ fun function(
 fun extend(
     @Injected context: MutableContext,
     name: String,
+    @Name("where") condition: Lambda? = null,
     @Body body: Lambda,
 ): VoidValue {
-    extendFunction(context, name, body)
+    extendFunction(context, name, condition, body)
     return VoidValue
 }
 

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/internal/FunctionExtension.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/internal/FunctionExtension.kt
@@ -5,6 +5,7 @@ import com.quarkdown.core.function.Function
 import com.quarkdown.core.function.SimpleFunction
 import com.quarkdown.core.function.call.executeAs
 import com.quarkdown.core.function.signatureAsString
+import com.quarkdown.core.function.value.BooleanValue
 import com.quarkdown.core.function.value.data.Lambda
 import com.quarkdown.core.function.value.data.LambdaParameter
 import com.quarkdown.stdlib.extend
@@ -20,6 +21,8 @@ private const val SUPER_NAME = "super"
  *
  * @param context context to register the wrapper in
  * @param targetName name of the existing function to extend
+ * @param condition optional condition to meet. Takes the same parameters as [body].
+ *                  If the condition is not met, the call falls back to the original function definition
  * @param body wrapper content; its explicit parameters, if any, must match the target's parameter names
  * @throws IllegalArgumentException if no function named [targetName] exists,
  *         or if any explicit body parameter does not match an original parameter
@@ -27,6 +30,7 @@ private const val SUPER_NAME = "super"
 internal fun extendFunction(
     context: MutableContext,
     targetName: String,
+    condition: Lambda?,
     body: Lambda,
 ) {
     val targetFunction: Function<*> =
@@ -51,7 +55,8 @@ internal fun extendFunction(
         )
     }
 
-    val lambda = Lambda(context, lambdaParameters, body.action)
+    val bodyLambda = Lambda(context, lambdaParameters, body.action)
+    val conditionLambda = condition?.let { Lambda(context, lambdaParameters, it.action) }
 
     context.markFunctionAsExtended(targetName)
 
@@ -69,6 +74,20 @@ internal fun extendFunction(
                 call.executeAs(targetFunction, arguments = mergedArgs)
             }
 
-        lambda.invokeDynamic(args, callingContext = call.context, additionalFunctions = setOf(superFunction))
+        when {
+            // Fall back to original call (.super) if condition is not met.
+            conditionLambda != null && !conditionLambda.invoke<Boolean, BooleanValue>(args).unwrappedValue -> {
+                call.executeAs(superFunction, arguments = emptyList())
+            }
+
+            // Invoke extension.
+            else -> {
+                bodyLambda.invokeDynamic(
+                    args,
+                    callingContext = call.context,
+                    additionalFunctions = setOf(superFunction),
+                )
+            }
+        }
     }
 }

--- a/quarkdown-test/src/test/kotlin/com/quarkdown/test/FunctionExtensionTest.kt
+++ b/quarkdown-test/src/test/kotlin/com/quarkdown/test/FunctionExtensionTest.kt
@@ -336,6 +336,44 @@ class FunctionExtensionTest {
     }
 
     @Test
+    fun `conditional extension`() {
+        execute(
+            """
+            .function {mysum}
+                 a b:
+                 .a::sum {.b}
+
+            .extend {mysum} where:{@lambda a b: .a::sum {.b}::islower than:{10}}
+                a:
+                .a
+            
+            .mysum {10} {11} .mysum {4} {8} .mysum {3} {5}
+            """.trimIndent(),
+        ) {
+            assertEquals("<p>21 12 3</p>", it)
+        }
+    }
+
+    @Test
+    fun `conditional extension, partial args`() {
+        execute(
+            """
+            .function {mysum}
+                 a b:
+                 .a::sum {.b}
+
+            .extend {mysum} where:{@lambda a: .a::islower than:{10}}
+                a:
+                .a
+            
+            .mysum {10} {11} .mysum {4} {8} .mysum {3} {5}
+            """.trimIndent(),
+        ) {
+            assertEquals("<p>21 4 3</p>", it)
+        }
+    }
+
+    @Test
     fun `stdlib extension`() {
         execute(
             """
@@ -353,13 +391,11 @@ class FunctionExtensionTest {
     fun `stdlib extension with injected parameter`() {
         execute(
             """
-            .extend {heading}
+            .extend {heading} where:{@lambda content: .content::equals {Hi}}
                 content:
-                .if {.content::equals {Hi}}
-                    .container
-                        .super
-                .ifnot {.content::equals {Hi}}
+                .container
                     .super
+                        .content::plaintext::uppercase
             
             .heading {Hi} depth:{2}
             
@@ -367,7 +403,7 @@ class FunctionExtensionTest {
             """.trimIndent(),
         ) {
             assertEquals(
-                "<div class=\"container\"><h2>Hi</h2></div><h2>Hello</h2>",
+                "<div class=\"container\"><h2>HI</h2></div><h2>Hello</h2>",
                 it,
             )
         }

--- a/quarkdown-test/src/test/kotlin/com/quarkdown/test/primitive/HeadingPrimitiveFunctionTest.kt
+++ b/quarkdown-test/src/test/kotlin/com/quarkdown/test/primitive/HeadingPrimitiveFunctionTest.kt
@@ -42,7 +42,32 @@ class HeadingPrimitiveFunctionTest {
     }
 
     @Test
-    fun `content can be matched and conditionally wrapped`() {
+    fun `content can be matched and conditionally wrapped (where)`() {
+        execute(
+            """
+             .noautopagebreak
+
+            .extend {heading} where:{@lambda content: .content::equals {Hi}}
+                 content:
+                 .container
+                     .super 
+
+             # Hello
+
+             ## Hi
+
+             ### Hey
+            """.trimIndent(),
+        ) {
+            assertEquals(
+                "<h1>Hello</h1><div class=\"container\"><h2>Hi</h2></div><h3>Hey</h3>",
+                it,
+            )
+        }
+    }
+
+    @Test
+    fun `content can be matched and conditionally wrapped (if)`() {
         execute(
             """
             .noautopagebreak


### PR DESCRIPTION
- [X] I have read the [contributing guidelines](https://github.com/iamgio/quarkdown/blob/main/CONTRIBUTING.md).
- [X] I have tested the changes locally.
- [ ] An issue for this change exists, and it was discussed with maintainers. This is required for new features and non-trivial changes. If present, append `Closes #ISSUE_NUMBER` at the end of this PR description.
- [ ] (Optional) I have added necessary documentation to [`docs`](https://github.com/iamgio/quarkdown/tree/main/docs) and [`CHANGELOG.md`](https://github.com/iamgio/quarkdown/blob/main/CHANGELOG.md)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added conditional `.extend` support via an optional `where` predicate; if the predicate fails, the original behavior is used.
  - Extensions can still delegate to the original implementation via `super`.

- **Documentation**
  - Updated the changelog and extending-functions guide with `where` examples, expanded `super`/wrapper-parameter guidance, and updated element styling (“show-rules”) examples (now marked experimental, including regex match usage).

- **Tests**
  - Added conditional extension coverage (including partially bound predicates) and adjusted heading/injected-parameter expected output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->