### PR TITLE
refactor(primitives): use dsl for call args declaration

### DIFF
--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/base/block/Heading.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/base/block/Heading.kt
@@ -2,7 +2,6 @@ package com.quarkdown.core.ast.base.block
 
 import com.quarkdown.amber.annotations.Diverge
 import com.quarkdown.core.ast.InlineContent
-import com.quarkdown.core.ast.InlineMarkdownContent
 import com.quarkdown.core.ast.attributes.id.Identifiable
 import com.quarkdown.core.ast.attributes.id.IdentifierProvider
 import com.quarkdown.core.ast.attributes.localization.LocalizedKind
@@ -13,12 +12,7 @@ import com.quarkdown.core.ast.attributes.style.NodeStyle
 import com.quarkdown.core.ast.attributes.style.StylableNode
 import com.quarkdown.core.ast.base.TextNode
 import com.quarkdown.core.ast.quarkdown.reference.CrossReferenceableNode
-import com.quarkdown.core.function.call.FunctionCallArgument
-import com.quarkdown.core.function.value.BooleanValue
-import com.quarkdown.core.function.value.NoneValue
-import com.quarkdown.core.function.value.NumberValue
-import com.quarkdown.core.function.value.StringValue
-import com.quarkdown.core.function.value.wrappedAsValue
+import com.quarkdown.core.function.dsl.functionCallArguments
 import com.quarkdown.core.visitor.node.NodeVisitor
 
 /**
@@ -73,14 +67,14 @@ class Heading(
         get() = "heading"
 
     override fun toFunctionCallArguments() =
-        listOf(
-            FunctionCallArgument(name = "content", expression = InlineMarkdownContent(text).wrappedAsValue()),
-            FunctionCallArgument(name = "depth", expression = NumberValue(depth)),
-            FunctionCallArgument(name = "ref", expression = referenceId?.let(::StringValue) ?: NoneValue),
-            FunctionCallArgument(name = "numbered", expression = BooleanValue(canTrackLocation)),
-            FunctionCallArgument(name = "indexed", expression = BooleanValue(!excludeFromTableOfContents)),
-            FunctionCallArgument(name = "breakpage", expression = BooleanValue(canBreakPage)),
-        )
+        functionCallArguments {
+            arg("content", inline(text))
+            arg("depth", number(depth))
+            arg("ref", string(referenceId))
+            arg("numbered", boolean(canTrackLocation))
+            arg("indexed", boolean(!excludeFromTableOfContents))
+            arg("breakpage", boolean(canBreakPage))
+        }
 
     companion object {
         /**

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/base/block/Paragraph.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/base/block/Paragraph.kt
@@ -2,13 +2,11 @@ package com.quarkdown.core.ast.base.block
 
 import com.quarkdown.amber.annotations.Diverge
 import com.quarkdown.core.ast.InlineContent
-import com.quarkdown.core.ast.InlineMarkdownContent
 import com.quarkdown.core.ast.attributes.primitive.PrimitiveFunctionBackedNode
 import com.quarkdown.core.ast.attributes.style.NodeStyle
 import com.quarkdown.core.ast.attributes.style.StylableNode
 import com.quarkdown.core.ast.base.TextNode
-import com.quarkdown.core.function.call.FunctionCallArgument
-import com.quarkdown.core.function.value.wrappedAsValue
+import com.quarkdown.core.function.dsl.functionCallArguments
 import com.quarkdown.core.visitor.node.NodeVisitor
 
 /**
@@ -24,9 +22,9 @@ class Paragraph(
     override val backingFunctionName: String = "paragraph"
 
     override fun toFunctionCallArguments() =
-        listOf(
-            FunctionCallArgument(name = "content", expression = InlineMarkdownContent(text).wrappedAsValue()),
-        )
+        functionCallArguments {
+            arg("content", inline(text))
+        }
 
     override fun <T> accept(visitor: NodeVisitor<T>) = visitor.visit(this)
 }

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/base/inline/Image.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/base/inline/Image.kt
@@ -1,18 +1,13 @@
 package com.quarkdown.core.ast.base.inline
 
 import com.quarkdown.amber.annotations.Diverge
-import com.quarkdown.core.ast.InlineMarkdownContent
 import com.quarkdown.core.ast.attributes.error.ErrorCapableNode
 import com.quarkdown.core.ast.attributes.primitive.PrimitiveFunctionBackedNode
 import com.quarkdown.core.ast.base.LinkNode
 import com.quarkdown.core.ast.base.block.LinkDefinition
 import com.quarkdown.core.ast.quarkdown.reference.CrossReferenceableNode
 import com.quarkdown.core.document.size.Size
-import com.quarkdown.core.function.call.FunctionCallArgument
-import com.quarkdown.core.function.value.BooleanValue
-import com.quarkdown.core.function.value.NoneValue
-import com.quarkdown.core.function.value.ObjectValue
-import com.quarkdown.core.function.value.wrappedAsValue
+import com.quarkdown.core.function.dsl.functionCallArguments
 import com.quarkdown.core.visitor.node.NodeVisitor
 
 /**
@@ -43,19 +38,16 @@ class Image(
     override val backingFunctionName = "image"
 
     override fun toFunctionCallArguments() =
-        listOf(
-            FunctionCallArgument(name = "url", expression = link.url.wrappedAsValue()),
-            FunctionCallArgument(name = "label", expression = InlineMarkdownContent(link.label).wrappedAsValue()),
-            FunctionCallArgument(
-                name = "title",
-                expression = link.title?.let(::InlineMarkdownContent)?.wrappedAsValue() ?: NoneValue,
-            ),
-            FunctionCallArgument(name = "width", expression = width?.let(::ObjectValue) ?: NoneValue),
-            FunctionCallArgument(name = "height", expression = height?.let(::ObjectValue) ?: NoneValue),
-            FunctionCallArgument(name = "ref", expression = referenceId?.wrappedAsValue() ?: NoneValue),
-            FunctionCallArgument(name = "mediastorage", expression = usesMediaStorage.wrappedAsValue()),
-            FunctionCallArgument(name = "figure", expression = BooleanValue(false)),
-        )
+        functionCallArguments {
+            arg("url", string(link.url))
+            arg("label", inline(link.label))
+            arg("title", inline(link.title))
+            arg("width", obj(width))
+            arg("height", obj(height))
+            arg("ref", string(referenceId))
+            arg("mediastorage", boolean(usesMediaStorage))
+            arg("figure", boolean(false))
+        }
 }
 
 /**

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/base/inline/Link.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/base/inline/Link.kt
@@ -2,7 +2,6 @@ package com.quarkdown.core.ast.base.inline
 
 import com.quarkdown.amber.annotations.Diverge
 import com.quarkdown.core.ast.InlineContent
-import com.quarkdown.core.ast.InlineMarkdownContent
 import com.quarkdown.core.ast.Node
 import com.quarkdown.core.ast.attributes.primitive.PrimitiveFunctionBackedNode
 import com.quarkdown.core.ast.attributes.reference.ReferenceNode
@@ -12,10 +11,7 @@ import com.quarkdown.core.ast.base.LinkNode
 import com.quarkdown.core.ast.base.TextNode
 import com.quarkdown.core.ast.base.block.LinkDefinition
 import com.quarkdown.core.context.file.FileSystem
-import com.quarkdown.core.function.call.FunctionCallArgument
-import com.quarkdown.core.function.value.NoneValue
-import com.quarkdown.core.function.value.StringValue
-import com.quarkdown.core.function.value.wrappedAsValue
+import com.quarkdown.core.function.dsl.functionCallArguments
 import com.quarkdown.core.pipeline.error.PipelineErrorHandler
 import com.quarkdown.core.util.stripAnchor
 import com.quarkdown.core.visitor.node.NodeVisitor
@@ -50,14 +46,11 @@ class Link(
         get() = "link"
 
     override fun toFunctionCallArguments() =
-        listOf(
-            FunctionCallArgument(name = "content", expression = InlineMarkdownContent(label).wrappedAsValue()),
-            FunctionCallArgument(name = "url", expression = StringValue(url)),
-            FunctionCallArgument(
-                name = "title",
-                expression = title?.let { InlineMarkdownContent(it).wrappedAsValue() } ?: NoneValue,
-            ),
-        )
+        functionCallArguments {
+            arg("content", inline(label))
+            arg("url", string(url))
+            arg("title", inline(title))
+        }
 
     override fun <T> acceptOnSuccess(visitor: NodeVisitor<T>) = visitor.visit(this)
 

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/quarkdown/block/Figure.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/quarkdown/block/Figure.kt
@@ -2,8 +2,6 @@ package com.quarkdown.core.ast.quarkdown.block
 
 import com.quarkdown.amber.annotations.Diverge
 import com.quarkdown.core.ast.InlineContent
-import com.quarkdown.core.ast.InlineMarkdownContent
-import com.quarkdown.core.ast.MarkdownContent
 import com.quarkdown.core.ast.Node
 import com.quarkdown.core.ast.SingleChildNestableNode
 import com.quarkdown.core.ast.attributes.localization.LocalizedKind
@@ -13,10 +11,7 @@ import com.quarkdown.core.ast.attributes.primitive.PrimitiveFunctionBackedNode
 import com.quarkdown.core.ast.base.inline.Image
 import com.quarkdown.core.ast.quarkdown.CaptionableNode
 import com.quarkdown.core.ast.quarkdown.reference.CrossReferenceableNode
-import com.quarkdown.core.function.call.FunctionCallArgument
-import com.quarkdown.core.function.value.NoneValue
-import com.quarkdown.core.function.value.StringValue
-import com.quarkdown.core.function.value.wrappedAsValue
+import com.quarkdown.core.function.dsl.functionCallArguments
 import com.quarkdown.core.util.node.group
 import com.quarkdown.core.visitor.node.NodeVisitor
 
@@ -54,20 +49,11 @@ open class Figure<T : Node>(
         get() = "figure"
 
     override fun toFunctionCallArguments() =
-        listOf(
-            FunctionCallArgument(
-                name = "caption",
-                expression = caption?.let { InlineMarkdownContent(it).wrappedAsValue() } ?: NoneValue,
-            ),
-            FunctionCallArgument(
-                name = "ref",
-                expression = referenceId?.let(::StringValue) ?: NoneValue,
-            ),
-            FunctionCallArgument(
-                name = "body",
-                expression = MarkdownContent(listOf(child)).wrappedAsValue(),
-            ),
-        )
+        functionCallArguments {
+            arg("caption", inline(caption))
+            arg("ref", string(referenceId))
+            arg("body", block(child))
+        }
 
     override fun <T> accept(visitor: NodeVisitor<T>): T = visitor.visit(this)
 }

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/quarkdown/block/Math.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/quarkdown/block/Math.kt
@@ -5,12 +5,7 @@ import com.quarkdown.core.ast.attributes.primitive.PrimitiveFunctionBackedNode
 import com.quarkdown.core.ast.attributes.style.NodeStyle
 import com.quarkdown.core.ast.attributes.style.StylableNode
 import com.quarkdown.core.ast.quarkdown.reference.CrossReferenceableNode
-import com.quarkdown.core.function.call.FunctionCallArgument
-import com.quarkdown.core.function.value.BooleanValue
-import com.quarkdown.core.function.value.NoneValue
-import com.quarkdown.core.function.value.ObjectValue
-import com.quarkdown.core.function.value.StringValue
-import com.quarkdown.core.function.value.data.EvaluableString
+import com.quarkdown.core.function.dsl.functionCallArguments
 import com.quarkdown.core.visitor.node.NodeVisitor
 
 /**
@@ -39,11 +34,11 @@ class Math(
         get() = "math"
 
     override fun toFunctionCallArguments() =
-        listOf(
-            FunctionCallArgument(name = "content", expression = ObjectValue(EvaluableString(expression))),
-            FunctionCallArgument(name = "block", expression = BooleanValue(true)),
-            FunctionCallArgument(name = "ref", expression = referenceId?.let(::StringValue) ?: NoneValue),
-        )
+        functionCallArguments {
+            arg("content", evaluable(expression))
+            arg("block", boolean(true))
+            arg("ref", string(referenceId))
+        }
 
     override fun <T> accept(visitor: NodeVisitor<T>) = visitor.visit(this)
 }

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/quarkdown/inline/MathSpan.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/quarkdown/inline/MathSpan.kt
@@ -4,10 +4,7 @@ import com.quarkdown.core.ast.Node
 import com.quarkdown.core.ast.attributes.primitive.PrimitiveFunctionBackedNode
 import com.quarkdown.core.ast.attributes.style.NodeStyle
 import com.quarkdown.core.ast.attributes.style.StylableNode
-import com.quarkdown.core.function.call.FunctionCallArgument
-import com.quarkdown.core.function.value.BooleanValue
-import com.quarkdown.core.function.value.ObjectValue
-import com.quarkdown.core.function.value.data.EvaluableString
+import com.quarkdown.core.function.dsl.functionCallArguments
 import com.quarkdown.core.visitor.node.NodeVisitor
 
 /**
@@ -28,10 +25,10 @@ class MathSpan(
         get() = "math"
 
     override fun toFunctionCallArguments() =
-        listOf(
-            FunctionCallArgument(name = "content", expression = ObjectValue(EvaluableString(expression))),
-            FunctionCallArgument(name = "block", expression = BooleanValue(false)),
-        )
+        functionCallArguments {
+            arg("content", evaluable(expression))
+            arg("block", boolean(false))
+        }
 
     override fun <T> accept(visitor: NodeVisitor<T>) = visitor.visit(this)
 }

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/function/dsl/FunctionCallArgumentsBuilder.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/function/dsl/FunctionCallArgumentsBuilder.kt
@@ -1,0 +1,107 @@
+package com.quarkdown.core.function.dsl
+
+import com.quarkdown.core.ast.InlineContent
+import com.quarkdown.core.ast.InlineMarkdownContent
+import com.quarkdown.core.ast.MarkdownContent
+import com.quarkdown.core.ast.Node
+import com.quarkdown.core.ast.attributes.primitive.PrimitiveFunctionBackedNode
+import com.quarkdown.core.function.call.FunctionCallArgument
+import com.quarkdown.core.function.expression.Expression
+import com.quarkdown.core.function.value.BooleanValue
+import com.quarkdown.core.function.value.NoneValue
+import com.quarkdown.core.function.value.NumberValue
+import com.quarkdown.core.function.value.ObjectValue
+import com.quarkdown.core.function.value.StringValue
+import com.quarkdown.core.function.value.data.EvaluableString
+import com.quarkdown.core.function.value.wrappedAsValue
+
+/**
+ * DSL marker for [FunctionCallArgumentsBuilder].
+ */
+@DslMarker
+private annotation class FunctionCallArgumentsDsl
+
+/**
+ * Builder for the argument list of a synthesized function call, typically used to
+ * implement [PrimitiveFunctionBackedNode.toFunctionCallArguments].
+ *
+ * Provides concise helpers that wrap common value shapes into [Expression]s,
+ * mapping `null` to [NoneValue] where an argument is optional.
+ *
+ * @see functionCallArguments
+ */
+@FunctionCallArgumentsDsl
+class FunctionCallArgumentsBuilder internal constructor() {
+    private val arguments = mutableListOf<FunctionCallArgument>()
+
+    /**
+     * Appends a named argument.
+     * @param name argument name, matching the corresponding parameter of the backing function
+     * @param expression argument expression, typically produced by one of the helpers in this scope
+     */
+    fun arg(
+        name: String,
+        expression: Expression,
+    ) {
+        arguments += FunctionCallArgument(name = name, expression = expression)
+    }
+
+    /**
+     * @return [content] wrapped as an inline Markdown expression, or [NoneValue] if `null`
+     */
+    fun inline(content: InlineContent?): Expression = content?.let { InlineMarkdownContent(it).wrappedAsValue() } ?: NoneValue
+
+    /**
+     * @return a block Markdown expression containing [node] as its single child, or [NoneValue] if `null`
+     */
+    fun block(node: Node?): Expression = node?.let { MarkdownContent(listOf(it)).wrappedAsValue() } ?: NoneValue
+
+    /**
+     * @return a block Markdown expression wrapping [nodes], or [NoneValue] if `null`
+     */
+    fun block(nodes: List<Node>?): Expression = nodes?.let { MarkdownContent(it).wrappedAsValue() } ?: NoneValue
+
+    /**
+     * @return [value] wrapped as a string expression, or [NoneValue] if `null`
+     */
+    fun string(value: String?): Expression = value?.let(::StringValue) ?: NoneValue
+
+    /**
+     * @return [value] wrapped as a numeric expression, or [NoneValue] if `null`
+     */
+    fun number(value: Number?): Expression = value?.let(::NumberValue) ?: NoneValue
+
+    /**
+     * @return [value] wrapped as a boolean expression, or [NoneValue] if `null`
+     */
+    fun boolean(value: Boolean?): Expression = value?.let(::BooleanValue) ?: NoneValue
+
+    /**
+     * @return [value] wrapped as an evaluable string, expanded (including nested function calls)
+     *         when the resulting argument is evaluated, or [NoneValue] if `null`
+     */
+    fun evaluable(value: String?): Expression = value?.let { ObjectValue(EvaluableString(it)) } ?: NoneValue
+
+    /**
+     * @return an arbitrary [value] wrapped as an object expression, or [NoneValue] if `null`
+     */
+    fun obj(value: Any?): Expression = value?.let { ObjectValue(it) } ?: NoneValue
+
+    internal fun build(): List<FunctionCallArgument> = arguments.toList()
+}
+
+/**
+ * Builds a list of [FunctionCallArgument]s via the [FunctionCallArgumentsBuilder] DSL.
+ * Preferred over listing arguments by hand in [PrimitiveFunctionBackedNode.toFunctionCallArguments].
+ *
+ * ```
+ * override fun toFunctionCallArguments() =
+ *     functionCallArguments {
+ *         arg("content", inline(label))
+ *         arg("url", string(url))
+ *         arg("title", inline(title))
+ *     }
+ * ```
+ */
+fun functionCallArguments(block: FunctionCallArgumentsBuilder.() -> Unit): List<FunctionCallArgument> =
+    FunctionCallArgumentsBuilder().apply(block).build()

--- a/quarkdown-core/src/test/kotlin/com/quarkdown/core/FunctionCallArgumentsBuilderTest.kt
+++ b/quarkdown-core/src/test/kotlin/com/quarkdown/core/FunctionCallArgumentsBuilderTest.kt
@@ -1,0 +1,152 @@
+package com.quarkdown.core
+
+import com.quarkdown.core.ast.InlineContent
+import com.quarkdown.core.ast.Node
+import com.quarkdown.core.ast.base.inline.Text
+import com.quarkdown.core.function.dsl.functionCallArguments
+import com.quarkdown.core.function.value.BooleanValue
+import com.quarkdown.core.function.value.InlineMarkdownContentValue
+import com.quarkdown.core.function.value.MarkdownContentValue
+import com.quarkdown.core.function.value.NoneValue
+import com.quarkdown.core.function.value.NumberValue
+import com.quarkdown.core.function.value.ObjectValue
+import com.quarkdown.core.function.value.StringValue
+import com.quarkdown.core.function.value.data.EvaluableString
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertSame
+
+/**
+ * Tests for the [functionCallArguments] DSL used by primitive-backed nodes.
+ * @see com.quarkdown.core.function.dsl.FunctionCallArgumentsBuilder
+ */
+class FunctionCallArgumentsBuilderTest {
+    @Test
+    fun `empty builder yields empty list`() {
+        assertEquals(emptyList(), functionCallArguments { })
+    }
+
+    @Test
+    fun `arg adds named argument`() {
+        val args = functionCallArguments { arg("depth", number(3)) }
+        assertEquals(1, args.size)
+        assertEquals("depth", args[0].name)
+        assertEquals(NumberValue(3), args[0].expression)
+    }
+
+    @Test
+    fun `multiple args preserve order`() {
+        val args =
+            functionCallArguments {
+                arg("a", string("x"))
+                arg("b", boolean(true))
+                arg("c", number(1))
+            }
+        assertEquals(listOf("a", "b", "c"), args.map { it.name })
+    }
+
+    @Test
+    fun `inline wraps InlineContent as inline markdown value`() {
+        val content: InlineContent = listOf(Text("hi"))
+        val expression = functionCallArguments { arg("x", inline(content)) }[0].expression
+        val value = assertIs<InlineMarkdownContentValue>(expression)
+        assertEquals(content, value.unwrappedValue.children)
+    }
+
+    @Test
+    fun `inline maps null to NoneValue`() {
+        val expression = functionCallArguments { arg("x", inline(null)) }[0].expression
+        assertSame(NoneValue, expression)
+    }
+
+    @Test
+    fun `block wraps single node in MarkdownContent`() {
+        val node = Text("hi")
+        val expression = functionCallArguments { arg("x", block(node)) }[0].expression
+        val value = assertIs<MarkdownContentValue>(expression)
+        assertEquals(listOf(node), value.unwrappedValue.children)
+    }
+
+    @Test
+    fun `block wraps list of nodes in MarkdownContent`() {
+        val nodes = listOf(Text("a"), Text("b"))
+        val expression = functionCallArguments { arg("x", block(nodes)) }[0].expression
+        val value = assertIs<MarkdownContentValue>(expression)
+        assertEquals(nodes, value.unwrappedValue.children)
+    }
+
+    @Test
+    fun `block maps null single node to NoneValue`() {
+        val expression = functionCallArguments { arg("x", block(null as Node?)) }[0].expression
+        assertSame(NoneValue, expression)
+    }
+
+    @Test
+    fun `block maps null list to NoneValue`() {
+        val expression = functionCallArguments { arg("x", block(null as List<Node>?)) }[0].expression
+        assertSame(NoneValue, expression)
+    }
+
+    @Test
+    fun `string wraps non-null value`() {
+        val expression = functionCallArguments { arg("x", string("hello")) }[0].expression
+        assertEquals(StringValue("hello"), expression)
+    }
+
+    @Test
+    fun `string maps null to NoneValue`() {
+        val expression = functionCallArguments { arg("x", string(null)) }[0].expression
+        assertSame(NoneValue, expression)
+    }
+
+    @Test
+    fun `number wraps as NumberValue`() {
+        val expression = functionCallArguments { arg("x", number(42)) }[0].expression
+        assertEquals(NumberValue(42), expression)
+    }
+
+    @Test
+    fun `number maps null to NoneValue`() {
+        val expression = functionCallArguments { arg("x", number(null)) }[0].expression
+        assertSame(NoneValue, expression)
+    }
+
+    @Test
+    fun `boolean wraps as BooleanValue`() {
+        val expression = functionCallArguments { arg("x", boolean(true)) }[0].expression
+        assertEquals(BooleanValue(true), expression)
+    }
+
+    @Test
+    fun `boolean maps null to NoneValue`() {
+        val expression = functionCallArguments { arg("x", boolean(null)) }[0].expression
+        assertSame(NoneValue, expression)
+    }
+
+    @Test
+    fun `evaluable wraps as ObjectValue holding EvaluableString`() {
+        val expression = functionCallArguments { arg("x", evaluable("a + b")) }[0].expression
+        val value = assertIs<ObjectValue<*>>(expression)
+        assertEquals(EvaluableString("a + b"), value.unwrappedValue)
+    }
+
+    @Test
+    fun `evaluable maps null to NoneValue`() {
+        val expression = functionCallArguments { arg("x", evaluable(null)) }[0].expression
+        assertSame(NoneValue, expression)
+    }
+
+    @Test
+    fun `obj wraps non-null as ObjectValue`() {
+        val payload = 123
+        val expression = functionCallArguments { arg("x", obj(payload)) }[0].expression
+        assertEquals(ObjectValue(payload), expression)
+    }
+
+    @Test
+    fun `obj maps null to NoneValue`() {
+        val expression = functionCallArguments { arg("x", obj(null)) }[0].expression
+        assertSame(NoneValue, expression)
+    }
+}


### PR DESCRIPTION
- [X] I have read the [contributing guidelines](https://github.com/iamgio/quarkdown/blob/main/CONTRIBUTING.md).
- [X] I have tested the changes locally.
- [ ] An issue for this change exists, and it was discussed with maintainers. This is required for new features and non-trivial changes. If present, append `Closes #ISSUE_NUMBER` at the end of this PR description.
- [ ] (Optional) I have added necessary documentation to [`docs`](https://github.com/iamgio/quarkdown/tree/main/docs) and [`CHANGELOG.md`](https://github.com/iamgio/quarkdown/blob/main/CHANGELOG.md)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized how headings, paragraphs, images, links, figures, and math inputs are packaged, improving consistency for inline text, nested blocks, scalar values, and optional fields.
  * Unifies handling of missing/nullable content to prevent inconsistencies across different markdown constructs.
* **Tests**
  * Added coverage for the argument-building DSL, including empty/non-empty cases, insertion order, correct helper conversions (inline/block/scalars/evaluable objects), and null-to-none behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->