### PR TITLE
feat(primitives): add .math

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,19 +24,19 @@ This is one of the biggest milestones for Quarkdown, on par with Typst's `#show`
 ## A heading <!-- Renders blue and italic -->
 ```
 
-This release ships with a handful of primitives as an experimental feature. The plan is to eventually have every Markdown element type backed by a primitive function.
+This release ships with a handful of primitives as an experimental feature: headings, paragraphs, figures, images, math, page breaks. The plan is to eventually have every Markdown element type backed by a primitive function.
 
 &nbsp;
 
-#### [New primitive: `.paragraph`]
+#### [New primitives: `.paragraph` and `.math`](https://quarkdown.com/wiki/primitives)
 
-The new `.paragraph` primitive backs Markdown paragraphs, enabling paragraph-level extensions via `.extend {paragraph}`.
+The new `.paragraph` primitive backs Markdown paragraphs, and `.math` backs `$`-delimited math blocks, enabling extensions via `.extend`.
 
 &nbsp;
 
-#### [Full styling options on `.heading` and `.paragraph`](https://quarkdown.com/wiki/element-styling-properties)
+#### [Full styling options on `.heading`, `.paragraph` and `.math`](https://quarkdown.com/wiki/element-styling-properties)
 
-`.container`'s styling options, such as `foreground`, `background`, `border`, `padding`, and `fontsize`, are now available on `.heading` and `.paragraph` as well. This allows for full customization without needing to wrap the element in a container.
+`.container`'s styling options, such as `foreground`, `background`, `border`, `padding`, and `fontsize`, are now available on `.heading`, `.paragraph` and `.math` as well. This allows for full customization without needing to wrap the element in a container.
 
 ```markdown
 .heading {Introduction} depth:{1} background:{blue} radius:{8px}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,6 +102,47 @@ Defining a new node involves:
 - Adding lexing/parsing logic (very uncommon in the current state of the project) or, more commonly for non-GFM nodes,
   defining a native function in the [standard library](#standard-library) that returns the node. See the `Layout` stdlib module for examples.
 
+### Primitive functions
+
+A *primitive function* is a stdlib function that backs a Markdown syntax element (`.heading` backs `#`, `.paragraph` backs paragraphs,
+`.figure` backs standalone images, `.pagebreak` backs `<<<`, `.math` backs `$ ... $`, and so on).
+Because Markdown syntax and the primitive call produce the same AST node, extending the primitive via `.extend {name}` also applies to the corresponding Markdown syntax.
+
+The wiring lives in `TreeRewriteStage` / `AstRewriter`: after function call expansion, the rewriter walks the AST and, whenever it finds a
+`PrimitiveFunctionBackedNode` whose `backingFunctionName` has been extended, it wraps the node in a synthesized `FunctionCallNode`.
+No other wiring is needed.
+
+Adding a new primitive-backed node involves two sides:
+
+- **AST node** (in `quarkdown-core`, under `ast/base` or `ast/quarkdown`).
+  Make the node implement `PrimitiveFunctionBackedNode`:
+  - Set `backingFunctionName` to the primitive's Quarkdown name (matching the `@Name` on the stdlib function, if any).
+  - Implement `toFunctionCallArguments()` to materialize the node's properties as `FunctionCallArgument`s whose *names* must match the primitive's parameter names.
+  - For inline nodes (e.g. `MathSpan`), override `isBackingCallBlock` to `false` so the inline output mapper is used during expansion.
+    Block nodes get the default `true` for free.
+  - If the node should be user-styleable, make it also implement `StylableNode` with a `style: NodeStyle` property.
+
+- **stdlib primitive** (in [`quarkdown-stdlib/.../Primitives.kt`](quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Primitives.kt)).
+  Declare a `@QFunction` returning the AST node wrapped as a value. Parameter names must match those emitted by `toFunctionCallArguments()`.
+  Include a KDoc example that uses `.extend {name}`, following the pattern already used by `.heading`, `.paragraph`, `.figure`, `.pagebreak`, and `.math`.
+  If the node is styleable, accept `@Spread style: StyleOptions = StyleOptions.DEFAULT` and pass `style.toNodeStyle()` into the node.
+
+- **Renderer** (for each rendering backend, e.g. [`quarkdown-html/.../QuarkdownHtmlNodeRenderer.kt`](quarkdown-html/src/main/kotlin/com/quarkdown/rendering/html/node/QuarkdownHtmlNodeRenderer.kt)).
+  If the node is styleable, the renderer's `visit(node)` must actually emit the style. In the HTML backend that means calling `style(node.style)` inside the tag builder block:
+
+  ```kotlin
+  override fun visit(node: MyNode) =
+      buildTag("my-tag") {
+          +node.content
+          style(node.style)
+      }
+  ```
+
+  Without this, the `style: NodeStyle` on the AST node is inert and `foreground:`, `background:`, `padding:`, etc. from `StyleOptions` will not reach the output.
+
+Tests should cover both the primitive function itself (in an appropriate module test, e.g. `MathTest`) and the extension mechanism
+(in `quarkdown-test/.../primitive/<Name>PrimitiveFunctionTest.kt`, mirroring the existing files there).
+
 ### Function calls and scripting
 
 The function call subsystem spans parsing, resolution, execution, and output mapping.

--- a/docs/primitives.qd
+++ b/docs/primitives.qd
@@ -1,61 +1,20 @@
 .docname {Primitive functions}
 .include {docs}
 
-Quarkdown exposes primitive functions that provide fine-grained control over standard Markdown elements. These functions offer parameters that are not accessible through the regular Markdown syntax.
+Primitive functions return elements that back standard Markdown syntax. Each one accepts parameters that plain Markdown may not, and can be intercepted via [`.extend`](extending-functions.qd) to customize their behavior and appearance across the entire document, even if created via standard Markdown syntax.
 
-## Headings
+For example, extending `.heading` affects every `#`, `##`, and so on. Extending `.math` affects every `$ ... $` and `$$$ ... $$$`. See [*Element styling*](element-styling.qd) for the full mechanism.
 
-The `.heading` function creates headings with explicit control over numbering, page breaks, table of contents indexing, and custom identifiers. See the [Headings](headings.qd) page for details.
+## Available primitives
 
-## Images
+- **`.heading`** .docslink {quarkdown-stdlib/com.quarkdown.stdlib.module.Primitives/heading.html} backs `#`, `##`, ... headings. Exposes explicit control over depth, numbering, page breaks, and cross-reference identifiers. See [Headings](headings.qd).
 
-The **`.image`** .docslink {quarkdown-stdlib/com.quarkdown.stdlib.module.Primitives/image.html} function creates an image with fine-grained control over its properties, compared to the standard Markdown image syntax (`![alt](url "title")`).
+- **`.paragraph`** .docslink {quarkdown-stdlib/com.quarkdown.stdlib.module.Primitives/paragraph.html} backs regular paragraphs.
 
-```markdown
-.image {photo.jpg} label:{A photo}
-```
+- **`.image`** .docslink {quarkdown-stdlib/com.quarkdown.stdlib.module.Primitives/image.html} backs `![alt](url "title")`, with additional control over figure wrapping and [media storage](media-storage.qd).
 
-### Size constraints
+- [**`.figure`**](figure.qd) .docslink {quarkdown-stdlib/com.quarkdown.stdlib.module.Primitives/figure.html} backs the block that wraps an image or other content.
 
-The `width` and `height` parameters accept any [size](sizes.qd) value.
+- [**`.math`**](tex-formulae.qd) .docslink {quarkdown-stdlib/com.quarkdown.stdlib.module.Primitives/math.html} backs `$ ... $` and `$$$ ... $$$` formulas.
 
-```markdown
-.image {photo.jpg} label:{A photo} width:{200px} height:{150px}
-
-.image {banner.svg} label:{Banner} width:{100%}
-```
-
-### Caption
-
-When a `title` is provided, it is used both as the image tooltip and as the figure caption.
-
-.examplemirror
-    .image {assets/icon.svg} label:{Icon} title:{The Quarkdown icon} width:{64px}
-
-### Figure wrapping
-
-By default, the image is wrapped in a figure block, which centers it and enables captioning and [numbering](numbering.qd). To disable this behavior, set `figure:{no}`, which produces a raw inline image instead.
-
-```markdown
-Hello .image {icon.svg} label:{Icon} figure:{no} width:{16px} height:{16px} world!
-```
-
-### Cross-referencing
-
-The `ref` parameter assigns an ID that can be used with [cross-references](cross-references.qd).
-
-```markdown
-.image {diagram.png} label:{Architecture diagram} title:{System overview} ref:{arch-diagram} width:{400px}
-
-See .ref {arch-diagram} for more details.
-```
-
-### Media storage opt-out
-
-By default, local images are copied to the output's media directory when [media storage](media-storage.qd) is enabled. To prevent this and reference the image at its original path instead, set `mediastorage:{no}`.
-
-```markdown
-.image {../banner.svg} label:{Banner} mediastorage:{no}
-```
-
-This is useful for images that should reference a fixed relative path, such as assets shared across multiple builds or maintained outside the project directory.
+- [**`.pagebreak`**](page-break.qd) .docslink {quarkdown-stdlib/com.quarkdown.stdlib.module.Primitives/pagebreak.html} backs `<<<`. Can be extended to decorate every forced page break in the document.

--- a/docs/tex-formulae.qd
+++ b/docs/tex-formulae.qd
@@ -38,6 +38,59 @@ A block formula can span over multiple lines thanks to a syntax similar to fence
     \end{cases}
     $$$
 
+## The `.math` function
+
+Equations can also be created via the **`.math`** [primitive function](primitives.qd). This is useful when the equation content is computed from other functions, or when you want to apply styling to a specific formula.
+
+.examplemirror
+    .math
+        E = mc^2
+
+    <!-- or, equivalently -->
+
+    .math {E = mc^2}
+
+By default, `.math` produces a block formula when produced by a [block function call](syntax-of-a-function-call.qd#block-vs-inline-function-calls). You can force one or the other via the `block` parameter:
+
+.examplemirror
+    Inline: .math {2 + 2}
+
+The content is evaluated as Quarkdown, so nested function calls are evaluated, contrary to the `$`-based syntax.
+
+.examplemirror
+    .var {n} {5}
+
+    .math
+        f(.n) = .n::multiply {2}
+
+### Styling
+
+Both inline and block equations accept the same [styling properties](element-styling-properties.qd) as containers.
+
+.examplemirror
+    .math fontsize:{larger}
+        \pi \approx 3.14
+
+### Extending
+
+`.math` backs the standard `$ ... $` syntax, so [extending it](element-styling.qd) affects every equation in the document at once.
+
+.exampleoutput {
+    .math fontsize:{larger} foreground:{skyblue}
+        a^2 + b^2 = c^2
+
+    Inline: .math {a^2 + b^2 = c^2} foreground:{skyblue}
+}
+    .extend {math}
+        .super foreground:{skyblue}
+
+    .extend {math} where:{block: .block}
+        .super fontsize:{larger}
+
+    $ a^2 + b^2 = c^2 $
+
+    Inline: $ a^2 + b^2 = c^2 $
+
 ## Macros
 
 Quarkdown supports the creation of TeX macros via the `.texmacro` function. See [*TeX macros*](tex-macros.qd) for more information.

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/attributes/primitive/PrimitiveFunctionBackedNode.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/attributes/primitive/PrimitiveFunctionBackedNode.kt
@@ -23,6 +23,14 @@ interface PrimitiveFunctionBackedNode : Node {
     val backingFunctionName: String
 
     /**
+     * Whether the synthesized backing call should be treated as a block call.
+     * Defaults to `true`; inline primitive nodes should override to `false`
+     * so the inline output mapper is used during expansion.
+     */
+    val isBackingCallBlock: Boolean
+        get() = true
+
+    /**
      * Materializes this node's properties into the arguments of the backing function call.
      * Argument names must match the parameter names of the function identified by [backingFunctionName].
      */

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/iterator/AstRewriter.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/iterator/AstRewriter.kt
@@ -107,6 +107,6 @@ class AstRewriter(
             context = context,
             name = node.backingFunctionName,
             arguments = node.toFunctionCallArguments(),
-            isBlock = true,
+            isBlock = node.isBackingCallBlock,
         ).also(context::register)
 }

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/quarkdown/block/Math.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/quarkdown/block/Math.kt
@@ -1,7 +1,16 @@
 package com.quarkdown.core.ast.quarkdown.block
 
 import com.quarkdown.core.ast.attributes.location.LocationTrackableNode
+import com.quarkdown.core.ast.attributes.primitive.PrimitiveFunctionBackedNode
+import com.quarkdown.core.ast.attributes.style.NodeStyle
+import com.quarkdown.core.ast.attributes.style.StylableNode
 import com.quarkdown.core.ast.quarkdown.reference.CrossReferenceableNode
+import com.quarkdown.core.function.call.FunctionCallArgument
+import com.quarkdown.core.function.value.BooleanValue
+import com.quarkdown.core.function.value.NoneValue
+import com.quarkdown.core.function.value.ObjectValue
+import com.quarkdown.core.function.value.StringValue
+import com.quarkdown.core.function.value.data.EvaluableString
 import com.quarkdown.core.visitor.node.NodeVisitor
 
 /**
@@ -10,17 +19,31 @@ import com.quarkdown.core.visitor.node.NodeVisitor
  * A math block can be cross-referenced and can be numbered, as long as it has a [referenceId].
  * @param expression expression content
  * @param referenceId optional reference id for cross-referencing via a [com.quarkdown.core.ast.quarkdown.reference.CrossReference]
+ * @param style styling applied to the block
  */
 class Math(
     val expression: String,
     override val referenceId: String? = null,
+    override val style: NodeStyle = NodeStyle.DEFAULT,
 ) : LocationTrackableNode,
-    CrossReferenceableNode {
+    CrossReferenceableNode,
+    StylableNode,
+    PrimitiveFunctionBackedNode {
     /**
      * A math block is numbered if it has a [referenceId].
      */
     override val canTrackLocation: Boolean
         get() = referenceId != null
+
+    override val backingFunctionName: String
+        get() = "math"
+
+    override fun toFunctionCallArguments() =
+        listOf(
+            FunctionCallArgument(name = "content", expression = ObjectValue(EvaluableString(expression))),
+            FunctionCallArgument(name = "block", expression = BooleanValue(true)),
+            FunctionCallArgument(name = "ref", expression = referenceId?.let(::StringValue) ?: NoneValue),
+        )
 
     override fun <T> accept(visitor: NodeVisitor<T>) = visitor.visit(this)
 }

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/quarkdown/inline/MathSpan.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/quarkdown/inline/MathSpan.kt
@@ -1,14 +1,37 @@
 package com.quarkdown.core.ast.quarkdown.inline
 
 import com.quarkdown.core.ast.Node
+import com.quarkdown.core.ast.attributes.primitive.PrimitiveFunctionBackedNode
+import com.quarkdown.core.ast.attributes.style.NodeStyle
+import com.quarkdown.core.ast.attributes.style.StylableNode
+import com.quarkdown.core.function.call.FunctionCallArgument
+import com.quarkdown.core.function.value.BooleanValue
+import com.quarkdown.core.function.value.ObjectValue
+import com.quarkdown.core.function.value.data.EvaluableString
 import com.quarkdown.core.visitor.node.NodeVisitor
 
 /**
  * A math (TeX) inline.
  * @param expression expression content
+ * @param style styling applied to the inline
  */
 class MathSpan(
     val expression: String,
-) : Node {
+    override val style: NodeStyle = NodeStyle.DEFAULT,
+) : Node,
+    StylableNode,
+    PrimitiveFunctionBackedNode {
+    override val backingFunctionName: String
+        get() = "math"
+
+    override val isBackingCallBlock: Boolean
+        get() = false
+
+    override fun toFunctionCallArguments() =
+        listOf(
+            FunctionCallArgument(name = "content", expression = ObjectValue(EvaluableString(expression))),
+            FunctionCallArgument(name = "block", expression = BooleanValue(false)),
+        )
+
     override fun <T> accept(visitor: NodeVisitor<T>) = visitor.visit(this)
 }

--- a/quarkdown-html/src/main/kotlin/com/quarkdown/rendering/html/node/QuarkdownHtmlNodeRenderer.kt
+++ b/quarkdown-html/src/main/kotlin/com/quarkdown/rendering/html/node/QuarkdownHtmlNodeRenderer.kt
@@ -195,6 +195,7 @@ class QuarkdownHtmlNodeRenderer(
             attribute("data-block", "")
             optionalAttribute("id", node.linkableReferenceId?.let(::sanitizeId))
             optionalAttribute("data-location", node.getLocationLabel(context))
+            style(node.style)
         }
 
     override fun visit(node: Container) =
@@ -413,7 +414,11 @@ class QuarkdownHtmlNodeRenderer(
 
     // Inline
 
-    override fun visit(node: MathSpan) = buildTag("formula", node.expression)
+    override fun visit(node: MathSpan) =
+        buildTag("formula") {
+            +node.expression
+            style(node.style)
+        }
 
     override fun visit(node: CrossReference): CharSequence {
         val definition: CrossReferenceableNode = node.getDefinition(context) ?: return Text("[???]").accept(this)

--- a/quarkdown-html/src/test/e2e/math/styling/main.qd
+++ b/quarkdown-html/src/test/e2e/math/styling/main.qd
@@ -1,0 +1,6 @@
+.extend {math}
+    .super foreground:{red} background:{black} padding:{10px}
+
+$ f(x) = \frac{1}{x} $
+
+Inline: $ y = x + 1 $

--- a/quarkdown-html/src/test/e2e/math/styling/styling.spec.ts
+++ b/quarkdown-html/src/test/e2e/math/styling/styling.spec.ts
@@ -1,0 +1,18 @@
+import {getComputedColor} from "../../__util/css";
+import {suite} from "../../quarkdown";
+
+const {test, expect} = suite(__dirname);
+
+test("applies inline styles to block and inline math", async (page) => {
+    const blockFormula = page.locator("formula[data-block]").first();
+    const inlineFormula = page.locator("p formula").first();
+
+    const red = await getComputedColor(page, "red");
+    const black = await getComputedColor(page, "black");
+
+    for (const formula of [blockFormula, inlineFormula]) {
+        await expect(formula).toHaveCSS("color", red);
+        await expect(formula).toHaveCSS("background-color", black);
+        await expect(formula).toHaveCSS("padding", "10px");
+    }
+});

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Primitives.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Primitives.kt
@@ -9,13 +9,17 @@ import com.quarkdown.core.ast.base.block.Paragraph
 import com.quarkdown.core.ast.base.inline.Image
 import com.quarkdown.core.ast.base.inline.Link
 import com.quarkdown.core.ast.quarkdown.block.Figure
+import com.quarkdown.core.ast.quarkdown.block.Math
 import com.quarkdown.core.ast.quarkdown.block.PageBreak
+import com.quarkdown.core.ast.quarkdown.inline.MathSpan
 import com.quarkdown.core.context.Context
 import com.quarkdown.core.document.size.Size
+import com.quarkdown.core.function.call.FunctionCall
 import com.quarkdown.core.function.reflect.annotation.Body
 import com.quarkdown.core.function.reflect.annotation.Injected
 import com.quarkdown.core.function.reflect.annotation.LikelyNamed
 import com.quarkdown.core.function.value.NodeValue
+import com.quarkdown.core.function.value.data.EvaluableString
 import com.quarkdown.core.function.value.wrappedAsValue
 import com.quarkdown.processor.annotation.Name
 import com.quarkdown.processor.annotation.QFunction
@@ -181,6 +185,56 @@ fun image(
 @QFunction
 @Name("pagebreak")
 fun pageBreak() = PageBreak().wrappedAsValue()
+
+/**
+ * Creates a math (TeX) node, either inline or as a block.
+ *
+ * Example:
+ * ```markdown
+ * .math {2 + 2}
+ *
+ * .math {E = mc^2} block:{yes} ref:{einstein}
+ * ```
+ *
+ * As a primitive backing both [Math] blocks and [MathSpan] inlines, this function can be used
+ * in `.extend` to affect all math nodes in the document:
+ *
+ * ```markdown
+ * .extend {math} where:{block: .block::not}
+ *     .super foreground:{gray}
+ * ```
+ *
+ * @param content TeX expression content
+ * @param block whether the node is rendered as a block instead of inline. If unset, it's inferred from whether the source function call is block or inline
+ * @param referenceId optional ID for cross-referencing via [reference], only applied to block math
+ * @return the new [Math] block node or [MathSpan] inline node, depending on [block]
+ */
+@QFunction
+fun math(
+    @Injected call: FunctionCall<*>,
+    @Body content: EvaluableString,
+    @LikelyNamed block: Boolean? = null,
+    @Name("ref") referenceId: String? = null,
+    @Spread style: StyleOptions = StyleOptions.DEFAULT,
+): NodeValue {
+    val isBlock = block ?: call.sourceNode?.isBlock ?: false
+    return when {
+        isBlock -> {
+            Math(
+                expression = content.content,
+                referenceId = referenceId,
+                style = style.toNodeStyle(),
+            ).wrappedAsValue()
+        }
+
+        else -> {
+            MathSpan(
+                expression = content.content,
+                style = style.toNodeStyle(),
+            ).wrappedAsValue()
+        }
+    }
+}
 
 /**
  * Inserts content in a figure block, with an optional caption.

--- a/quarkdown-test/src/test/kotlin/com/quarkdown/test/MathTest.kt
+++ b/quarkdown-test/src/test/kotlin/com/quarkdown/test/MathTest.kt
@@ -75,6 +75,91 @@ class MathTest {
     }
 
     @Test
+    fun `math primitive in inline context defaults to inline`() {
+        execute("Hello .math {2 + 2}") {
+            assertEquals(
+                "<p>Hello <formula>2 + 2</formula></p>",
+                it,
+            )
+        }
+    }
+
+    @Test
+    fun `math primitive on its own line defaults to block`() {
+        execute(".math {2 + 2}") {
+            assertEquals(
+                "<formula data-block=\"\">2 + 2</formula>",
+                it,
+            )
+        }
+    }
+
+    @Test
+    fun `math primitive block override forces block in inline context`() {
+        execute("Hello .math {2 + 2} block:{yes}") {
+            assertEquals(
+                "<p>Hello <formula data-block=\"\">2 + 2</formula></p>",
+                it,
+            )
+        }
+    }
+
+    @Test
+    fun `math primitive block override forces inline on its own line`() {
+        execute(".math {2 + 2} block:{no}") {
+            assertEquals(
+                "<formula>2 + 2</formula>",
+                it,
+            )
+        }
+    }
+
+    @Test
+    fun `math primitive block with reference`() {
+        execute(".math {2 + 2} ref:{eq1}") {
+            assertEquals(
+                "<formula data-block=\"\" id=\"eq1\">2 + 2</formula>",
+                it,
+            )
+        }
+    }
+
+    @Test
+    fun `math primitive inline with styling`() {
+        execute("Hello .math {2 + 2} foreground:{red}") {
+            assertEquals(
+                "<p>Hello <formula style=\"color: rgba(255, 0, 0, 1.0);\">2 + 2</formula></p>",
+                it,
+            )
+        }
+    }
+
+    @Test
+    fun `math primitive block with styling`() {
+        execute(".math {2 + 2} background:{blue}") {
+            assertEquals(
+                "<formula data-block=\"\" style=\"background-color: rgba(0, 0, 255, 1.0);\">2 + 2</formula>",
+                it,
+            )
+        }
+    }
+
+    @Test
+    fun `math primitive body evaluates nested function calls`() {
+        execute(
+            """
+            .math
+                2 + 2 = .sum {2} {2}
+            """.trimIndent(),
+        ) {
+            assertEquals(
+                "<formula data-block=\"\">2 + 2 = 4</formula>",
+                it,
+            )
+        }
+    }
+
+    @Test
     fun `custom macro`() {
         execute(
             """

--- a/quarkdown-test/src/test/kotlin/com/quarkdown/test/primitive/MathPrimitiveFunctionTest.kt
+++ b/quarkdown-test/src/test/kotlin/com/quarkdown/test/primitive/MathPrimitiveFunctionTest.kt
@@ -1,0 +1,85 @@
+package com.quarkdown.test.primitive
+
+import com.quarkdown.test.util.execute
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Tests for `.extend` applied to Markdown math nodes.
+ */
+class MathPrimitiveFunctionTest {
+    @Test
+    fun `no extension renders unchanged`() {
+        execute("Hello $ x + 1 $ and $ y $") {
+            assertEquals(
+                "<p>Hello <formula>x + 1</formula> and <formula>y</formula></p>",
+                it,
+            )
+        }
+    }
+
+    @Test
+    fun `extension wraps every block math`() {
+        execute(
+            """
+            .extend {math}
+                .container
+                    .super
+
+            $ x + 1 $
+            """.trimIndent(),
+        ) {
+            assertEquals(
+                "<div class=\"container\"><formula data-block=\"\">x + 1</formula></div>",
+                it,
+            )
+        }
+    }
+
+    @Test
+    fun `extension can be matched by block param`() {
+        execute(
+            """
+            .extend {math} where:{block: .block}
+                .container
+                    .super
+
+            $ y $ is inline
+
+            $ x + 1 $
+            """.trimIndent(),
+        ) {
+            assertEquals(
+                "<p><formula>y</formula> is inline</p>" +
+                    "<div class=\"container\"><formula data-block=\"\">x + 1</formula></div>",
+                it,
+            )
+        }
+    }
+
+    @Test
+    fun `chained broad and conditional extensions stack on block, only broad on inline`() {
+        execute(
+            """
+            .extend {math}
+                .super foreground:{red}
+
+            .extend {math} where:{block: .block}
+                .super fontsize:{large}
+
+            $ a^2 + b^2 = c^2 $
+
+            Inline: $ a^2 + b^2 = c^2 $
+            """.trimIndent(),
+        ) {
+            assertEquals(
+                "<formula data-block=\"\" " +
+                    "style=\"color: rgba(255, 0, 0, 1.0); font-size: var(--qd-size-large, 1em);\">" +
+                    "a^2 + b^2 = c^2</formula>" +
+                    "<p>Inline: " +
+                    "<formula style=\"color: rgba(255, 0, 0, 1.0);\">a^2 + b^2 = c^2</formula></p>",
+                it,
+            )
+        }
+    }
+}


### PR DESCRIPTION
- [X] I have read the [contributing guidelines](https://github.com/iamgio/quarkdown/blob/main/CONTRIBUTING.md).
- [X] I have tested the changes locally.
- [ ] An issue for this change exists, and it was discussed with maintainers. This is required for new features and non-trivial changes. If present, append `Closes #ISSUE_NUMBER` at the end of this PR description.
- [ ] (Optional) I have added necessary documentation to [`docs`](https://github.com/iamgio/quarkdown/tree/main/docs) and [`CHANGELOG.md`](https://github.com/iamgio/quarkdown/blob/main/CHANGELOG.md)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded the experimental primitives rollout to explicitly cover headings, paragraphs, figures, images, math, and page breaks.
  * Added enhanced `.math` support for inline vs block output, references, nested evaluation, and styling.
* **Bug Fixes**
  * Improved primitive extension behavior so inline vs block math remains consistent when intercepted by extensions.
* **Documentation**
  * Updated primitives and TeX formulae docs, including a concise “available primitives” list.
* **Tests**
  * Added end-to-end math styling coverage and expanded unit tests for inline/block placement, refs, styling, and extension chaining.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->