### PR TITLE
fix: fix inline evals returning paragraphs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,14 +56,20 @@ This plays particularly well with the new primitive extension system:
 
 `.extend`'s new `where` parameter defines a condition to meet. If not met, the behavior falls back to the original function definition.
 
+The following snippet applies a teal background to all headings of depth 1 and 2, while leaving deeper headings unchanged:
+
 ```markdown
 .extend {heading} where:{depth: .depth::islower than:{3}}
     .super background:{teal}
 ```
 
+The following snippet adds an icon to all external links:
+
 ```markdown
-.extend {link} where:{url: .url::startswith {https://}}
-    .super foreground:{blue} textdecoration:{underline}
+.extend {link} where:{url: .url::startswith {https://quarkdown.com}::not}
+    content:
+    .super
+        .content .icon {box-arrow-up-right}
 ```
 
 &nbsp;
@@ -84,13 +90,13 @@ Output:
 This is particularly useful for element styling:
 
 ```markdown
-.extend {heading}
+.extend {paragraph}
     content:
     .super
         .content::match {[Qq]uark(down|s)?}
-            *.1*
+            **.1**
 
-## Quarkdown takes its name from quarks
+Quarkdown takes its name from quarks
 ```
 
 &nbsp;

--- a/docs/element-styling.qd
+++ b/docs/element-styling.qd
@@ -51,24 +51,25 @@ Any argument of the intercepted call can be used in the condition, for example [
 
 Intercepted parameters can also be modified on the go. A common use case would be transforming the Markdown content of an element. 
 
-.exampleoutput {.heading {.icon {boxes} *This is a heading*} depth:{2} indexed:{no}} \
-               prelude:{Here we add an [icon](icons.qd) to all headings, and italicize their content. Note that [body arguments](syntax-of-a-function-call.qd#the-body-argument) work with `\.super` normally.}
-    .extend {heading}
+.exampleoutput {Check out the [docs](https://quarkdown.com/docs) and the [repo .icon {box-arrow-up-right}](https://github.com/iamgio/quarkdown)} \
+               prelude:{Here we add an [icon](icons.qd) to all external links. Note that [body arguments](syntax-of-a-function-call.qd#the-body-argument) work with `\.super` normally.}
+    .extend {link} where:{url: .url::startswith {https://quarkdown.com}::not}
         content:
         .super
-            .icon {boxes} *.content*
+            .content .icon {box-arrow-up-right}
 
-    ## This is a heading
+    Check out the [docs](https://quarkdown.com/docs)
+    and the [repo](https://github.com/iamgio/quarkdown)
 
 ## Pattern matching
 
 Quarkdown supports transforming arbitrary content according to RegEx patterns via the **`.match {content} {pattern} {replacement}`** .docslink {quarkdown-stdlib/com.quarkdown.stdlib.module.Text/match.html} function, which replaces all occurrences of `pattern` within `content` with `replacement`.
 
-.exampleoutput {*Quarkdown* takes its name from *quarks*}
+.exampleoutput {***Quarkdown*** takes its name from ***quarks***}
     .extend {paragraph}
         content:
         .super
             .content::match {[Qq]uark(down|s)?}
-                *.1*
+                ***.1***
 
     Quarkdown takes its name from quarks

--- a/docs/quickstart.qd
+++ b/docs/quickstart.qd
@@ -318,6 +318,15 @@ For example, to make all level 2 headings appear on a teal background:
 
 Every `## Heading` now renders with the new styling, while other levels remain unchanged. `.super` invokes the original function, optionally overriding any of its arguments.
 
+To add an icon to all external links, you can intercept the `.link` primitive function and add an [icon](icons.qd) to its content:
+
+```markdown
+.extend {link} where:{url: .url::startswith {https://quarkdown.com}::not}
+    content:
+    .super
+        .content .icon {box-arrow-up-right}
+```
+
 To italicize the word "Quarkdown" in all paragraphs, you can use the [`.match`](regex-match.qd) function:
 
 ```markdown

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/function/value/output/node/InlineNodeOutputValueVisitor.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/function/value/output/node/InlineNodeOutputValueVisitor.kt
@@ -1,11 +1,15 @@
 package com.quarkdown.core.function.value.output.node
 
+import com.quarkdown.core.ast.InlineMarkdownContent
+import com.quarkdown.core.ast.MarkdownContent
+import com.quarkdown.core.ast.base.block.Paragraph
 import com.quarkdown.core.ast.base.inline.CheckBox
 import com.quarkdown.core.ast.base.inline.CodeSpan
 import com.quarkdown.core.ast.base.inline.CriticalContent
 import com.quarkdown.core.ast.base.inline.Text
 import com.quarkdown.core.context.Context
 import com.quarkdown.core.function.value.BooleanValue
+import com.quarkdown.core.function.value.NodeValue
 import com.quarkdown.core.function.value.NoneValue
 import com.quarkdown.core.function.value.NumberValue
 import com.quarkdown.core.function.value.ObjectValue
@@ -29,6 +33,24 @@ class InlineNodeOutputValueVisitor(
     override fun visit(value: ObjectValue<*>) = CriticalContent(value.unwrappedValue.toString())
 
     override fun visit(value: NoneValue) = CodeSpan(value.unwrappedValue.toString())
+
+    // A NodeValue that wraps a plain block Paragraph, typically produced by an eval, is unwrapped into its inline children.
+    override fun visit(value: NodeValue) =
+        when (val node = value.unwrappedValue) {
+            is Paragraph -> {
+                InlineMarkdownContent(node.text)
+            }
+
+            is MarkdownContent -> {
+                (node.children.singleOrNull() as? Paragraph)
+                    ?.let { InlineMarkdownContent(it.text) }
+                    ?: node
+            }
+
+            else -> {
+                node
+            }
+        }
 
     // Raw Markdown code is parsed as inline.
     override fun parseRaw(

--- a/quarkdown-test/src/test/kotlin/com/quarkdown/test/primitive/LinkPrimitiveFunctionTest.kt
+++ b/quarkdown-test/src/test/kotlin/com/quarkdown/test/primitive/LinkPrimitiveFunctionTest.kt
@@ -36,6 +36,23 @@ class LinkPrimitiveFunctionTest {
     }
 
     @Test
+    fun `extension body with trailing text stays inline`() {
+        execute(
+            """
+            .extend {link}
+                .super (external)
+
+            See the [docs](https://example.com)
+            """.trimIndent(),
+        ) {
+            assertEquals(
+                "<p>See the <a href=\"https://example.com\">docs</a> (external)</p>",
+                it,
+            )
+        }
+    }
+
+    @Test
     fun `extension can match by url`() {
         execute(
             """


### PR DESCRIPTION
- [X] I have read the [contributing guidelines](https://github.com/iamgio/quarkdown/blob/main/CONTRIBUTING.md).
- [X] I have tested the changes locally.
- [ ] An issue for this change exists, and it was discussed with maintainers. This is required for new features and non-trivial changes. If present, append `Closes #ISSUE_NUMBER` at the end of this PR description.
- [ ] (Optional) I have added necessary documentation to [`docs`](https://github.com/iamgio/quarkdown/tree/main/docs) and [`CHANGELOG.md`](https://github.com/iamgio/quarkdown/blob/main/CHANGELOG.md)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added updated documentation examples for conditional element styling, including enhanced external-link handling with icons.
  * Added/updated quickstart guidance for extending link rendering for specific URLs.
* **Bug Fixes**
  * Fixed link extensions so trailing inline text stays inside the generated link (not rendered outside).
* **Documentation**
  * Updated changelog and docs examples for regex matching and styling outcomes (bold/italic emphasis changes).
  * Refreshed element-styling and quickstart examples to match current extension patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->