### PR TITLE
fix(paged): avoid blank first page from CSS config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,12 @@ Fixed the ability to chain multiple `.match` calls onto the same content:
             .1::text color:{red}
 ```
 
+#### Fixed empty pages on CSS declarations
+
+Fixed an issue that caused `.css` and `.cssproperties` to produce empty pages in `paged` documents when the declaration was before an H1.
+
+Thanks @arpitagarwal1301!
+
 ## [2.4.0] - 2026-07-13
 
 Quarkdown 2.4 is one of the most impactful releases in the history of the project, introducing a new system for extending Markdown elements behavior and styling.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,8 @@ Fixed the ability to chain multiple `.match` calls onto the same content:
             .1::text color:{red}
 ```
 
+&nbsp;
+
 #### Fixed empty pages on CSS declarations
 
 Fixed an issue that caused `.css` and `.cssproperties` to produce empty pages in `paged` documents when the declaration was before an H1.

--- a/quarkdown-html/src/main/typescript/document/global-handlers.ts
+++ b/quarkdown-html/src/main/typescript/document/global-handlers.ts
@@ -6,10 +6,12 @@ import {QuarkdownDocument} from "./quarkdown-document";
 import {MathRenderer} from "./handlers/capabilities/math-renderer";
 import {CodeHighlighter} from "./handlers/capabilities/code-highlighter";
 import {MermaidRenderer} from "./handlers/capabilities/mermaid-renderer";
+import {StyleHeadRelocator} from "./handlers/style-head-relocator";
 
 /** Global document handlers that apply to all documents. */
 export function getGlobalHandlers(document: QuarkdownDocument): ConditionalDocumentHandler[] {
     return [
+        new StyleHeadRelocator(document),
         new InlineCollapsibles(document),
         new PlatformAwareKeybindings(document),
         capabilities.code && new CodeHighlighter(document),

--- a/quarkdown-html/src/main/typescript/document/handlers/style-head-relocator.ts
+++ b/quarkdown-html/src/main/typescript/document/handlers/style-head-relocator.ts
@@ -1,0 +1,10 @@
+import {DocumentHandler} from "../document-handler";
+
+/** Moves generated styles out of document content before rendering. */
+export class StyleHeadRelocator extends DocumentHandler {
+    async onPreRendering() {
+        document
+            .querySelectorAll<HTMLStyleElement>('body style[data-hidden]')
+            .forEach(style => document.head.appendChild(style));
+    }
+}

--- a/quarkdown-html/src/main/typescript/document/type/paged-document.ts
+++ b/quarkdown-html/src/main/typescript/document/type/paged-document.ts
@@ -64,6 +64,11 @@ export class PagedDocument implements PagedLikeQuarkdownDocument {
 
     /** Initializes paged.js rendering. */
     initializeRendering(): void {
+        // Hidden style setup must not become paged content before an initial page break.
+        document
+            .querySelectorAll<HTMLStyleElement>('.paged-content-wrapper > style[data-hidden]')
+            .forEach(style => document.head.appendChild(style));
+
         (window as any).PagedPolyfill?.preview().then();
     }
 

--- a/quarkdown-html/src/main/typescript/document/type/paged-document.ts
+++ b/quarkdown-html/src/main/typescript/document/type/paged-document.ts
@@ -64,11 +64,6 @@ export class PagedDocument implements PagedLikeQuarkdownDocument {
 
     /** Initializes paged.js rendering. */
     initializeRendering(): void {
-        // Hidden style setup must not become paged content before an initial page break.
-        document
-            .querySelectorAll<HTMLStyleElement>('.paged-content-wrapper > style[data-hidden]')
-            .forEach(style => document.head.appendChild(style));
-
         (window as any).PagedPolyfill?.preview().then();
     }
 

--- a/quarkdown-html/src/test/e2e/css/properties/main.qd
+++ b/quarkdown-html/src/test/e2e/css/properties/main.qd
@@ -1,4 +1,8 @@
 .cssproperties
     - link-color: red
 
+.tableofcontents
+
+# Heading
+
 [Link](https://example.com)

--- a/quarkdown-html/src/test/e2e/css/properties/properties.spec.ts
+++ b/quarkdown-html/src/test/e2e/css/properties/properties.spec.ts
@@ -1,10 +1,21 @@
 import {suite} from "../../quarkdown";
 
-const {test, expect} = suite(__dirname);
+const {test, testMatrix, expect} = suite(__dirname);
 
 test("applies CSS property overrides", async (page) => {
-    const link = page.locator("a");
+    const link = page.getByRole("link", {name: "Link"});
 
     await expect(link).toBeAttached();
     await expect(link).toHaveCSS("color", "rgb(255, 0, 0)");
 });
+
+testMatrix(
+    "does not create a blank page before the table of contents",
+    ["paged"],
+    async (page) => {
+        const pages = page.locator(".pagedjs_page");
+
+        await expect(pages).toHaveCount(2);
+        await expect(pages.first().getByRole("link", {name: "Heading"})).toHaveCSS("color", "rgb(255, 0, 0)");
+    }
+);

--- a/quarkdown-html/src/test/e2e/css/properties/properties.spec.ts
+++ b/quarkdown-html/src/test/e2e/css/properties/properties.spec.ts
@@ -1,12 +1,19 @@
-import {suite} from "../../quarkdown";
+import {DocumentType, suite} from "../../quarkdown";
 
-const {test, testMatrix, expect} = suite(__dirname);
+const {testMatrix, expect} = suite(__dirname);
+const documentTypes: DocumentType[] = ["plain", "paged", "slides", "docs"];
 
-test("applies CSS property overrides", async (page) => {
+testMatrix("moves CSS property overrides out of document content", documentTypes, async (page, documentType) => {
     const link = page.getByRole("link", {name: "Link"});
 
-    await expect(link).toBeAttached();
-    await expect(link).toHaveCSS("color", "rgb(255, 0, 0)");
+    if (documentType !== "paged") {
+        await expect(page.locator("head > style[data-hidden]")).toHaveCount(1);
+    }
+    await expect(page.locator("body style[data-hidden]")).toHaveCount(0);
+    if (documentType !== "slides") {
+        await expect(link).toBeAttached();
+        await expect(link).toHaveCSS("color", "rgb(255, 0, 0)");
+    }
 });
 
 testMatrix(

--- a/quarkdown-html/src/test/e2e/css/raw/main.qd
+++ b/quarkdown-html/src/test/e2e/css/raw/main.qd
@@ -3,4 +3,6 @@
         color: red;
     }
 
+# Heading
+
 [Link](https://example.com)

--- a/quarkdown-html/src/test/e2e/css/raw/raw.spec.ts
+++ b/quarkdown-html/src/test/e2e/css/raw/raw.spec.ts
@@ -1,10 +1,22 @@
 import {suite} from "../../quarkdown";
 
-const {test, expect} = suite(__dirname);
+const {test, testMatrix, expect} = suite(__dirname);
 
 test("applies raw CSS styles", async (page) => {
-    const link = page.locator("a");
+    const link = page.getByRole("link", {name: "Link"});
 
     await expect(link).toBeAttached();
     await expect(link).toHaveCSS("color", "rgb(255, 0, 0)");
 });
+
+testMatrix(
+    "does not create a blank page before the first heading",
+    ["paged"],
+    async (page) => {
+        const pages = page.locator(".pagedjs_page");
+
+        await expect(pages).toHaveCount(1);
+        await expect(pages.first().getByRole("heading", {name: "Heading"})).toBeVisible();
+        await expect(pages.first().getByRole("link", {name: "Link"})).toHaveCSS("color", "rgb(255, 0, 0)");
+    }
+);

--- a/quarkdown-html/src/test/e2e/css/raw/raw.spec.ts
+++ b/quarkdown-html/src/test/e2e/css/raw/raw.spec.ts
@@ -1,10 +1,15 @@
-import {suite} from "../../quarkdown";
+import {DocumentType, suite} from "../../quarkdown";
 
-const {test, testMatrix, expect} = suite(__dirname);
+const {testMatrix, expect} = suite(__dirname);
+const documentTypes: DocumentType[] = ["plain", "paged", "slides", "docs"];
 
-test("applies raw CSS styles", async (page) => {
+testMatrix("moves raw CSS out of document content and applies it", documentTypes, async (page, documentType) => {
     const link = page.getByRole("link", {name: "Link"});
 
+    if (documentType !== "paged") {
+        await expect(page.locator("head > style[data-hidden]")).toHaveCount(1);
+    }
+    await expect(page.locator("body style[data-hidden]")).toHaveCount(0);
     await expect(link).toBeAttached();
     await expect(link).toHaveCSS("color", "rgb(255, 0, 0)");
 });


### PR DESCRIPTION
## What does this PR do?

Prevents leading `.css` and `.cssproperties` configuration from creating a blank first page in paged documents.

Generated hidden style elements are moved from paged body content into the document head before Paged.js starts pagination. Their ordering and styling precedence are preserved, while initial headings and tables of contents are once again treated as the first visible content.

## Related issue

Closes #603

## How was this tested?

- Focused Playwright coverage for leading `.css` before the first heading
- Focused Playwright coverage for leading `.cssproperties` before a table of contents
- `./gradlew :quarkdown-html:test`
- `./gradlew ktlintCheck`
- `./gradlew test`
- `./gradlew installDist`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of hidden CSS declarations by relocating them to document head so overrides apply correctly across plain, paged, slides, and docs.
  * Fixed raw CSS styling and link override consistency.
  * Resolved an issue where CSS declarations could cause paged documents to render an unintended empty first page.
* **Tests**
  * Expanded end-to-end coverage with a document-type matrix, adding assertions for style placement behavior and paged rendering (including the heading/link styling).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->