### PR TITLE
feat(primitives): add .link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,19 +24,19 @@ This is one of the biggest milestones for Quarkdown, on par with Typst's `#show`
 ## A heading <!-- Renders blue and italic -->
 ```
 
-This release ships with a handful of primitives as an experimental feature: headings, paragraphs, figures, images, math, page breaks. The plan is to eventually have every Markdown element type backed by a primitive function.
+This release ships with a handful of primitives as an experimental feature: headings, paragraphs, links, figures, images, math, page breaks. The plan is to eventually have every Markdown element type backed by a primitive function.
 
 &nbsp;
 
-#### [New primitives: `.paragraph` and `.math`](https://quarkdown.com/wiki/primitives)
+#### [New primitives: `.paragraph`, `.math`, `.link`](https://quarkdown.com/wiki/primitives)
 
-The new `.paragraph` primitive backs Markdown paragraphs, and `.math` backs `$`-delimited math blocks, enabling extensions via `.extend`.
+The new `.paragraph` primitive backs Markdown paragraphs, `.math` backs `$`-delimited math blocks, and `.link` backs Markdown links, enabling extensions via `.extend`.
 
 &nbsp;
 
-#### [Full styling options on `.heading`, `.paragraph` and `.math`](https://quarkdown.com/wiki/element-styling-properties)
+#### [Full styling options on `.heading`, `.paragraph`, `.math` and `.link`](https://quarkdown.com/wiki/element-styling-properties)
 
-`.container`'s styling options, such as `foreground`, `background`, `border`, `padding`, and `fontsize`, are now available on `.heading`, `.paragraph` and `.math` as well. This allows for full customization without needing to wrap the element in a container.
+`.container`'s styling options, such as `foreground`, `background`, `border`, `padding`, and `fontsize`, are now available on `.heading`, `.paragraph`, `.math` and `.link` as well. This allows for full customization without needing to wrap the element in a container.
 
 ```markdown
 .heading {Introduction} depth:{1} background:{blue} radius:{8px}
@@ -59,6 +59,11 @@ This plays particularly well with the new primitive extension system:
 ```markdown
 .extend {heading} where:{depth: .depth::islower than:{3}}
     .super background:{teal}
+```
+
+```markdown
+.extend {link} where:{url: .url::startswith {https://}}
+    .super foreground:{blue} textdecoration:{underline}
 ```
 
 &nbsp;

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,8 +105,10 @@ Defining a new node involves:
 ### Primitive functions
 
 A *primitive function* is a stdlib function that backs a Markdown syntax element (`.heading` backs `#`, `.paragraph` backs paragraphs,
-`.figure` backs standalone images, `.pagebreak` backs `<<<`, `.math` backs `$ ... $`, and so on).
+`.link` backs `[label](url "title")` with an optional title, `.figure` backs standalone images, `.pagebreak` backs `<<<`, `.math` backs `$ ... $`, and so on).
 Because Markdown syntax and the primitive call produce the same AST node, extending the primitive via `.extend {name}` also applies to the corresponding Markdown syntax.
+
+The full list of primitives is documented for end users at [`docs/primitives.qd`](docs/primitives.qd); keep it in sync whenever you add a new one.
 
 The wiring lives in `TreeRewriteStage` / `AstRewriter`: after function call expansion, the rewriter walks the AST and, whenever it finds a
 `PrimitiveFunctionBackedNode` whose `backingFunctionName` has been extended, it wraps the node in a synthesized `FunctionCallNode`.
@@ -118,13 +120,14 @@ Adding a new primitive-backed node involves two sides:
   Make the node implement `PrimitiveFunctionBackedNode`:
   - Set `backingFunctionName` to the primitive's Quarkdown name (matching the `@Name` on the stdlib function, if any).
   - Implement `toFunctionCallArguments()` to materialize the node's properties as `FunctionCallArgument`s whose *names* must match the primitive's parameter names.
-  - For inline nodes (e.g. `MathSpan`), override `isBackingCallBlock` to `false` so the inline output mapper is used during expansion.
+  - For inline nodes (e.g. `MathSpan`, `Link`), override `isBackingCallBlock` to `false` so the inline output mapper is used during expansion.
     Block nodes get the default `true` for free.
   - If the node should be user-styleable, make it also implement `StylableNode` with a `style: NodeStyle` property.
+    Remember to carry it through any custom `copy(...)` helpers on the node.
 
 - **stdlib primitive** (in [`quarkdown-stdlib/.../Primitives.kt`](quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Primitives.kt)).
   Declare a `@QFunction` returning the AST node wrapped as a value. Parameter names must match those emitted by `toFunctionCallArguments()`.
-  Include a KDoc example that uses `.extend {name}`, following the pattern already used by `.heading`, `.paragraph`, `.figure`, `.pagebreak`, and `.math`.
+  Include a KDoc example that uses `.extend {name}`, following the pattern already used by `.heading`, `.paragraph`, `.figure`, `.pagebreak`, `.math`, and `.link`.
   If the node is styleable, accept `@Spread style: StyleOptions = StyleOptions.DEFAULT` and pass `style.toNodeStyle()` into the node.
 
 - **Renderer** (for each rendering backend, e.g. [`quarkdown-html/.../QuarkdownHtmlNodeRenderer.kt`](quarkdown-html/src/main/kotlin/com/quarkdown/rendering/html/node/QuarkdownHtmlNodeRenderer.kt)).
@@ -140,8 +143,8 @@ Adding a new primitive-backed node involves two sides:
 
   Without this, the `style: NodeStyle` on the AST node is inert and `foreground:`, `background:`, `padding:`, etc. from `StyleOptions` will not reach the output.
 
-Tests should cover both the primitive function itself (in an appropriate module test, e.g. `MathTest`) and the extension mechanism
-(in `quarkdown-test/.../primitive/<Name>PrimitiveFunctionTest.kt`, mirroring the existing files there).
+Tests should cover both the primitive function itself (in an appropriate module test, e.g. `MathTest`), the extension mechanism
+(in `quarkdown-test/.../primitive/<Name>PrimitiveFunctionTest.kt`, mirroring the existing files there), and an e2e test that exercises the primitive in a real document if there are styling options involved (in `quarkdown-html/src/test/e2e/<category>/styling/`, see `paragraph/styling/` for an example).
 
 ### Function calls and scripting
 

--- a/docs/primitives.qd
+++ b/docs/primitives.qd
@@ -7,9 +7,11 @@ For example, extending `.heading` affects every `#`, `##`, and so on. Extending 
 
 ## Available primitives
 
-- **`.heading`** .docslink {quarkdown-stdlib/com.quarkdown.stdlib.module.Primitives/heading.html} backs `#`, `##`, ... headings. Exposes explicit control over depth, numbering, page breaks, and cross-reference identifiers. See [Headings](headings.qd).
+- [**`.heading`**](headings.qd) .docslink {quarkdown-stdlib/com.quarkdown.stdlib.module.Primitives/heading.html} backs `#`, `##`, ... headings. Exposes explicit control over depth, numbering, page breaks, and cross-reference identifiers.
 
 - **`.paragraph`** .docslink {quarkdown-stdlib/com.quarkdown.stdlib.module.Primitives/paragraph.html} backs regular paragraphs.
+
+- **`.link`** .docslink {quarkdown-stdlib/com.quarkdown.stdlib.module.Primitives/link.html} backs `[label](url "title")`.
 
 - **`.image`** .docslink {quarkdown-stdlib/com.quarkdown.stdlib.module.Primitives/image.html} backs `![alt](url "title")`, with additional control over figure wrapping and [media storage](media-storage.qd).
 

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/attributes/primitive/PrimitiveFunctionBackedNode.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/attributes/primitive/PrimitiveFunctionBackedNode.kt
@@ -18,17 +18,17 @@ import com.quarkdown.core.function.call.FunctionCallArgument
  */
 interface PrimitiveFunctionBackedNode : Node {
     /**
-     * The name of the function that backs this node, from a loaded library.
-     */
-    val backingFunctionName: String
-
-    /**
      * Whether the synthesized backing call should be treated as a block call.
      * Defaults to `true`; inline primitive nodes should override to `false`
      * so the inline output mapper is used during expansion.
      */
     val isBackingCallBlock: Boolean
         get() = true
+
+    /**
+     * The name of the function that backs this node, from a loaded library.
+     */
+    val backingFunctionName: String
 
     /**
      * Materializes this node's properties into the arguments of the backing function call.

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/base/block/LinkDefinition.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/base/block/LinkDefinition.kt
@@ -17,7 +17,7 @@ import com.quarkdown.core.visitor.node.NodeVisitor
  */
 class LinkDefinition(
     @Diverge override val label: InlineContent,
-    override val url: String,
+    @Diverge override val url: String,
     override val title: InlineContent?,
     override val fileSystem: FileSystem? = null,
 ) : LinkNode,
@@ -32,11 +32,5 @@ class LinkDefinition(
     override val text: InlineContent
         get() = label
 
-    override fun copy(url: String) =
-        LinkDefinition(
-            label = label,
-            url = url,
-            title = title,
-            fileSystem = fileSystem,
-        )
+    override fun copy(url: String) = diverge(url = url)
 }

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/base/inline/Link.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/base/inline/Link.kt
@@ -2,12 +2,20 @@ package com.quarkdown.core.ast.base.inline
 
 import com.quarkdown.amber.annotations.Diverge
 import com.quarkdown.core.ast.InlineContent
+import com.quarkdown.core.ast.InlineMarkdownContent
 import com.quarkdown.core.ast.Node
+import com.quarkdown.core.ast.attributes.primitive.PrimitiveFunctionBackedNode
 import com.quarkdown.core.ast.attributes.reference.ReferenceNode
+import com.quarkdown.core.ast.attributes.style.NodeStyle
+import com.quarkdown.core.ast.attributes.style.StylableNode
 import com.quarkdown.core.ast.base.LinkNode
 import com.quarkdown.core.ast.base.TextNode
 import com.quarkdown.core.ast.base.block.LinkDefinition
 import com.quarkdown.core.context.file.FileSystem
+import com.quarkdown.core.function.call.FunctionCallArgument
+import com.quarkdown.core.function.value.NoneValue
+import com.quarkdown.core.function.value.StringValue
+import com.quarkdown.core.function.value.wrappedAsValue
 import com.quarkdown.core.pipeline.error.PipelineErrorHandler
 import com.quarkdown.core.util.stripAnchor
 import com.quarkdown.core.visitor.node.NodeVisitor
@@ -18,28 +26,42 @@ import com.quarkdown.core.visitor.node.NodeVisitor
  * @param url URL this link points to
  * @param title optional inline title
  * @param fileSystem optional file system where this link is defined, used for resolving relative paths
+ * @param style styling applied to the link
  */
 class Link(
     @Diverge override val label: InlineContent,
-    override val url: String,
+    @Diverge override val url: String,
     override val title: InlineContent?,
     override val fileSystem: FileSystem? = null,
+    override val style: NodeStyle = NodeStyle.DEFAULT,
 ) : LinkNode,
-    TextNode {
+    TextNode,
+    StylableNode,
+    PrimitiveFunctionBackedNode {
     override val text: InlineContent
         get() = label
 
     override var error: Pair<Throwable, PipelineErrorHandler>? = null
 
+    override val isBackingCallBlock: Boolean
+        get() = false
+
+    override val backingFunctionName: String
+        get() = "link"
+
+    override fun toFunctionCallArguments() =
+        listOf(
+            FunctionCallArgument(name = "content", expression = InlineMarkdownContent(label).wrappedAsValue()),
+            FunctionCallArgument(name = "url", expression = StringValue(url)),
+            FunctionCallArgument(
+                name = "title",
+                expression = title?.let { InlineMarkdownContent(it).wrappedAsValue() } ?: NoneValue,
+            ),
+        )
+
     override fun <T> acceptOnSuccess(visitor: NodeVisitor<T>) = visitor.visit(this)
 
-    override fun copy(url: String) =
-        Link(
-            label = label,
-            url = url,
-            title = title,
-            fileSystem = fileSystem,
-        )
+    override fun copy(url: String) = diverge(url = url)
 
     /**
      * Strips the anchor (fragment) from the URL.

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/base/inline/SubdocumentLink.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/base/inline/SubdocumentLink.kt
@@ -30,11 +30,7 @@ class SubdocumentLink(
 
     override fun <T> acceptOnSuccess(visitor: NodeVisitor<T>) = visitor.visit(this)
 
-    override fun copy(url: String) =
-        SubdocumentLink(
-            link = link.copy(url = url),
-            anchor = anchor,
-        )
+    override fun copy(url: String) = diverge(link = link.copy(url = url))
 }
 
 /**

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/quarkdown/inline/MathSpan.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/quarkdown/inline/MathSpan.kt
@@ -21,11 +21,11 @@ class MathSpan(
 ) : Node,
     StylableNode,
     PrimitiveFunctionBackedNode {
-    override val backingFunctionName: String
-        get() = "math"
-
     override val isBackingCallBlock: Boolean
         get() = false
+
+    override val backingFunctionName: String
+        get() = "math"
 
     override fun toFunctionCallArguments() =
         listOf(

--- a/quarkdown-html/src/main/kotlin/com/quarkdown/rendering/html/node/BaseHtmlNodeRenderer.kt
+++ b/quarkdown-html/src/main/kotlin/com/quarkdown/rendering/html/node/BaseHtmlNodeRenderer.kt
@@ -290,6 +290,7 @@ open class BaseHtmlNodeRenderer(
         tagBuilder("a", node.label)
             .attribute("href", node.url)
             .optionalAttribute("title", node.title?.toPlainText(renderer = this))
+            .style(node.style)
 
     override fun visitTransformed(node: Link) = buildLinkTag(node).build()
 

--- a/quarkdown-html/src/test/e2e/link/styling/main.qd
+++ b/quarkdown-html/src/test/e2e/link/styling/main.qd
@@ -1,0 +1,4 @@
+.extend {link}
+    .super foreground:{red} background:{black} padding:{4px}
+
+Visit [Quarkdown](https://quarkdown.com) for more.

--- a/quarkdown-html/src/test/e2e/link/styling/styling.spec.ts
+++ b/quarkdown-html/src/test/e2e/link/styling/styling.spec.ts
@@ -1,0 +1,15 @@
+import {getComputedColor} from "../../__util/css";
+import {suite} from "../../quarkdown";
+
+const {test, expect} = suite(__dirname);
+
+test("applies inline styles to a link", async (page) => {
+    const link = page.locator("p a").first();
+
+    const red = await getComputedColor(page, "red");
+    const black = await getComputedColor(page, "black");
+
+    await expect(link).toHaveCSS("color", red);
+    await expect(link).toHaveCSS("background-color", black);
+    await expect(link).toHaveCSS("padding", "4px");
+});

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Primitives.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Primitives.kt
@@ -102,6 +102,37 @@ fun paragraph(
 ).wrappedAsValue()
 
 /**
+ * Creates a link.
+ *
+ * As a [Link] primitive, this function can be used in `.extend` to affect all links in the document,
+ * including those introduced by the standard `[text](url)` Markdown syntax:
+ *
+ * ```markdown
+ * .extend {link} where:{url: .url::startswith {https://}}
+ *     .super foreground:{blue}
+ * ```
+ *
+ * @param content inline label of the link
+ * @param url URL the link points to
+ * @param title optional inline title used as the tooltip
+ * @return a wrapped [Link] node
+ */
+@QFunction
+fun link(
+    @Injected context: Context,
+    @Body content: InlineMarkdownContent,
+    url: String,
+    @LikelyNamed title: InlineMarkdownContent? = null,
+    @Spread style: StyleOptions = StyleOptions.DEFAULT,
+) = Link(
+    label = content.children,
+    url = url,
+    title = title?.children,
+    fileSystem = context.fileSystem,
+    style = style.toNodeStyle(),
+).wrappedAsValue()
+
+/**
  * Creates an image with fine-grained control over its properties,
  * compared to the standard Markdown image syntax (`![alt text](url "title")`).
  *

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Strings.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Strings.kt
@@ -122,6 +122,23 @@ fun isEmpty(string: String) = string.isEmpty().wrappedAsValue()
 fun isNotEmpty(string: String) = string.isNotEmpty().wrappedAsValue()
 
 /**
+ * Checks if a string starts with a given prefix.
+ *
+ * @param string string to check
+ * @param prefix prefix to check for
+ * @param ignoreCase whether to ignore case when checking
+ * @return `true` if the string starts with the prefix, `false` otherwise
+ */
+@QFunction
+@Name("startswith")
+@LikelyChained
+fun startsWith(
+    string: String,
+    prefix: String,
+    ignoreCase: Boolean = false,
+) = string.startsWith(prefix, ignoreCase).wrappedAsValue()
+
+/**
  * Converts Markdown content to plain text.
  *
  * Example: `Hello, **world**!` -> `Hello, world!`

--- a/quarkdown-test/src/test/kotlin/com/quarkdown/test/LinkTest.kt
+++ b/quarkdown-test/src/test/kotlin/com/quarkdown/test/LinkTest.kt
@@ -29,6 +29,36 @@ class LinkTest {
     }
 
     @Test
+    fun `link primitive basic`() {
+        execute("Go .link {here} url:{https://example.com}") {
+            assertEquals(
+                "<p>Go <a href=\"https://example.com\">here</a></p>",
+                it,
+            )
+        }
+    }
+
+    @Test
+    fun `link primitive with title`() {
+        execute("Go .link {here} url:{https://example.com} title:{Tooltip}") {
+            assertEquals(
+                "<p>Go <a href=\"https://example.com\" title=\"Tooltip\">here</a></p>",
+                it,
+            )
+        }
+    }
+
+    @Test
+    fun `link primitive with styling`() {
+        execute("Go .link {here} url:{https://example.com} foreground:{red}") {
+            assertEquals(
+                "<p>Go <a href=\"https://example.com\" style=\"color: rgba(255, 0, 0, 1.0);\">here</a></p>",
+                it,
+            )
+        }
+    }
+
+    @Test
     fun `reference link`() {
         execute(
             """

--- a/quarkdown-test/src/test/kotlin/com/quarkdown/test/StringTest.kt
+++ b/quarkdown-test/src/test/kotlin/com/quarkdown/test/StringTest.kt
@@ -64,4 +64,15 @@ class StringTest {
             assertEquals("<p>hello</p>", it)
         }
     }
+
+    @Test
+    fun `starts with`() {
+        execute(".startswith {hello world} {hello}") {
+            assertEquals("<p><input disabled=\"\" type=\"checkbox\" checked=\"\" /></p>", it)
+        }
+
+        execute(".sum {3} {8}::startswith {1}") {
+            assertEquals("<p><input disabled=\"\" type=\"checkbox\" checked=\"\" /></p>", it)
+        }
+    }
 }

--- a/quarkdown-test/src/test/kotlin/com/quarkdown/test/primitive/LinkPrimitiveFunctionTest.kt
+++ b/quarkdown-test/src/test/kotlin/com/quarkdown/test/primitive/LinkPrimitiveFunctionTest.kt
@@ -1,0 +1,55 @@
+package com.quarkdown.test.primitive
+
+import com.quarkdown.test.util.execute
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Tests for `.extend` applied to Markdown links.
+ */
+class LinkPrimitiveFunctionTest {
+    @Test
+    fun `no extension renders unchanged`() {
+        execute("See [here](https://example.com).") {
+            assertEquals(
+                "<p>See <a href=\"https://example.com\">here</a>.</p>",
+                it,
+            )
+        }
+    }
+
+    @Test
+    fun `extension styles every link`() {
+        execute(
+            """
+            .extend {link}
+                .super foreground:{red}
+
+            See [here](https://example.com).
+            """.trimIndent(),
+        ) {
+            assertEquals(
+                "<p>See <a href=\"https://example.com\" style=\"color: rgba(255, 0, 0, 1.0);\">here</a>.</p>",
+                it,
+            )
+        }
+    }
+
+    @Test
+    fun `extension can match by url`() {
+        execute(
+            """
+            .extend {link} where:{url: .url::startswith {https://match}}
+                .super foreground:{red}
+
+            [Match](https://match.com) and [No match](https://other.com)
+            """.trimIndent(),
+        ) {
+            assertEquals(
+                "<p><a href=\"https://match.com\" style=\"color: rgba(255, 0, 0, 1.0);\">Match</a> " +
+                    "and <a href=\"https://other.com\">No match</a></p>",
+                it,
+            )
+        }
+    }
+}


### PR DESCRIPTION
- [X] I have read the [contributing guidelines](https://github.com/iamgio/quarkdown/blob/main/CONTRIBUTING.md).
- [X] I have tested the changes locally.
- [ ] An issue for this change exists, and it was discussed with maintainers. This is required for new features and non-trivial changes. If present, append `Closes #ISSUE_NUMBER` at the end of this PR description.
- [ ] (Optional) I have added necessary documentation to [`docs`](https://github.com/iamgio/quarkdown/tree/main/docs) and [`CHANGELOG.md`](https://github.com/iamgio/quarkdown/blob/main/CHANGELOG.md)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `.link` primitive (label + URL, optional title) with support for styling via `.extend {link}`.
  * Added conditional `.extend` behavior for links based on URL prefix matching.
  * Added the `.startswith` string function.

* **Documentation**
  * Updated primitive/styling documentation and examples to include `.link`, plus expanded guidance for styleable primitives and required styling e2e coverage.

* **Bug Fixes**
  * Link HTML rendering now includes node styles on the generated `<a>` element.

* **Tests**
  * Added unit and end-to-end tests covering `.link`, titles, styling, conditional matching, and `.startswith`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->