### PR TITLE
perf: use lightweight nodestyle/styleoptions references

### DIFF
--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/attributes/style/NodeStyle.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/attributes/style/NodeStyle.kt
@@ -33,6 +33,10 @@ data class NodeStyle(
     val textAlignment: TextAlignment? = null,
     val textTransform: TextTransformData? = null,
 ) {
+    companion object {
+        val DEFAULT = NodeStyle()
+    }
+
     /**
      * Possible alignment types.
      */

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/base/block/Heading.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/base/block/Heading.kt
@@ -42,7 +42,7 @@ class Heading(
     val canBreakPage: Boolean = true,
     override val canTrackLocation: Boolean = true,
     val excludeFromTableOfContents: Boolean = false,
-    override val style: NodeStyle = NodeStyle(),
+    override val style: NodeStyle = NodeStyle.DEFAULT,
 ) : TextNode,
     Identifiable,
     LocationTrackableNode,

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/quarkdown/block/Container.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/quarkdown/block/Container.kt
@@ -26,7 +26,7 @@ class Container(
     val float: FloatAlignment? = null,
     val fullColumnSpan: Boolean = false,
     val className: String? = null,
-    override val style: NodeStyle = NodeStyle(),
+    override val style: NodeStyle = NodeStyle.DEFAULT,
     @Diverge override val children: List<Node>,
 ) : NestableNode,
     StylableNode {

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Layout.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Layout.kt
@@ -78,8 +78,9 @@ data class StyleOptions(
     @Name("textcase") val textCase: TextTransformData.Case? = null,
 ) {
     /** @see com.quarkdown.core.ast.attributes.style.StylableNode */
-    fun toNodeStyle(): NodeStyle =
-        NodeStyle(
+    fun toNodeStyle(): NodeStyle {
+        if (this == DEFAULT) return NodeStyle.DEFAULT
+        return NodeStyle(
             foregroundColor = foregroundColor,
             backgroundColor = backgroundColor,
             borderColor = borderColor,
@@ -100,6 +101,11 @@ data class StyleOptions(
                     case = textCase,
                 ),
         )
+    }
+
+    companion object {
+        val DEFAULT = StyleOptions()
+    }
 }
 
 /**
@@ -125,7 +131,7 @@ fun container(
     @LikelyNamed float: Container.FloatAlignment? = null,
     @Name("fullspan") fullColumnSpan: Boolean = false,
     @Name("classname") className: String? = null,
-    @Spread style: StyleOptions = StyleOptions(),
+    @Spread style: StyleOptions = StyleOptions.DEFAULT,
     @Body body: MarkdownContent? = null,
 ) = Container(
     width,

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Primitives.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Primitives.kt
@@ -51,7 +51,7 @@ fun heading(
     @Name("numbered") canTrackLocation: Boolean = true,
     @Name("indexed") includeInTableOfContents: Boolean = true,
     @Name("breakpage") canBreakPage: Boolean = true,
-    @Spread style: StyleOptions = StyleOptions(),
+    @Spread style: StyleOptions = StyleOptions.DEFAULT,
 ): NodeValue {
     require(depth in Heading.MIN_DEPTH..Heading.MAX_DEPTH) {
         "Heading depth must be between ${Heading.MIN_DEPTH} and ${Heading.MAX_DEPTH}, but got $depth."


### PR DESCRIPTION
- [X] I have read the [contributing guidelines](https://github.com/iamgio/quarkdown/blob/main/CONTRIBUTING.md).
- [X] I have tested the changes locally.
- [ ] An issue for this change exists, and it was discussed with maintainers. This is required for new features and non-trivial changes. If present, append `Closes #ISSUE_NUMBER` at the end of this PR description.
- [ ] (Optional) I have added necessary documentation to [`docs`](https://github.com/iamgio/quarkdown/tree/main/docs) and [`CHANGELOG.md`](https://github.com/iamgio/quarkdown/blob/main/CHANGELOG.md)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized default styling for headings and containers to use shared default style instances.
  * Updated layout and primitive helpers to reuse shared default style options when callers omit styling.
  * Introduced a reusable default for style options to ensure consistent baseline styling while reducing unnecessary creation of new style/option objects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->