### PR TITLE
feat(primitives): add .paragraph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,9 +28,15 @@ This release ships with a handful of primitives as an experimental feature. The 
 
 &nbsp;
 
-#### [Full styling options on `.heading`](https://quarkdown.com/wiki/element-styling-properties)
+#### [New primitive: `.paragraph`]
 
-`.container`'s styling options, such as `foreground`, `background`, `border`, `padding`, and `fontsize`, are now available on `.heading` as well. This allows for full customization without needing to wrap the heading in a container.
+The new `.paragraph` primitive backs Markdown paragraphs, enabling paragraph-level extensions via `.extend {paragraph}`.
+
+&nbsp;
+
+#### [Full styling options on `.heading` and `.paragraph`](https://quarkdown.com/wiki/element-styling-properties)
+
+`.container`'s styling options, such as `foreground`, `background`, `border`, `padding`, and `fontsize`, are now available on `.heading` and `.paragraph` as well. This allows for full customization without needing to wrap the element in a container.
 
 ```markdown
 .heading {Introduction} depth:{1} background:{blue} radius:{8px}
@@ -75,8 +81,9 @@ This is particularly useful for element styling:
 ```markdown
 .extend {heading}
     content:
-    .content::match {[Qq]uark(down|s)?}
-        *.1*
+    .super
+        .content::match {[Qq]uark(down|s)?}
+            *.1*
 
 ## Quarkdown takes its name from quarks
 ```

--- a/docs/element-styling.qd
+++ b/docs/element-styling.qd
@@ -17,23 +17,17 @@ Extending a primitive allows you to intercept and alter the call itself through 
 
 > Tip: For a list of styling properties supported by most primitives, see [*Styling properties*](element-styling-properties.qd).
 
-## Adaptive styling
+## Conditional styling
 
-As per function extension rules, parameters can be intercepted as well by declaring them with the same name in the wrapper body.
+The `where` parameter allows you to apply styling conditionally based on the arguments of the original function call.
 
 .exampleoutput {
     .heading {This is red} depth:{2} background:{red} indexed:{no}
 
     .heading {This is not red} depth:{3} indexed:{no}
 }
-    .extend {heading}
-        depth:
-        .let {.depth::equals {2}}
-            .if {.1}
-                .super background:{red}
-            .ifnot {.1}
-                .super
-        
+    .extend {heading} where:{@lambda depth: .depth::equals {2}}
+        .super background:{red}
 
     ## This is red (depth 2)
 
@@ -56,11 +50,11 @@ Intercepted parameters can also be modified on the go. A common use case would b
 
 Quarkdown supports transforming arbitrary content according to RegEx patterns via the **`.match {content} {pattern} {replacement}`** .docslink {quarkdown-stdlib/com.quarkdown.stdlib.module.Text/match.html} function, which replaces all occurrences of `pattern` within `content` with `replacement`.
 
-.exampleoutput {.heading {*Quarkdown* takes its name from *quarks*} depth:{2} indexed:{no}}
-    .extend {heading}
+.exampleoutput {*Quarkdown* takes its name from *quarks*}
+    .extend {paragraph}
         content:
         .super
             .content::match {[Qq]uark(down|s)?}
                 *.1*
 
-    ## Quarkdown takes its name from quarks
+    Quarkdown takes its name from quarks

--- a/docs/headings.qd
+++ b/docs/headings.qd
@@ -63,7 +63,7 @@ You can assign a custom identifier for [cross-referencing](cross-references.qd):
 
 ## Styling
 
-`.heading` accepts every option described on [Element styling](element-styling.qd), for customizing colors, spacing, borders, and text appearance. 
+`.heading` accepts every option described on [*Element styling properties*](element-styling-properties.qd), for customizing colors, spacing, borders, and text appearance. 
 
 .examplemirror
     .heading {Introduction} depth:{2} foreground:{teal} fontvariant:{smallcaps} indexed:{no}

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/base/block/Paragraph.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/base/block/Paragraph.kt
@@ -2,7 +2,13 @@ package com.quarkdown.core.ast.base.block
 
 import com.quarkdown.amber.annotations.Diverge
 import com.quarkdown.core.ast.InlineContent
+import com.quarkdown.core.ast.InlineMarkdownContent
+import com.quarkdown.core.ast.attributes.primitive.PrimitiveFunctionBackedNode
+import com.quarkdown.core.ast.attributes.style.NodeStyle
+import com.quarkdown.core.ast.attributes.style.StylableNode
 import com.quarkdown.core.ast.base.TextNode
+import com.quarkdown.core.function.call.FunctionCallArgument
+import com.quarkdown.core.function.value.wrappedAsValue
 import com.quarkdown.core.visitor.node.NodeVisitor
 
 /**
@@ -11,6 +17,16 @@ import com.quarkdown.core.visitor.node.NodeVisitor
  */
 class Paragraph(
     @Diverge override val text: InlineContent,
-) : TextNode {
+    override val style: NodeStyle = NodeStyle.DEFAULT,
+) : TextNode,
+    StylableNode,
+    PrimitiveFunctionBackedNode {
+    override val backingFunctionName: String = "paragraph"
+
+    override fun toFunctionCallArguments() =
+        listOf(
+            FunctionCallArgument(name = "content", expression = InlineMarkdownContent(text).wrappedAsValue()),
+        )
+
     override fun <T> accept(visitor: NodeVisitor<T>) = visitor.visit(this)
 }

--- a/quarkdown-html/src/main/kotlin/com/quarkdown/rendering/html/node/BaseHtmlNodeRenderer.kt
+++ b/quarkdown-html/src/main/kotlin/com/quarkdown/rendering/html/node/BaseHtmlNodeRenderer.kt
@@ -160,7 +160,11 @@ open class BaseHtmlNodeRenderer(
             .void(true)
             .build()
 
-    override fun visit(node: Heading) = buildTag("h${node.depth}", node.text)
+    override fun visit(node: Heading) =
+        buildTag("h${node.depth}") {
+            +node.text
+            style(node.style)
+        }
 
     override fun visit(node: LinkDefinition) = "" // Not rendered
 
@@ -261,7 +265,11 @@ open class BaseHtmlNodeRenderer(
 
     override fun visit(node: Table) = tableBuilder(node).build()
 
-    override fun visit(node: Paragraph) = buildTag("p", node.text)
+    override fun visit(node: Paragraph) =
+        buildTag("p") {
+            +node.text
+            style(node.style)
+        }
 
     override fun visit(node: BlockQuote) = buildTag("blockquote", node.content)
 

--- a/quarkdown-html/src/test/e2e/paragraph/styling/main.qd
+++ b/quarkdown-html/src/test/e2e/paragraph/styling/main.qd
@@ -1,0 +1,4 @@
+.extend {paragraph}
+    .super foreground:{red} background:{black} padding:{10px} textcase:{uppercase} fontvariant:{smallcaps}
+
+Styled paragraph text.

--- a/quarkdown-html/src/test/e2e/paragraph/styling/styling.spec.ts
+++ b/quarkdown-html/src/test/e2e/paragraph/styling/styling.spec.ts
@@ -1,0 +1,17 @@
+import {getComputedColor} from "../../__util/css";
+import {suite} from "../../quarkdown";
+
+const {test, expect} = suite(__dirname);
+
+test("applies multiple inline styles to a paragraph", async (page) => {
+    const paragraph = page.locator("p").first();
+
+    const red = await getComputedColor(page, "red");
+    const black = await getComputedColor(page, "black");
+
+    await expect(paragraph).toHaveCSS("color", red);
+    await expect(paragraph).toHaveCSS("background-color", black);
+    await expect(paragraph).toHaveCSS("padding", "10px");
+    await expect(paragraph).toHaveCSS("text-transform", "uppercase");
+    await expect(paragraph).toHaveCSS("font-variant-caps", "small-caps");
+});

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Primitives.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Primitives.kt
@@ -5,6 +5,7 @@ package com.quarkdown.stdlib
 import com.quarkdown.core.ast.InlineMarkdownContent
 import com.quarkdown.core.ast.MarkdownContent
 import com.quarkdown.core.ast.base.block.Heading
+import com.quarkdown.core.ast.base.block.Paragraph
 import com.quarkdown.core.ast.base.inline.Image
 import com.quarkdown.core.ast.base.inline.Link
 import com.quarkdown.core.ast.quarkdown.block.Figure
@@ -30,6 +31,15 @@ import com.quarkdown.processor.annotation.Spread
  * Example:
  * ```markdown
  * .heading {My heading} depth:{2} numbered:{no}
+ * ```
+ *
+ * As a [Heading] primitive, this function can be used in `.extend` to affect all headings in the document:
+ *
+ * ```markdown
+ * .extend {heading} where:{@lambda depth: .depth::equals {1}}
+ *     content:
+ *     .super foreground:{blue}
+ *         *.content*
  * ```
  *
  * @param content inline content of the heading
@@ -67,6 +77,25 @@ fun heading(
         style = style.toNodeStyle(),
     ).let(::NodeValue)
 }
+
+/**
+ * Creates a paragraph with fine-grained control over its properties.
+ *
+ * As a [Paragraph] primitive, this function can be used in `.extend` to affect all paragraphs in the document:
+ *
+ * ```markdown
+ * .extend {paragraph}
+ *     .super foreground:{gray}
+ * ```
+ */
+@QFunction
+fun paragraph(
+    @Body content: InlineMarkdownContent,
+    @Spread style: StyleOptions = StyleOptions.DEFAULT,
+) = Paragraph(
+    text = content.children,
+    style = style.toNodeStyle(),
+).wrappedAsValue()
 
 /**
  * Creates an image with fine-grained control over its properties,

--- a/quarkdown-test/src/test/kotlin/com/quarkdown/test/FunctionExtensionTest.kt
+++ b/quarkdown-test/src/test/kotlin/com/quarkdown/test/FunctionExtensionTest.kt
@@ -355,6 +355,29 @@ class FunctionExtensionTest {
     }
 
     @Test
+    fun `multiple conditional extensions`() {
+        execute(
+            """
+            .function {mysum}
+                 a b:
+                 .a::sum {.b}
+
+            .extend {mysum} where:{@lambda a: .a::islower than:{10}}
+                a:
+                .a
+            
+            .extend {mysum} where:{@lambda b: .b::islower than:{10}}
+                b:
+                .b
+                
+            .mysum {10} {11} .mysum {4} {12} .mysum {16} {5} .mysum {8} {3}
+            """.trimIndent(),
+        ) {
+            assertEquals("<p>21 4 5 3</p>", it)
+        }
+    }
+
+    @Test
     fun `conditional extension, partial args`() {
         execute(
             """

--- a/quarkdown-test/src/test/kotlin/com/quarkdown/test/primitive/ParagraphPrimitiveFunctionTest.kt
+++ b/quarkdown-test/src/test/kotlin/com/quarkdown/test/primitive/ParagraphPrimitiveFunctionTest.kt
@@ -1,0 +1,69 @@
+package com.quarkdown.test.primitive
+
+import com.quarkdown.test.util.execute
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Tests for `.extend` applied to Markdown paragraphs.
+ */
+class ParagraphPrimitiveFunctionTest {
+    @Test
+    fun `no extension renders unchanged`() {
+        execute("Hello") {
+            assertEquals("<p>Hello</p>", it)
+        }
+    }
+
+    @Test
+    fun `extension wraps every paragraph`() {
+        execute(
+            """
+            .extend {paragraph}
+                .container
+                    .super
+
+            Hello
+            """.trimIndent(),
+        ) {
+            assertEquals("<div class=\"container\"><p>Hello</p></div>", it)
+        }
+    }
+
+    @Test
+    fun `content can be matched`() {
+        execute(
+            """
+            .extend {paragraph} where:{@lambda content: .content::equals {Hello}}
+                .super foreground:{blue} background:{white}
+            
+            Hello
+            
+            Hi
+            """.trimIndent(),
+        ) {
+            assertEquals(
+                "<p style=\"color: rgba(0, 0, 255, 1.0); background-color: rgba(255, 255, 255, 1.0);\">Hello</p>" +
+                    "<p>Hi</p>",
+                it,
+            )
+        }
+    }
+
+    @Test
+    fun `content can be matched against pattern`() {
+        execute(
+            """
+            .extend {paragraph}
+                content:
+                .super
+                    .content::match {[Qq]uark(down|s)?}
+                        **.1**
+            
+            Quarkdown takes its name from quarks
+            """.trimIndent(),
+        ) {
+            assertEquals("<p><strong>Quarkdown</strong> takes its name from <strong>quarks</strong></p>", it)
+        }
+    }
+}


### PR DESCRIPTION
- [X] I have read the [contributing guidelines](https://github.com/iamgio/quarkdown/blob/main/CONTRIBUTING.md).
- [X] I have tested the changes locally.
- [ ] An issue for this change exists, and it was discussed with maintainers. This is required for new features and non-trivial changes. If present, append `Closes #ISSUE_NUMBER` at the end of this PR description.
- [ ] (Optional) I have added necessary documentation to [`docs`](https://github.com/iamgio/quarkdown/tree/main/docs) and [`CHANGELOG.md`](https://github.com/iamgio/quarkdown/blob/main/CHANGELOG.md)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new `paragraph` primitive (and `.extend {paragraph}` support) backed by Markdown paragraphs.
  * Paragraph rendering now supports per-node styling, including conditional styling via `where` and content/pattern matching.
  * HTML rendering now applies element styles to both headings and paragraphs.

* **Documentation**
  * Updated `.paragraph` documentation and revised element-styling guidance.
  * Refreshed conditional styling and pattern-matching examples (including `.content::match`).

* **Tests**
  * Added tests for multiple conditional extensions and `paragraph` extension behavior (wrapping, unchanged output, conditional styling, and content matching).
  * Added a new paragraph styling end-to-end fixture and spec.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->