### PR TITLE
fix(value): fix node -> inline markdown adaptation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## [Unreleased]
 
+### Fixed
+
+&nbsp;
+
+#### Inline replacement lambdas accept nested function calls
+
+Node-returning function calls, such as `.text`, can now be used in `.match` and other body lambdas as expected.
+
+```markdown
+.match {Quarkdown takes its name from quarks} pattern:{[Qq]uark(down|s)?}
+    .text {.1} color:{mediumpurple} decoration:{underline}
+```
+
 ## [2.4.0] - 2026-07-13
 
 Quarkdown 2.4 is one of the most impactful releases in the history of the project, introducing a new system for extending Markdown elements behavior and styling.

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/function/value/data/Lambda.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/function/value/data/Lambda.kt
@@ -167,14 +167,19 @@ open class Lambda(
      */
     inline fun <reified T, reified V : Value<T>> invoke(values: List<Value<*>>): V {
         // Invoke the lambda action and convert the result to a static type.
-        val result = invokeDynamic(values)
+        var result: Value<*> =
+            when (val raw = invokeDynamic(values)) {
+                is DynamicValue -> DynamicValueConverter(raw).convertTo(T::class, parentContext) ?: raw
+                else -> raw
+            }
 
-        return when (result) {
-            is V -> result
-            is DynamicValue -> DynamicValueConverter(result).convertTo(T::class, parentContext)
-            is AdaptableValue<*> -> result.adapt()
-            else -> result
-        } as? V
+        // Follow the adaptation chain (e.g. NodeValue -> MarkdownContentValue -> InlineMarkdownContentValue)
+        // until V is reached or no further adaptation is possible.
+        while (result !is V && result is AdaptableValue<*>) {
+            result = result.adapt()
+        }
+
+        return result as? V
             ?: throw IllegalArgumentException("Unexpected lambda result: expected ${V::class}, found ${result::class}")
     }
 

--- a/quarkdown-test/src/test/kotlin/com/quarkdown/test/MatchTest.kt
+++ b/quarkdown-test/src/test/kotlin/com/quarkdown/test/MatchTest.kt
@@ -45,6 +45,50 @@ class MatchTest {
     }
 
     @Test
+    fun `match lambda body returning inline NodeValue via text call`() {
+        execute(
+            """
+            .match {Quarkdown takes its name from quarks} pattern:{[Qq]uark(down|s)?}
+                .text {.1} decoration:{underline}
+            """.trimIndent(),
+        ) {
+            assertEquals(
+                "<p><span style=\"text-decoration: underline;\">Quarkdown</span> takes its name from " +
+                    "<span style=\"text-decoration: underline;\">quarks</span></p>",
+                it,
+            )
+        }
+    }
+
+    @Test
+    fun `match lambda body returning inline NodeValue via chained text call`() {
+        execute(
+            """
+            .match {Quarkdown is a tool} {Quarkdown}
+                .1::text
+            """.trimIndent(),
+        ) {
+            assertEquals("<p><span>Quarkdown</span> is a tool</p>", it)
+        }
+    }
+
+    @Test
+    fun `match in paragraph extension with chained inline call`() {
+        execute(
+            """
+            .extend {paragraph}
+                content:
+                .content::match {Quarkdown}
+                    .1::text
+
+            Quarkdown is a tool.
+            """.trimIndent(),
+        ) {
+            assertEquals("<p><span>Quarkdown</span> is a tool.</p>", it)
+        }
+    }
+
+    @Test
     fun `match inside heading extension`() {
         execute(
             """


### PR DESCRIPTION
- [X] I have read the [contributing guidelines](https://github.com/iamgio/quarkdown/blob/main/CONTRIBUTING.md).
- [X] I have tested the changes locally.
- [ ] An issue for this change exists, and it was discussed with maintainers. This is required for new features and non-trivial changes. If present, append `Closes #ISSUE_NUMBER` at the end of this PR description.
- [ ] (Optional) I have added necessary documentation to [`docs`](https://github.com/iamgio/quarkdown/tree/main/docs) and [`CHANGELOG.md`](https://github.com/iamgio/quarkdown/blob/main/CHANGELOG.md)

Closes #593



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed inline replacement lambdas so nested function calls, including `.text`, work correctly within `.match` and other body lambdas.
  * Improved rendering of chained inline calls and decorated text in replacement content.

* **Documentation**
  * Added an unreleased changelog entry with examples of the corrected behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->