### PR TITLE
feat: support section-scoped total page counts

### DIFF
--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/quarkdown/inline/PageCounter.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/quarkdown/inline/PageCounter.kt
@@ -11,6 +11,7 @@ import com.quarkdown.core.visitor.node.NodeVisitor
  */
 class PageCounter(
     val target: Target,
+    val scope: Scope = Scope.DOCUMENT,
 ) : Node {
     enum class Target {
         /**
@@ -22,6 +23,11 @@ class PageCounter(
          * The total amount of pages.
          */
         TOTAL,
+    }
+
+    enum class Scope {
+        DOCUMENT,
+        SECTION,
     }
 
     override fun <T> accept(visitor: NodeVisitor<T>): T = visitor.visit(this)

--- a/quarkdown-html/src/main/kotlin/com/quarkdown/rendering/html/node/QuarkdownHtmlNodeRenderer.kt
+++ b/quarkdown-html/src/main/kotlin/com/quarkdown/rendering/html/node/QuarkdownHtmlNodeRenderer.kt
@@ -577,6 +577,12 @@ class QuarkdownHtmlNodeRenderer(
                     PageCounter.Target.TOTAL -> "total-page-number"
                 },
             )
+            if (node.target == PageCounter.Target.TOTAL) {
+                attribute(
+                    "data-scope",
+                    node.scope.name.lowercase(),
+                )
+            }
         }
 
     override fun visit(node: LastHeading) =

--- a/quarkdown-html/src/main/typescript/document/handlers/__tests__/page-numbers-document-handler.spec.ts
+++ b/quarkdown-html/src/main/typescript/document/handlers/__tests__/page-numbers-document-handler.spec.ts
@@ -110,4 +110,42 @@ describe('PageNumbersDocumentHandler', () => {
         const numbers = Array.from(document.querySelectorAll<HTMLSpanElement>('.toc-page-number')).map(span => span.textContent);
         expect(numbers).toEqual(['1', '5']);
     });
+    it('uses reset start value when computing section total pages', async () => {
+    document.body.className = 'quarkdown quarkdown-paged';
+    document.body.innerHTML = `
+      <div class="pagedjs_page" data-page-number="1">
+        <span class="total-page-number" data-scope="document"></span>
+      </div>
+
+      <div class="pagedjs_page" data-page-number="2">
+        <div class="pagedjs_area">
+          <span class="page-number-reset" data-start="5"></span>
+          <span class="total-page-number" data-scope="section"></span>
+        </div>
+      </div>
+
+      <div class="pagedjs_page" data-page-number="3">
+        <div class="pagedjs_area">
+          <span class="total-page-number" data-scope="section"></span>
+        </div>
+      </div>
+
+      <div class="pagedjs_page" data-page-number="4">
+        <div class="pagedjs_area">
+          <span class="total-page-number" data-scope="section"></span>
+        </div>
+      </div>`;
+
+      const pages = Array.from(document.querySelectorAll<HTMLElement>('.pagedjs_page'));
+      const handler = new Concrete(new DummyDocument(pages));
+
+      await handler.onPostRendering();
+
+      const totals = Array.from(
+          document.querySelectorAll<HTMLElement>('.total-page-number')
+      ).map(el => el.textContent);
+
+      expect(totals[0]).toBe('4');
+      expect(totals.slice(1)).toEqual(['7', '7', '7']);
+    });
 });

--- a/quarkdown-html/src/main/typescript/document/handlers/page-numbers.ts
+++ b/quarkdown-html/src/main/typescript/document/handlers/page-numbers.ts
@@ -44,9 +44,46 @@ export class PageNumbers extends DocumentHandler<PagedLikeQuarkdownDocument<any>
      * Updates all total page number elements with the total count of pages.
      */
     private updateTotalPageNumbers(pages: QuarkdownPage[]) {
-        const amount = pages.length;
-        this.getTotalPageNumberElements().forEach(total => {
-            total.innerText = amount.toString();
+
+        const sectionTotals = new Map<QuarkdownPage, number>();
+
+        let currentSection: QuarkdownPage[] = [];
+
+        const flush = () => {
+            const total = currentSection.length;
+
+            currentSection.forEach(page =>
+                sectionTotals.set(page, total)
+            );
+        };
+
+    pages.forEach(page => {
+
+        if (
+            this.getPageNumberResetMarkers(page).length &&
+            currentSection.length
+        ) {
+            flush();
+            currentSection = [];
+        }
+
+        currentSection.push(page);
+    });
+
+    flush();
+
+    this.getTotalPageNumberElements().forEach(element => {
+
+            const page = this.quarkdownDocument.getPage(element);
+
+            if (!page) return;
+
+            const total =
+                element.dataset.scope === "section"
+                    ? sectionTotals.get(page) ?? pages.length
+                    : pages.length;
+
+            element.innerText = total.toString();
         });
     }
 

--- a/quarkdown-html/src/main/typescript/document/handlers/page-numbers.ts
+++ b/quarkdown-html/src/main/typescript/document/handlers/page-numbers.ts
@@ -44,27 +44,40 @@ export class PageNumbers extends DocumentHandler<PagedLikeQuarkdownDocument<any>
      * Updates all total page number elements with the total count of pages.
      */
     private updateTotalPageNumbers(pages: QuarkdownPage[]) {
+    const sectionTotals = new Map<QuarkdownPage, number>();
 
-        const sectionTotals = new Map<QuarkdownPage, number>();
+    let currentSection: QuarkdownPage[] = [];
+    let sectionStart = 1;
 
-        let currentSection: QuarkdownPage[] = [];
+    const flush = () => {
+        if (currentSection.length === 0) {
+            return;
+        }
 
-        const flush = () => {
-            const total = currentSection.length;
+        const total = sectionStart + currentSection.length - 1;
 
-            currentSection.forEach(page =>
-                sectionTotals.set(page, total)
-            );
-        };
+        currentSection.forEach(page => {
+            sectionTotals.set(page, total);
+        });
+    };
 
     pages.forEach(page => {
+        const resetMarkers = this.getPageNumberResetMarkers(page);
 
-        if (
-            this.getPageNumberResetMarkers(page).length &&
-            currentSection.length
-        ) {
+        if (resetMarkers.length && currentSection.length) {
             flush();
             currentSection = [];
+        }
+
+        if (resetMarkers.length) {
+            const lastReset = resetMarkers[resetMarkers.length - 1];
+            const requested = parseInt(lastReset.dataset.start ?? "1", 10);
+
+            if (Number.isFinite(requested) && requested > 0) {
+                sectionStart = requested;
+            } else {
+                sectionStart = 1;
+            }
         }
 
         currentSection.push(page);
@@ -73,18 +86,19 @@ export class PageNumbers extends DocumentHandler<PagedLikeQuarkdownDocument<any>
     flush();
 
     this.getTotalPageNumberElements().forEach(element => {
+        const page = this.quarkdownDocument.getPage(element);
 
-            const page = this.quarkdownDocument.getPage(element);
+        if (!page) {
+            return;
+        }
 
-            if (!page) return;
+        const total =
+            element.dataset.scope === "section"
+                ? sectionTotals.get(page) ?? pages.length
+                : pages.length;
 
-            const total =
-                element.dataset.scope === "section"
-                    ? sectionTotals.get(page) ?? pages.length
-                    : pages.length;
-
-            element.innerText = total.toString();
-        });
+        element.innerText = total.toString();
+    });
     }
 
     /**

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Document.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Document.kt
@@ -826,7 +826,15 @@ fun currentPage() = PageCounter(PageCounter.Target.CURRENT).wrappedAsValue()
  */
 @QFunction
 @Name("totalpages")
-fun totalPages() = PageCounter(PageCounter.Target.TOTAL).wrappedAsValue()
+fun totalPages(
+    @Name("scope") scope: String = "document",
+) = PageCounter(
+    PageCounter.Target.TOTAL,
+    when (scope.lowercase()) {
+        "section" -> PageCounter.Scope.SECTION
+        else -> PageCounter.Scope.DOCUMENT
+    }
+).wrappedAsValue()
 
 /**
  * Sets a new page number format from the page where this function appears.


### PR DESCRIPTION
## Summary

This PR adds support for section-scoped total page counts through an optional `document | section` argument on `.totalpages`.

By default, `.totalpages` continues to return the total number of pages in the document, preserving backwards compatibility.

When `section` is specified, the total page count is calculated from the most recent `.resetpagenumber` (or from the start of the document if no reset exists), matching the requested behavior.

### Changes

- Added optional `document | section` scope to `.totalpages`
- Preserved `document` as the default behavior
- Updated the HTML renderer to expose the selected scope to the runtime
- Implemented section-aware total page counting in the runtime

### Testing

- Built the project successfully
- Ran the frontend test suite (`npm test`)
- All 131 frontend tests passed

Closes #596

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for page total counters scoped to sections, including a `totalPages(scope)` API option.
  * Section totals are now calculated and rendered separately from document-wide totals.

* **Bug Fixes**
  * Fixed total page number rendering so “total” values respect page numbering reset markers instead of always showing the document-wide count.

* **Tests**
  * Added automated coverage to verify totals update correctly with reset-start markers and section scoping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->