### PR TITLE
feat(primitives): make Figure primitive-backed

### DIFF
--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/base/inline/Image.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/base/inline/Image.kt
@@ -54,8 +54,6 @@ class Image(
             FunctionCallArgument(name = "height", expression = height?.let(::ObjectValue) ?: NoneValue),
             FunctionCallArgument(name = "ref", expression = referenceId?.wrappedAsValue() ?: NoneValue),
             FunctionCallArgument(name = "mediastorage", expression = usesMediaStorage.wrappedAsValue()),
-            // Suppress the default Figure wrap — the parser already wraps the Image in an
-            // ImageFigure when relevant, so .super must return a bare Image to avoid double-figuring.
             FunctionCallArgument(name = "figure", expression = BooleanValue(false)),
         )
 }

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/quarkdown/block/Figure.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/quarkdown/block/Figure.kt
@@ -2,14 +2,21 @@ package com.quarkdown.core.ast.quarkdown.block
 
 import com.quarkdown.amber.annotations.Diverge
 import com.quarkdown.core.ast.InlineContent
+import com.quarkdown.core.ast.InlineMarkdownContent
+import com.quarkdown.core.ast.MarkdownContent
 import com.quarkdown.core.ast.Node
 import com.quarkdown.core.ast.SingleChildNestableNode
 import com.quarkdown.core.ast.attributes.localization.LocalizedKind
 import com.quarkdown.core.ast.attributes.localization.LocalizedKindKeys
 import com.quarkdown.core.ast.attributes.location.LocationTrackableNode
+import com.quarkdown.core.ast.attributes.primitive.PrimitiveFunctionBackedNode
 import com.quarkdown.core.ast.base.inline.Image
 import com.quarkdown.core.ast.quarkdown.CaptionableNode
 import com.quarkdown.core.ast.quarkdown.reference.CrossReferenceableNode
+import com.quarkdown.core.function.call.FunctionCallArgument
+import com.quarkdown.core.function.value.NoneValue
+import com.quarkdown.core.function.value.StringValue
+import com.quarkdown.core.function.value.wrappedAsValue
 import com.quarkdown.core.util.node.group
 import com.quarkdown.core.visitor.node.NodeVisitor
 
@@ -29,7 +36,8 @@ open class Figure<T : Node>(
     LocationTrackableNode,
     CrossReferenceableNode,
     CaptionableNode,
-    LocalizedKind {
+    LocalizedKind,
+    PrimitiveFunctionBackedNode {
     override val children: List<Node>
         get() = listOf(child, caption.group())
 
@@ -41,6 +49,25 @@ open class Figure<T : Node>(
      */
     override val canTrackLocation: Boolean
         get() = caption != null || referenceId != null
+
+    override val backingFunctionName: String
+        get() = "figure"
+
+    override fun toFunctionCallArguments() =
+        listOf(
+            FunctionCallArgument(
+                name = "caption",
+                expression = caption?.let { InlineMarkdownContent(it).wrappedAsValue() } ?: NoneValue,
+            ),
+            FunctionCallArgument(
+                name = "ref",
+                expression = referenceId?.let(::StringValue) ?: NoneValue,
+            ),
+            FunctionCallArgument(
+                name = "body",
+                expression = MarkdownContent(listOf(child)).wrappedAsValue(),
+            ),
+        )
 
     override fun <T> accept(visitor: NodeVisitor<T>): T = visitor.visit(this)
 }

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Primitives.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Primitives.kt
@@ -177,6 +177,15 @@ fun pageBreak() = PageBreak().wrappedAsValue()
  *
  * If either [caption] or [referenceId] is set, the figure will be numbered according to the `figures` [numbering] rule.
  *
+ * As a [Figure] primitive, this function can be used in `.extend` to affect all figures in the document,
+ * including standalone Markdown images (`![alt](url)`) that are automatically wrapped in a figure:
+ *
+ * ```markdown
+ * .extend {figure} where:{ref: .ref::equals {logo}}
+ *     .container border:{1px solid gray}
+ *         .super
+ * ```
+ *
  * @param caption optional inline caption of the figure
  * @param referenceId optional ID for cross-referencing via [reference]
  * @param body content of the figure

--- a/quarkdown-test/src/test/kotlin/com/quarkdown/test/primitive/FigurePrimitiveFunctionTest.kt
+++ b/quarkdown-test/src/test/kotlin/com/quarkdown/test/primitive/FigurePrimitiveFunctionTest.kt
@@ -1,0 +1,82 @@
+package com.quarkdown.test.primitive
+
+import com.quarkdown.test.util.execute
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Tests for `.extend` applied to Markdown figures.
+ */
+class FigurePrimitiveFunctionTest {
+    @Test
+    fun `no extension renders unchanged`() {
+        execute("![Logo](img.png)") {
+            assertEquals(
+                "<figure><img src=\"img.png\" alt=\"Logo\" /></figure>",
+                it,
+            )
+        }
+    }
+
+    @Test
+    fun `extension wraps every figure`() {
+        execute(
+            """
+            .extend {figure}
+                .container
+                    .super
+
+            ![Logo](img.png)
+            """.trimIndent(),
+        ) {
+            assertEquals(
+                "<div class=\"container\"><figure><img src=\"img.png\" alt=\"Logo\" /></figure></div>",
+                it,
+            )
+        }
+    }
+
+    @Test
+    fun `ref can be matched and conditionally wrapped`() {
+        execute(
+            """
+            .extend {figure} where:{ref: .ref::equals {my-fig}}
+                .container
+                    .super
+
+            ![Match](match.png) {#my-fig}
+
+            ![No match](nomatch.png)
+            """.trimIndent(),
+        ) {
+            assertEquals(
+                "<div class=\"container\"><figure id=\"my-fig\"><img src=\"match.png\" alt=\"Match\" /></figure></div>" +
+                    "<figure><img src=\"nomatch.png\" alt=\"No match\" /></figure>",
+                it,
+            )
+        }
+    }
+
+    @Test
+    fun `caption can be matched`() {
+        execute(
+            """
+            .extend {figure} where:{caption: .caption::equals {Match}}
+                .container
+                    .super
+
+            ![Alt](match.png "Match")
+
+            ![Alt](nomatch.png "No match")
+            """.trimIndent(),
+        ) {
+            assertEquals(
+                "<div class=\"container\"><figure><img src=\"match.png\" alt=\"Alt\" title=\"Match\" />" +
+                    "<figcaption class=\"caption-bottom\">Match</figcaption></figure></div>" +
+                    "<figure><img src=\"nomatch.png\" alt=\"Alt\" title=\"No match\" />" +
+                    "<figcaption class=\"caption-bottom\">No match</figcaption></figure>",
+                it,
+            )
+        }
+    }
+}


### PR DESCRIPTION
- [X] I have read the [contributing guidelines](https://github.com/iamgio/quarkdown/blob/main/CONTRIBUTING.md).
- [X] I have tested the changes locally.
- [ ] An issue for this change exists, and it was discussed with maintainers. This is required for new features and non-trivial changes. If present, append `Closes #ISSUE_NUMBER` at the end of this PR description.
- [ ] (Optional) I have added necessary documentation to [`docs`](https://github.com/iamgio/quarkdown/tree/main/docs) and [`CHANGELOG.md`](https://github.com/iamgio/quarkdown/blob/main/CHANGELOG.md)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Figures can now be extended and customized using the `figure` primitive.
  * Figure extensions support wrapping figures and conditionally matching by reference or caption.
  * Standalone Markdown images continue to be handled as figures.

* **Documentation**
  * Added examples and clarified how `.extend` applies to figures and Markdown images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->