### PR TITLE
feat: remove @lambda from inline lambdas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,7 @@ This plays particularly well with the new primitive extension system:
 `.extend`'s new `where` parameter defines a condition to meet. If not met, the behavior falls back to the original function definition.
 
 ```markdown
-.extend {heading} where:{@lambda depth: .depth::islower than:{3}}
+.extend {heading} where:{depth: .depth::islower than:{3}}
     .super background:{teal}
 ```
 
@@ -91,6 +91,26 @@ This is particularly useful for element styling:
 &nbsp;
 
 ### Changed
+
+&nbsp;
+
+#### [Inline lambdas without `@lambda`](https://quarkdown.com/wiki/lambda#inline-lambda)
+
+Inline lambdas passed as arguments no longer require the `@lambda` prefix. When the target parameter is a `Lambda`, the argument is parsed as a lambda directly.
+
+```markdown
+.num::takeif {x: .x::equals {5}}
+```
+
+```markdown
+.mydictionary::sorted by:{name value: .value}
+
+```markdown
+.extend {heading} where:{depth: .depth::islower than:{3}}
+    .super background:{teal}
+```
+
+The `@lambda` prefix is still accepted for backward compatibility with older documents.
 
 &nbsp;
 

--- a/demo/demo.qd
+++ b/demo/demo.qd
@@ -83,7 +83,7 @@ so that you'll feel at home typing code you're comfortable typing.
         .container alignment:{center} fullwidth:{yes}
             .downarrow
 
-        .var {voffset} {.shrinkvertical::ifpresent {@lambda .1::multiply {-1}}::otherwise {0}}
+        .var {voffset} {.shrinkvertical::ifpresent {.1::multiply {-1}}::otherwise {0}}
 
         .container textalignment:{center} margin:{.voffset 0 0 0} fullwidth:{yes}
             .source

--- a/docs/destructuring.qd
+++ b/docs/destructuring.qd
@@ -33,8 +33,6 @@ In this example, we define a [Dictionary](dictionary.qd) and iterate over its de
 
 In this example, we define a [Dictionary](dictionary.qd) and iterate over its destructured key-value components using `.foreach`, but only after sorting its entries by value using [`.sorted`](iterable.qd#operations), which takes a lambda that defines the ordering criteria.
 
-> Note: Remember that `@lambda` is required when declaring an [inline lambda](lambda.qd#inline-lambda).
-
 .examplemirror
     .var {mydictionary}
         .dictionary
@@ -42,6 +40,6 @@ In this example, we define a [Dictionary](dictionary.qd) and iterate over its de
             - b: 1
             - c: 2
 
-    .foreach {.mydictionary::sorted by:{@lambda name value: .value}}
+    .foreach {.mydictionary::sorted by:{name value: .value}}
         name value:
         .name

--- a/docs/element-styling.qd
+++ b/docs/element-styling.qd
@@ -26,7 +26,7 @@ The `where` parameter allows you to apply styling conditionally based on the arg
 
     .heading {This is not red} depth:{3} indexed:{no}
 }
-    .extend {heading} where:{@lambda depth: .depth::equals {2}}
+    .extend {heading} where:{depth: .depth::equals {2}}
         .super background:{red}
 
     ## This is red (depth 2)

--- a/docs/extending-functions.qd
+++ b/docs/extending-functions.qd
@@ -72,7 +72,7 @@ An optional `where` [inline lambda](lambda.qd) parameter lets you define a condi
         greeting name:
         .greeting, .name!
 
-    .extend {greet} where:{@lambda name: .name::equals {world}}
+    .extend {greet} where:{name: .name::equals {world}}
         greeting:
         .super greeting:{.greeting::uppercase}
 
@@ -88,7 +88,7 @@ An optional `where` [inline lambda](lambda.qd) parameter lets you define a condi
     .heading {H4} depth:{4} indexed:{no}
 } \
                prelude:{Built-in functions, such as [`\.heading`](headings.qd), can be extended. See [*Element styling*](element-styling.qd) for more details.}
-    .extend {heading} where:{@lambda depth: .depth::islower than:{4}}
+    .extend {heading} where:{depth: .depth::islower than:{4}}
         content:
         .super background:{teal}
 

--- a/docs/lambda.qd
+++ b/docs/lambda.qd
@@ -27,23 +27,21 @@ The second parameter is .2
 
 Lambdas are constructs that can fork and create new **scopes**.
 - Nested scopes inherit properties from their parent, such as defined variables and functions.
-- Properties defined inside a nested scope cannot be accessed by their parent, meaning variables defined within a lambda block do not exist outside of the lambda itself.
+- Properties defined inside a nested scope cannot be accessed by their parent, meaning variables defined within a lambda block do not exist outside the lambda itself.
 
 ## Inline lambda
 
-Lambdas are defined the same way whether they appear in a block or an inline argument (those wrapped in curly braces). However, for inline arguments, you must add a **`@lambda`** instruction at the beginning to help the compiler recognize that it is dealing with a lambda.
+Lambdas are defined the same way whether they appear in a block or an inline argument (those wrapped in curly braces).
 
 ```markdown
-.myfunction {@lambda x y: The values are .x and .y}
+.myfunction {x y: The values are .x and .y}
 ```
 
 Implicit parameters work as well:
 
 ```markdown
-.myfunction {@lambda The values are .1 and .2}
+.myfunction {The values are .1 and .2}
 ```
-
-This is only needed if you access parameters of the lambda. If the evaluation is constant, you can omit `@lambda`.
 
 ## Examples
 
@@ -75,5 +73,5 @@ The body of `.function` is a lambda that accepts a variable amount of *explicit*
 ### [`.takeif`](none.qd#operations)
 
 ```markdown
-.num::takeif {@lambda x: .x::equals {5}}
+.num::takeif {x: .x::equals {5}}
 ```

--- a/docs/none.qd
+++ b/docs/none.qd
@@ -40,17 +40,17 @@ This is particularly useful when a value is stored in a variable that might or m
 
 .example
     ```markdown
-    .num::takeif {@lambda x: .x::equals {5}}
+    .num::takeif {x: .x::equals {5}}
     ```
     .quarkdownoutput
         - If `num` is 5: *5*
         - Otherwise: *None*
 
-    > Confused about `@lambda`? It begins a parametric [inline `Lambda`](lambda.qd#inline-lambda). Check its page for further details.
+    > Curious about the `x:` syntax? It declares a parametric [inline `Lambda`](lambda.qd#inline-lambda). Check its page for further details.
 
 .example
     ```markdown
-    .num::takeif {@lambda x: .x::iseven}::ifpresent {Even}::otherwise {Odd}
+    .num::takeif {x: .x::iseven}::ifpresent {Even}::otherwise {Odd}
     ```
     .quarkdownoutput
         - If `num` is even: *Even*
@@ -58,7 +58,7 @@ This is particularly useful when a value is stored in a variable that might or m
 
 .example
     ```markdown
-    .x::ifpresent {@lambda Yes, .1 is present}::otherwise {Not present}
+    .x::ifpresent {Yes, .1 is present}::otherwise {Not present}
     ```
     .quarkdownoutput
         - If `x` is `something`: *Yes, something is present*

--- a/docs/table-manipulation.qd
+++ b/docs/table-manipulation.qd
@@ -43,7 +43,7 @@ The **`.tablefilter`** function keeps or removes rows based on the values of a s
 | `filter`  | Lambda that returns whether each row should be kept, with the value of its cell in the corresponding column as input. | [`Dynamic`](typing.qd) -> [`Boolean`](boolean.qd) [lambda](lambda.qd) |
 
 .examplemirror
-    .tablefilter {2} {@lambda x: .x::isgreater {20}}
+    .tablefilter {2} {x: .x::isgreater {20}}
         | Name | Age | City |
         |------|-----|------|
         | John | 25  | NY   |
@@ -62,7 +62,7 @@ The **`.tablecompute`** function computes the cells in a column and appends the 
 See [*Iterable*](iterable.qd) to learn more about available operations on collections.
 
 .examplemirror
-    .tablecompute {2} {@lambda x: .x::average::round}
+    .tablecompute {2} {x: .x::average::round}
         | Name | Age | City |
         |------|-----|------|
         | John | 25  | NY   |
@@ -74,7 +74,7 @@ See [*Iterable*](iterable.qd) to learn more about available operations on collec
 You can chain multiple table operations. The order of operations goes from inner to outer:
 
 .examplemirror
-    .tablecompute {2} {@lambda x: .x::average::round}
+    .tablecompute {2} {x: .x::average::round}
         .tablesort {2}
             | Name | Age | City |
             |------|-----|------|

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/function/call/binding/RegularArgumentsBinder.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/function/call/binding/RegularArgumentsBinder.kt
@@ -9,11 +9,13 @@ import com.quarkdown.core.function.error.MismatchingArgumentTypeException
 import com.quarkdown.core.function.error.ParameterAlreadyBoundException
 import com.quarkdown.core.function.error.UnnamedArgumentAfterNamedException
 import com.quarkdown.core.function.error.UnresolvedParameterException
+import com.quarkdown.core.function.expression.RawInlineExpression
 import com.quarkdown.core.function.reflect.DynamicValueConverter
 import com.quarkdown.core.function.value.AdaptableValue
 import com.quarkdown.core.function.value.DynamicValue
 import com.quarkdown.core.function.value.NoneValue
 import com.quarkdown.core.function.value.StringValue
+import com.quarkdown.core.function.value.data.Lambda
 import com.quarkdown.core.function.value.factory.ValueFactory
 import com.quarkdown.core.function.value.isNone
 import com.quarkdown.core.pipeline.error.PipelineException
@@ -85,6 +87,14 @@ class RegularArgumentsBinder(
         parameter: FunctionParameter<*>,
         argument: FunctionCallArgument,
     ): FunctionCallArgument {
+        // A raw inline argument targeting a Lambda parameter is parsed as a lambda directly,
+        // bypassing the eager expression pipeline. This matches how body arguments are handled.
+        val expression = argument.expression
+
+        if (expression is RawInlineExpression && call.context != null && parameter.type.isSubclassOf(Lambda::class)) {
+            return argument.copy(expression = ValueFactory.lambda(expression.raw, call.context))
+        }
+
         // The value held by the argument.
         // If the argument is dynamic, it is converted to a static type.
         val value = argument.value

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/function/expression/RawInlineExpression.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/function/expression/RawInlineExpression.kt
@@ -1,0 +1,26 @@
+package com.quarkdown.core.function.expression
+
+import com.quarkdown.core.context.Context
+import com.quarkdown.core.function.expression.visitor.ExpressionVisitor
+import com.quarkdown.core.function.value.factory.ValueFactory
+
+/**
+ * An [Expression] wrapping the raw string of an inline function-call argument.
+ *
+ * When evaluated, it delegates to [ValueFactory.safeExpression], preserving the current
+ * eager evaluation behavior. The [raw] string, however, remains accessible so that consumers
+ * (for example, [com.quarkdown.core.function.call.binding.RegularArgumentsBinder]) can route
+ * the argument through a different parsing strategy when the target parameter type demands it,
+ * as is the case for [com.quarkdown.core.function.value.data.Lambda]-typed parameters.
+ *
+ * @param raw raw source text of the inline argument
+ * @param context context used when the raw string is eventually parsed as an expression
+ */
+class RawInlineExpression(
+    val raw: String,
+    context: Context,
+) : Expression {
+    private val delegate: Expression by lazy { ValueFactory.safeExpression(raw, context) }
+
+    override fun <T> accept(visitor: ExpressionVisitor<T>): T = delegate.accept(visitor)
+}

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/function/value/factory/ValueFactory.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/function/value/factory/ValueFactory.kt
@@ -518,7 +518,9 @@ object ValueFactory {
     ): LambdaValue {
         if (raw is Lambda) return LambdaValue(raw)
 
-        val (parameters, body) = LambdaParser.parse(raw.toString())
+        // The `@lambda` prefix is no longer required, but is tolerated for backward compatibility.
+        val source = raw.toString().removePrefix(EXPRESSION_FORCE_LAMBDA_PREFIX)
+        val (parameters, body) = LambdaParser.parse(source)
 
         return LambdaValue(
             Lambda(context, explicitParameters = parameters) { _, newContext ->

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/parser/FunctionCallRefiner.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/parser/FunctionCallRefiner.kt
@@ -4,8 +4,8 @@ import com.quarkdown.core.ast.quarkdown.FunctionCallNode
 import com.quarkdown.core.context.Context
 import com.quarkdown.core.function.call.FunctionCallArgument
 import com.quarkdown.core.function.call.UncheckedFunctionCall
+import com.quarkdown.core.function.expression.RawInlineExpression
 import com.quarkdown.core.function.value.DynamicValue
-import com.quarkdown.core.function.value.factory.ValueFactory
 import com.quarkdown.core.parser.walker.funcall.WalkedFunctionCall
 
 /**
@@ -47,8 +47,7 @@ class FunctionCallRefiner(
                 .asSequence()
                 .map { arg ->
                     val raw = arg.value.trim()
-                    // Convert the raw argument to an expression.
-                    val expression = ValueFactory.safeExpression(raw, context)
+                    val expression = RawInlineExpression(raw, context)
                     FunctionCallArgument(
                         expression,
                         name = arg.name,

--- a/quarkdown-html/src/test/resources/issues/template/template.qd
+++ b/quarkdown-html/src/test/resources/issues/template/template.qd
@@ -6,6 +6,6 @@
 
   .var {repo} {https://github.com/iamgio/quarkdown}
 
-  - **Opened in:** .issue::ifpresent {@lambda .text {#.1} url:{.repo/issues/.1}}
-  - **Fixed in:** .pr::ifpresent {@lambda .text {#.1} url:{.repo/pulls/.1}} (next release: .nextrelease)
+  - **Opened in:** .issue::ifpresent {.text {#.1} url:{.repo/issues/.1}}
+  - **Fixed in:** .pr::ifpresent {.text {#.1} url:{.repo/pulls/.1}} (next release: .nextrelease)
   - **Related to:** .relatedto 

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Flow.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Flow.kt
@@ -160,11 +160,10 @@ fun ifNot(
  *
  * > Output: `a`
  *
- * Note that, like any lambda, its content can be inlined by means of the `@lambda` annotation.
- * The previous snippet can be simplified as follows:
+ * Its content can also be inlined. The previous snippet can be simplified as follows:
  *
  * ```
- * .foreach {.collection} {@lambda item: .item::lowercase}::first
+ * .foreach {.collection} {item: .item::lowercase}::first
  * ```
  *
  * @param iterable collection to iterate
@@ -354,7 +353,7 @@ fun function(
  * The following snippets have identical behavior:
  *
  * - ```
- *   .extend {greet} where:{@lambda name: .name::equals {World}}
+ *   .extend {greet} where:{name: .name::equals {World}}
  *       name:
  *       .super::uppercase
  *   ```

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Optionality.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Optionality.kt
@@ -67,15 +67,13 @@ fun otherwise(
 ): DynamicValue = if (isNone(value.unwrappedValue)) fallback else value
 
 /**
- * Maps [value] to the result of [mapping].
- *
- * Note: this function is usually inlined. When inlining lambda arguments, an explicit `@lambda` annotation is required:
+ * Maps [value] to the result of [mapping]. This function is usually inlined:
  *
  * ```
- * .name::ifpresent {@lambda x: .x::uppercase}::otherwise {unnamed}
+ * .name::ifpresent {x: .x::uppercase}::otherwise {unnamed}
  * ```
  *
- * As with any inlined lambda, `@lambda` can be omitted if the result is constant:
+ * A constant result is also valid:
  *
  * ```
  * .name::ifpresent {I have a name}::otherwise {I'm unnamed}
@@ -99,16 +97,16 @@ fun ifPresent(
 /**
  * Keeps [value] if [condition] is true, otherwise returns [none].
  *
- * Note: this function is usually inlined. When inlining lambda arguments, an explicit `@lambda` annotation is required:
+ * Note: this function is usually inlined:
  *
  * ```
- * .takeif {5} {@lambda x: .x::iseven} <!-- None -->
+ * .takeif {5} {x: .x::iseven} <!-- None -->
  * ```
  *
  * This function is particularly useful when chained, for example:
  *
  * ```
- * .sum {2} {3}::takeif {@lambda x: .iseven {.x}}::otherwise {0} <!-- 0 -->
+ * .sum {2} {3}::takeif {x: .iseven {.x}}::otherwise {0} <!-- 0 -->
  * ```
  *
  * @param value value to check

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Primitives.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Primitives.kt
@@ -36,7 +36,7 @@ import com.quarkdown.processor.annotation.Spread
  * As a [Heading] primitive, this function can be used in `.extend` to affect all headings in the document:
  *
  * ```markdown
- * .extend {heading} where:{@lambda depth: .depth::equals {1}}
+ * .extend {heading} where:{depth: .depth::equals {1}}
  *     content:
  *     .super foreground:{blue}
  *         *.content*

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/TableComputation.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/TableComputation.kt
@@ -165,7 +165,7 @@ fun tableSort(
  *
  * Example:
  * ```
- * .tablefilter {2} {@lambda x: .x::isgreater {20}}
+ * .tablefilter {2} {x: .x::isgreater {20}}
  *     | Name | Age | City |
  *     |------|-----|------|
  *     | John | 25  | NY   |
@@ -211,7 +211,7 @@ fun tableFilter(
  *
  * Example:
  * ```
- * .tablecompute {2} {@lambda x: .x::average::round}
+ * .tablecompute {2} {x: .x::average::round}
  *     | Name | Age | City |
  *     |------|-----|------|
  *     | John | 25  | NY   |

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/internal/Comparison.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/internal/Comparison.kt
@@ -15,6 +15,7 @@ import com.quarkdown.core.util.node.toPlainText
 internal fun asComparablePlainText(value: Any?): String? =
     when (value) {
         is String -> value
+        is Number -> value.toString()
         is InlineMarkdownContent -> value.children.toPlainText()
         is MarkdownContent -> value.children.toPlainText()
         else -> null

--- a/quarkdown-test/src/test/kotlin/com/quarkdown/test/FunctionCallChainingTest.kt
+++ b/quarkdown-test/src/test/kotlin/com/quarkdown/test/FunctionCallChainingTest.kt
@@ -21,11 +21,11 @@ class FunctionCallChainingTest {
 
     @Test
     fun functional() {
-        execute(".sum {2} {4}::subtract {1}::takeif {@lambda x: .iseven {.x}}::otherwise {Odd number!}") {
+        execute(".sum {2} {4}::subtract {1}::takeif {x: .iseven {.x}}::otherwise {Odd number!}") {
             assertEquals("<p>Odd number!</p>", it)
         }
 
-        execute(".sum {2} {4}::subtract {1}::takeif {@lambda x: .iseven {.x}::not}::otherwise {Odd number!}") {
+        execute(".sum {2} {4}::subtract {1}::takeif {x: .iseven {.x}::not}::otherwise {Odd number!}") {
             assertEquals("<p>5</p>", it)
         }
     }

--- a/quarkdown-test/src/test/kotlin/com/quarkdown/test/FunctionExtensionTest.kt
+++ b/quarkdown-test/src/test/kotlin/com/quarkdown/test/FunctionExtensionTest.kt
@@ -343,7 +343,7 @@ class FunctionExtensionTest {
                  a b:
                  .a::sum {.b}
 
-            .extend {mysum} where:{@lambda a b: .a::sum {.b}::islower than:{10}}
+            .extend {mysum} where:{a b: .a::sum {.b}::islower than:{10}}
                 a:
                 .a
             
@@ -362,11 +362,11 @@ class FunctionExtensionTest {
                  a b:
                  .a::sum {.b}
 
-            .extend {mysum} where:{@lambda a: .a::islower than:{10}}
+            .extend {mysum} where:{a: .a::islower than:{10}}
                 a:
                 .a
             
-            .extend {mysum} where:{@lambda b: .b::islower than:{10}}
+            .extend {mysum} where:{b: .b::islower than:{10}}
                 b:
                 .b
                 
@@ -385,7 +385,7 @@ class FunctionExtensionTest {
                  a b:
                  .a::sum {.b}
 
-            .extend {mysum} where:{@lambda a: .a::islower than:{10}}
+            .extend {mysum} where:{a: .a::islower than:{10}}
                 a:
                 .a
             
@@ -414,7 +414,7 @@ class FunctionExtensionTest {
     fun `stdlib extension with injected parameter`() {
         execute(
             """
-            .extend {heading} where:{@lambda content: .content::equals {Hi}}
+            .extend {heading} where:{content: .content::equals {Hi}}
                 content:
                 .container
                     .super

--- a/quarkdown-test/src/test/kotlin/com/quarkdown/test/IterableTest.kt
+++ b/quarkdown-test/src/test/kotlin/com/quarkdown/test/IterableTest.kt
@@ -191,7 +191,7 @@ class IterableTest {
                      - b: 1
                      - c: 2
              
-            .foreach {.dict::sorted by:{@lambda name value: .value}}
+            .foreach {.dict::sorted by:{name value: .value}}
                 name value:
                 .name
             """.trimIndent(),

--- a/quarkdown-test/src/test/kotlin/com/quarkdown/test/LambdaTest.kt
+++ b/quarkdown-test/src/test/kotlin/com/quarkdown/test/LambdaTest.kt
@@ -3,10 +3,9 @@ package com.quarkdown.test
 import com.quarkdown.test.util.execute
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFails
 
 /**
- * Tests for `@lambda` expressions: implicit `.1` parameters, explicit named parameters,
+ * Tests for lambda expressions: implicit `.1` parameters, explicit named parameters,
  * and how lambdas combine with higher-order functions such as `.takeif` and `.otherwise`.
  */
 class LambdaTest {
@@ -16,7 +15,7 @@ class LambdaTest {
             """
             .let {hello}
                 .1
-                
+
                 .let {world}
                     .1
             """.trimIndent(),
@@ -26,22 +25,10 @@ class LambdaTest {
     }
 
     @Test
-    fun `bare body without @lambda fails to bind a parameter`() {
-        // `.1` is only defined within an actual lambda block; the bare body cannot resolve it.
-        assertFails {
-            execute(
-                """
-                .takeif {3} { .islower {.1} than:{5} }
-                """.trimIndent(),
-            ) {}
-        }
-    }
-
-    @Test
-    fun `takeif keeps the value when the @lambda predicate is true`() {
+    fun `inline lambda binds implicit parameter`() {
         execute(
             """
-            .takeif {3} { @lambda .islower {.1} than:{5} }
+            .takeif {3} { .islower {.1} than:{5} }
             """.trimIndent(),
         ) {
             assertEquals("<p>3</p>", it)
@@ -49,10 +36,21 @@ class LambdaTest {
     }
 
     @Test
-    fun `takeif drops the value when the @lambda predicate is false`() {
+    fun `inline lambda binds explicit named parameter`() {
         execute(
             """
-            .takeif {3} { @lambda .islower {.1} than:{2} }
+            .takeif {3} { x: .islower {.x} than:{5} }
+            """.trimIndent(),
+        ) {
+            assertEquals("<p>3</p>", it)
+        }
+    }
+
+    @Test
+    fun `inline lambda drops value when predicate is false`() {
+        execute(
+            """
+            .takeif {3} { x: .islower {.x} than:{2} }
             """.trimIndent(),
         ) {
             assertEquals(
@@ -63,21 +61,21 @@ class LambdaTest {
     }
 
     @Test
-    fun `lambda with explicit named parameter`() {
+    fun `inline lambda in chained call`() {
         execute(
             """
-            .takeif {3} { @lambda x: .islower {.x} than:{5} }
+            .takeif {3} {x: .iseven {.x}}::otherwise {0}
             """.trimIndent(),
         ) {
-            assertEquals("<p>3</p>", it)
+            assertEquals("<p>0</p>", it)
         }
     }
 
     @Test
-    fun `takeif combined with otherwise as fallback`() {
+    fun `inline lambda as fallback argument`() {
         execute(
             """
-            .otherwise {.takeif {3} {@lambda x: .iseven {.x}}} {0}
+            .otherwise {.takeif {3} {x: .iseven {.x}}} {0}
             """.trimIndent(),
         ) {
             assertEquals("<p>0</p>", it)
@@ -104,13 +102,13 @@ class LambdaTest {
     }
 
     @Test
-    fun `takeif combined with otherwise via chaining`() {
+    fun `legacy @lambda prefix is still accepted for backward compatibility`() {
         execute(
             """
-            .takeif {3} {@lambda x: .iseven {.x}}::otherwise {0}
+            .takeif {3} {@lambda x: .islower {.x} than:{5} }
             """.trimIndent(),
         ) {
-            assertEquals("<p>0</p>", it)
+            assertEquals("<p>3</p>", it)
         }
     }
 }

--- a/quarkdown-test/src/test/kotlin/com/quarkdown/test/OptionalityTest.kt
+++ b/quarkdown-test/src/test/kotlin/com/quarkdown/test/OptionalityTest.kt
@@ -169,7 +169,7 @@ class OptionalityTest {
         execute(
             """
             .var {num} {5}
-            .num::takeif {@lambda x: .x::equals {5}}
+            .num::takeif {x: .x::equals {5}}
             """.trimIndent(),
         ) {
             assertEquals(
@@ -182,7 +182,7 @@ class OptionalityTest {
             """
             .function {oddeven}
               num:
-              .num::takeif {@lambda x: .x::iseven}::ifpresent {Even}::otherwise {Odd}
+              .num::takeif {x: .x::iseven}::ifpresent {Even}::otherwise {Odd}
               
             .oddeven {5}
             
@@ -200,7 +200,7 @@ class OptionalityTest {
             """
             .function {present}
               x:
-              .x::ifpresent {@lambda Yes, .1 is present}::otherwise {Not present}
+              .x::ifpresent {Yes, .1 is present}::otherwise {Not present}
             
             .present {5}
             
@@ -225,9 +225,9 @@ class OptionalityTest {
               - b: 2
               - c: 3
               
-            .x::get {b}::ifpresent {@lambda .1::sum {3}}::otherwise {No}
+            .x::get {b}::ifpresent {.1::sum {3}}::otherwise {No}
 
-            .x::get {d}::ifpresent {@lambda .1::sum {3}}::otherwise {No}
+            .x::get {d}::ifpresent {.1::sum {3}}::otherwise {No}
             """.trimIndent(),
         ) {
             assertEquals("<p>5</p><p>No</p>", it)
@@ -241,9 +241,9 @@ class OptionalityTest {
               - 20
               - 30
               
-            .x::getat {2}::ifpresent {@lambda .1::sum {3}}::otherwise {No}
+            .x::getat {2}::ifpresent {.1::sum {3}}::otherwise {No}
             
-            .x::getat {5}::ifpresent {@lambda .1::sum {3}}::otherwise {No}
+            .x::getat {5}::ifpresent {.1::sum {3}}::otherwise {No}
             """.trimIndent(),
         ) {
             assertEquals("<p>23</p><p>No</p>", it)

--- a/quarkdown-test/src/test/kotlin/com/quarkdown/test/TableComputationTest.kt
+++ b/quarkdown-test/src/test/kotlin/com/quarkdown/test/TableComputationTest.kt
@@ -54,7 +54,7 @@ class TableComputationTest {
 
     @Test
     fun `plain filtering`() {
-        execute(".tablefilter {2} {@lambda x: .x::isgreater {20}}\n$table") {
+        execute(".tablefilter {2} {x: .x::isgreater {20}}\n$table") {
             assertEquals(
                 htmlTable(john + barbara + lisa),
                 it,
@@ -64,7 +64,7 @@ class TableComputationTest {
 
     @Test
     fun `plain sum computing`() {
-        execute(".tablecompute {2} {@lambda x: .x::sumall}\n$table") {
+        execute(".tablecompute {2} {x: .x::sumall}\n$table") {
             assertEquals(
                 htmlTable(
                     john + barbara + lisa + mike +
@@ -77,7 +77,7 @@ class TableComputationTest {
 
     @Test
     fun `plain average computing`() {
-        execute(".tablecompute {2} {@lambda .1::average::round}\n$table") {
+        execute(".tablecompute {2} {.1::average::round}\n$table") {
             assertEquals(
                 htmlTable(
                     john + barbara + lisa + mike +
@@ -91,7 +91,7 @@ class TableComputationTest {
     @Test
     fun composition() {
         execute(
-            ".tablecompute {2} {@lambda x: .x::average::round}\n" +
+            ".tablecompute {2} {x: .x::average::round}\n" +
                 "\t.tablesort {2}\n" +
                 table.indent("\t"),
         ) {
@@ -151,7 +151,7 @@ class TableComputationTest {
 
     @Test
     fun `compute on csv`() {
-        execute(".tablecompute {2} {@lambda x: .x::average::round}\n\t.csv {csv/people.csv}") {
+        execute(".tablecompute {2} {x: .x::average::round}\n\t.csv {csv/people.csv}") {
             assertEquals(
                 htmlTable(
                     john + lisa + mike +
@@ -165,7 +165,7 @@ class TableComputationTest {
     @Test
     fun `composition on csv`() {
         execute(
-            ".tablecompute {2} {@lambda x: .x::average::round}\n" +
+            ".tablecompute {2} {x: .x::average::round}\n" +
                 "\t.tablesort {2}\n" +
                 "\t\t.csv {csv/people.csv}",
         ) {

--- a/quarkdown-test/src/test/kotlin/com/quarkdown/test/primitive/HeadingPrimitiveFunctionTest.kt
+++ b/quarkdown-test/src/test/kotlin/com/quarkdown/test/primitive/HeadingPrimitiveFunctionTest.kt
@@ -47,7 +47,11 @@ class HeadingPrimitiveFunctionTest {
             """
              .noautopagebreak
 
-            .extend {heading} where:{@lambda content: .content::equals {Hi}}
+            .extend {heading} where:{depth: .depth::equals {2}}
+                 content:
+                 .super foreground:{red}
+            
+            .extend {heading} where:{content: .content::equals {Hi}}
                  content:
                  .container
                      .super 
@@ -55,12 +59,20 @@ class HeadingPrimitiveFunctionTest {
              # Hello
 
              ## Hi
+             
+             ## Hello
 
+             ### Hi
+             
              ### Hey
             """.trimIndent(),
         ) {
             assertEquals(
-                "<h1>Hello</h1><div class=\"container\"><h2>Hi</h2></div><h3>Hey</h3>",
+                "<h1>Hello</h1>" +
+                    "<div class=\"container\"><h2 style=\"color: rgba(255, 0, 0, 1.0);\">Hi</h2></div>" +
+                    "<h2 style=\"color: rgba(255, 0, 0, 1.0);\">Hello</h2>" +
+                    "<div class=\"container\"><h3>Hi</h3></div>" +
+                    "<h3>Hey</h3>",
                 it,
             )
         }
@@ -202,7 +214,7 @@ class HeadingPrimitiveFunctionTest {
             .extend {heading}
                 depth:
                 .super foreground:{red} \
-                       background:{.takeif {red} {@lambda .depth::islower than:{3}}} \
+                       background:{.takeif {red} {.depth::islower than:{3}}} \
                        fontvariant:{smallcaps}
 
             ## Hello
@@ -319,7 +331,7 @@ class HeadingPrimitiveFunctionTest {
             
             .extend {heading}
                 content:
-                .container foreground:{.takeif {red} {@lambda .content::plaintext::equals {Hello}}}
+                .container foreground:{.takeif {red} {.content::plaintext::equals {Hello}}}
                     .super
             
             # Hello

--- a/quarkdown-test/src/test/kotlin/com/quarkdown/test/primitive/ParagraphPrimitiveFunctionTest.kt
+++ b/quarkdown-test/src/test/kotlin/com/quarkdown/test/primitive/ParagraphPrimitiveFunctionTest.kt
@@ -34,7 +34,7 @@ class ParagraphPrimitiveFunctionTest {
     fun `content can be matched`() {
         execute(
             """
-            .extend {paragraph} where:{@lambda content: .content::equals {Hello}}
+            .extend {paragraph} where:{content: .content::equals {Hello}}
                 .super foreground:{blue} background:{white}
             
             Hello


### PR DESCRIPTION
- [x] I have read the [contributing guidelines](https://github.com/iamgio/quarkdown/blob/main/CONTRIBUTING.md).
- [x] I have tested the changes locally.
- [ ] An issue for this change exists, and it was discussed with maintainers. This is required for new features and non-trivial changes. If present, append `Closes #ISSUE_NUMBER` at the end of this PR description.
- [x] (Optional) I have added necessary documentation to [`docs`](https://github.com/iamgio/quarkdown/tree/main/docs) and [`CHANGELOG.md`](https://github.com/iamgio/quarkdown/blob/main/CHANGELOG.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Inline lambda arguments can now be written without the `@lambda` prefix.
  * Existing `@lambda` syntax remains supported for backward compatibility.
  * Numeric values now work correctly in plain-text comparisons.

* **Documentation**
  * Updated guides, examples, and API documentation to demonstrate the simplified inline lambda syntax.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->