### PR TITLE
feat(primitives): make PageBreak primitive-backed

### DIFF
--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/quarkdown/block/PageBreak.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/quarkdown/block/PageBreak.kt
@@ -1,12 +1,21 @@
 package com.quarkdown.core.ast.quarkdown.block
 
 import com.quarkdown.core.ast.Node
+import com.quarkdown.core.ast.attributes.primitive.PrimitiveFunctionBackedNode
+import com.quarkdown.core.function.call.FunctionCallArgument
 import com.quarkdown.core.visitor.node.NodeVisitor
 
 /**
  * A forced page break.
  */
-class PageBreak : Node {
+class PageBreak :
+    Node,
+    PrimitiveFunctionBackedNode {
+    override val backingFunctionName: String
+        get() = "pagebreak"
+
+    override fun toFunctionCallArguments() = emptyList<FunctionCallArgument>()
+
     override fun toString() = "PageBreak"
 
     override fun <T> accept(visitor: NodeVisitor<T>) = visitor.visit(this)

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Primitives.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Primitives.kt
@@ -166,6 +166,16 @@ fun image(
  * .pagebreak
  * ```
  *
+ * As a [PageBreak] primitive, this function can be used in `.extend` to affect all page breaks in the document,
+ * including those introduced by the `<<<` syntax:
+ *
+ * ```markdown
+ * .extend {pagebreak}
+ *     .container border:{1px dashed gray}
+ *
+ *     .super
+ * ```
+ *
  * @return a [PageBreak] node
  */
 @QFunction

--- a/quarkdown-test/src/test/kotlin/com/quarkdown/test/primitive/PageBreakPrimitiveFunctionTest.kt
+++ b/quarkdown-test/src/test/kotlin/com/quarkdown/test/primitive/PageBreakPrimitiveFunctionTest.kt
@@ -1,0 +1,82 @@
+package com.quarkdown.test.primitive
+
+import com.quarkdown.test.util.execute
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Tests for `.extend` applied to page breaks.
+ */
+class PageBreakPrimitiveFunctionTest {
+    @Test
+    fun `no extension renders unchanged`() {
+        execute(
+            """
+            Hello
+
+            <<<
+
+            World
+            """.trimIndent(),
+        ) {
+            assertEquals(
+                "<p>Hello</p>" +
+                    "<div class=\"page-break\" data-hidden=\"\"></div>" +
+                    "<p>World</p>",
+                it,
+            )
+        }
+    }
+
+    @Test
+    fun `extension precedes every syntax page break with a sibling block`() {
+        execute(
+            """
+            .extend {pagebreak}
+                .container
+
+                .super
+
+            Hello
+
+            <<<
+
+            World
+            """.trimIndent(),
+        ) {
+            assertEquals(
+                "<p>Hello</p>" +
+                    "<div class=\"container\"></div>" +
+                    "<div class=\"page-break\" data-hidden=\"\"></div>" +
+                    "<p>World</p>",
+                it,
+            )
+        }
+    }
+
+    @Test
+    fun `extension precedes every primitive page break with a sibling block`() {
+        execute(
+            """
+            .extend {pagebreak}
+                .container
+
+                .super
+
+            Hello
+
+            .pagebreak
+
+            World
+            """.trimIndent(),
+        ) {
+            assertEquals(
+                "<p>Hello</p>" +
+                    "<div class=\"container\"></div>" +
+                    "<div class=\"page-break\" data-hidden=\"\"></div>" +
+                    "<p>World</p>",
+                it,
+            )
+        }
+    }
+}


### PR DESCRIPTION
- [X] I have read the [contributing guidelines](https://github.com/iamgio/quarkdown/blob/main/CONTRIBUTING.md).
- [X] I have tested the changes locally.
- [ ] An issue for this change exists, and it was discussed with maintainers. This is required for new features and non-trivial changes. If present, append `Closes #ISSUE_NUMBER` at the end of this PR description.
- [ ] (Optional) I have added necessary documentation to [`docs`](https://github.com/iamgio/quarkdown/tree/main/docs) and [`CHANGELOG.md`](https://github.com/iamgio/quarkdown/blob/main/CHANGELOG.md)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Page breaks created with `<<<` can now participate in `.extend {pagebreak}` behavior alongside primitive page breaks.
  - Extended page-break content is now inserted in the correct position relative to the rendered page-break element.

- **Documentation**
  - Updated the `pagebreak` primitive docs with additional explanation and an `.extend {pagebreak}` example.

- **Tests**
  - Added test coverage for both unchanged rendering and extended rendering order across `<<<` and primitive `.pagebreak` cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->