### PR TITLE
fix(extension): use lifo declaration order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ## [Unreleased]
 
-&nbsp;
-
 ### Added
 
 &nbsp;
@@ -11,6 +9,10 @@
 #### [`em` size units](https://quarkdown.com/wiki/sizes)
 
 Size values now support the font-relative `em` unit, including decimal values such as `0.7em` and `0.15em`.
+
+Thanks @arpitagarwal1301!
+
+&nbsp;
 
 ### Fixed
 
@@ -22,7 +24,26 @@ Node-returning function calls, such as `.text`, can now be used in `.match` and 
 
 ```markdown
 .match {Quarkdown takes its name from quarks} pattern:{[Qq]uark(down|s)?}
-    .text {.1} color:{mediumpurple} decoration:{underline}
+    .1::text color:{purple} decoration:{underline}
+```
+
+&nbsp;
+
+#### Chained `.extend` composes in declaration order
+
+Multiple extensions on the same function now stack in the correct LIFO declaration order. The following snippet now correctly renders the heading in red, rather than blue:
+
+```markdown
+.extend {heading}
+    .super foreground:{blue}
+
+.extend {heading}
+    .super foreground:{green}
+
+.extend {heading}
+    .super foreground:{red}
+
+## Heading
 ```
 
 ## [2.4.0] - 2026-07-13

--- a/docs/extending-functions.qd
+++ b/docs/extending-functions.qd
@@ -97,3 +97,27 @@ An optional `where` [inline lambda](lambda.qd) parameter lets you define a condi
     ## H3
 
     ## H4
+
+## Chaining multiple extensions
+
+You can call `.extend` more than once on the same function, with each new extension added on top of the previous chain.
+
+.exampleoutput {
+    .heading {H2} depth:{2} indexed:{no} foreground:{red}
+
+    .heading {H3} depth:{3} indexed:{no} foreground:{green}
+}
+    .extend {heading}
+        .super foreground:{blue}
+
+    .extend {heading}
+        .super foreground:{green}
+
+    .extend {heading} where:{depth: .depth::equals {2}}
+        .super foreground:{red}
+
+    ## H2
+
+    ### H3
+
+When extensions carry `where` conditions, the outer (first-declared) condition is checked first, so declaration order matters if two conditions can both apply to the same call.

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/internal/FunctionDefinition.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/internal/FunctionDefinition.kt
@@ -1,6 +1,7 @@
 package com.quarkdown.stdlib.internal
 
 import com.quarkdown.core.context.MutableContext
+import com.quarkdown.core.function.Function
 import com.quarkdown.core.function.FunctionParameter
 import com.quarkdown.core.function.SimpleFunction
 import com.quarkdown.core.function.call.FunctionCall
@@ -49,7 +50,22 @@ internal fun declareFunction(
 
             invoke(call, args, bindings)
         }
-    context.loadLibrary(Library(CUSTOM_FUNCTION_LIBRARY_NAME_PREFIX + name, setOf(function)))
+    declareFunction(context, function)
+}
+
+/**
+ * Registers a pre-constructed [function] in [context], under the same custom-function library
+ * naming convention used by the other overloads.
+ *
+ * Useful when the caller needs the callable to be a specific [Function] subtype rather than the
+ * standard [SimpleFunction] built by the other overloads (e.g. an extension wrapper that carries
+ * its own mutable state).
+ */
+internal fun declareFunction(
+    context: MutableContext,
+    function: Function<*>,
+) {
+    context.loadLibrary(Library(CUSTOM_FUNCTION_LIBRARY_NAME_PREFIX + function.name, setOf(function)))
 }
 
 /**

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/internal/FunctionExtension.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/internal/FunctionExtension.kt
@@ -2,27 +2,127 @@ package com.quarkdown.stdlib.internal
 
 import com.quarkdown.core.context.MutableContext
 import com.quarkdown.core.function.Function
+import com.quarkdown.core.function.FunctionParameter
 import com.quarkdown.core.function.SimpleFunction
+import com.quarkdown.core.function.call.FunctionCall
+import com.quarkdown.core.function.call.FunctionCallArgument
+import com.quarkdown.core.function.call.binding.ArgumentBindings
 import com.quarkdown.core.function.call.executeAs
+import com.quarkdown.core.function.call.validate.FunctionCallValidator
 import com.quarkdown.core.function.signatureAsString
 import com.quarkdown.core.function.value.BooleanValue
+import com.quarkdown.core.function.value.NoneValue
+import com.quarkdown.core.function.value.OutputValue
+import com.quarkdown.core.function.value.Value
 import com.quarkdown.core.function.value.data.Lambda
 import com.quarkdown.core.function.value.data.LambdaParameter
 import com.quarkdown.stdlib.extend
 
 /**
- * Name under which the original function is exposed inside an [extend] wrapper body.
+ * Name under which the target of an [extend] wrapper is exposed inside its body.
  */
 private const val SUPER_NAME = "super"
 
 /**
- * Implementation of [extend]: registers a wrapper around [targetName] in [context],
- * exposing the original function as `.${SUPER_NAME}` within [body].
+ * Function produced by an [extend] call. It exposes its body as the callable target and
+ * a rewireable [superTarget] as the function invoked by `.${SUPER_NAME}` within the body.
+ *
+ * @param name name of the function being extended
+ * @param parameters parameters of the function being extended, all marked optional
+ * @param body extension body invoked when the target is called
+ * @param condition optional predicate; when it returns `false`, the call transparently
+ *                  delegates to [superTarget] instead of running [body]
+ * @param initialSuperTarget target of `.${SUPER_NAME}` at construction time (usually the original function)
+ */
+private class ExtensionFunction(
+    override val name: String,
+    override val parameters: List<FunctionParameter<*>>,
+    private val body: Lambda,
+    private val condition: Lambda?,
+    initialSuperTarget: Function<*>,
+) : Function<OutputValue<*>> {
+    override val validators: List<FunctionCallValidator<OutputValue<*>>> = emptyList()
+
+    /**
+     * Function that `.${SUPER_NAME}` inside [body] delegates to. Mutated when a new extension
+     * is chained after this one, so `.super` transparently walks down toward the original.
+     */
+    var superTarget: Function<*> = initialSuperTarget
+
+    override val invoke: (ArgumentBindings, FunctionCall<OutputValue<*>>) -> OutputValue<*> = { outerBindings, call ->
+        val args: List<Value<*>> = parameters.map { outerBindings[it]?.value ?: NoneValue }
+
+        val superFunction =
+            SimpleFunction(SUPER_NAME, parameters = parameters) { overrides, _ ->
+                call.executeAs(superTarget, arguments = mergeNamedArguments(outerBindings, overrides))
+            }
+
+        when {
+            // Condition not met: transparently fall through to the current `.super`.
+            condition != null && !condition.invoke<Boolean, BooleanValue>(args).unwrappedValue -> {
+                call.executeAs(superFunction, arguments = emptyList())
+            }
+
+            else -> {
+                body.invokeDynamic(
+                    args,
+                    callingContext = call.context,
+                    additionalFunctions = setOf(superFunction),
+                )
+            }
+        }
+    }
+}
+
+/**
+ * Follows any [ExtensionFunction] chain rooted at this function until it reaches a
+ * non-extension function.
+ *
+ * @return the innermost [ExtensionFunction] (whose `superTarget` is the original), paired
+ *         with that original function; or `null to this` if this function is not extended.
+ */
+private fun Function<*>.followExtensionChain(): Pair<ExtensionFunction?, Function<*>> {
+    val innermost =
+        generateSequence(this as? ExtensionFunction) { it.superTarget as? ExtensionFunction }
+            .lastOrNull()
+            ?: return null to this
+    return innermost to innermost.superTarget
+}
+
+/**
+ * Merges [outerBindings] with [overrides] into a list of named arguments, with [overrides]
+ * winning for parameters present in both. Each argument is re-emitted as named to keep the
+ * "named arguments come last" rule intact regardless of the relative position of overrides
+ * and positional fall-throughs.
+ */
+private fun mergeNamedArguments(
+    outerBindings: ArgumentBindings,
+    overrides: ArgumentBindings,
+): List<FunctionCallArgument> {
+    val merged = mutableMapOf<String, FunctionCallArgument>()
+    for ((param, arg) in outerBindings) {
+        merged[param.name] = arg.copy(name = param.name)
+    }
+    for ((param, arg) in overrides) {
+        merged[param.name] = arg.copy(name = param.name)
+    }
+    return merged.values.toList()
+}
+
+/**
+ * Implementation of [extend]: adds a wrapper around [targetName] in [context],
+ * exposing the target function as `.${SUPER_NAME}` within [body].
+ *
+ * Multiple extensions on the same name compose in declaration order:
+ * the first-declared extension is the outermost caller, and each subsequent
+ * `.extend` inserts itself just above the original. This means the last-declared
+ * extension's `.super X` overrides are what the original ultimately sees.
  *
  * @param context context to register the wrapper in
  * @param targetName name of the existing function to extend
  * @param condition optional condition to meet. Takes the same parameters as [body].
- *                  If the condition is not met, the call falls back to the original function definition
+ *                  If the condition is not met, the call falls through to `.super`,
+ *                  which resolves to the next extension or the original function.
  * @param body wrapper content; its explicit parameters, if any, must match the target's parameter names
  * @throws IllegalArgumentException if no function named [targetName] exists,
  *         or if any explicit body parameter does not match an original parameter
@@ -33,16 +133,17 @@ internal fun extendFunction(
     condition: Lambda?,
     body: Lambda,
 ) {
-    val targetFunction: Function<*> =
+    val existing =
         context.getFunctionByName(targetName)
             ?: throw IllegalArgumentException("Cannot extend function $targetName because it does not exist.")
 
-    // The wrapper mirrors the target's non-injected parameters, all marked optional.
+    val (innermost, originalFunction) = existing.followExtensionChain()
+
+    // The wrapper mirrors the original's non-injected parameters, all marked optional.
     val wrapperParameters =
-        targetFunction.parameters
+        originalFunction.parameters
             .filterNot { it.isInjected }
             .map { it.copy(isOptional = true) }
-
     val lambdaParameters = wrapperParameters.map { LambdaParameter(it.name, isOptional = true) }
 
     // Every explicit body parameter must match an original parameter by name.
@@ -50,7 +151,7 @@ internal fun extendFunction(
     val unresolved = body.explicitParameters.filter { it.name !in targetNames }
     if (unresolved.isNotEmpty()) {
         throw IllegalArgumentException(
-            "The following parameters are not part of ${targetFunction.signatureAsString()}: " +
+            "The following parameters are not part of ${originalFunction.signatureAsString()}: " +
                 unresolved.joinToString { it.name },
         )
     }
@@ -58,36 +159,23 @@ internal fun extendFunction(
     val bodyLambda = Lambda(context, lambdaParameters, body.action)
     val conditionLambda = condition?.let { Lambda(context, lambdaParameters, it.action) }
 
+    val newExtension =
+        ExtensionFunction(
+            name = targetName,
+            parameters = wrapperParameters,
+            body = bodyLambda,
+            condition = conditionLambda,
+            initialSuperTarget = originalFunction,
+        )
+
     context.markFunctionAsExtended(targetName)
 
-    declareFunction(context, targetName, wrapperParameters) { call, args, outerBindings ->
-        // `super` is exposed as a callable within the body: its explicit arguments override the outer call's bindings.
-        val superFunction =
-            SimpleFunction(SUPER_NAME, parameters = wrapperParameters) { overrides, _ ->
-                // Each merged argument is re-emitted as named so the relative order of named overrides
-                // and positional fall-throughs cannot violate the "named arguments come last" rule.
-                val mergedArgs =
-                    (outerBindings.entries + overrides.entries)
-                        .associate { (param, arg) -> param.name to arg.copy(name = param.name) }
-                        .values
-                        .toList()
-                call.executeAs(targetFunction, arguments = mergedArgs)
-            }
-
-        when {
-            // Fall back to original call (.super) if condition is not met.
-            conditionLambda != null && !conditionLambda.invoke<Boolean, BooleanValue>(args).unwrappedValue -> {
-                call.executeAs(superFunction, arguments = emptyList())
-            }
-
-            // Invoke extension.
-            else -> {
-                bodyLambda.invokeDynamic(
-                    args,
-                    callingContext = call.context,
-                    additionalFunctions = setOf(superFunction),
-                )
-            }
-        }
+    if (innermost == null) {
+        // First extension for this name: register the wrapper as the callable target.
+        declareFunction(context, newExtension)
+    } else {
+        // Splice the new extension between the previous innermost wrapper and the original,
+        // so its `.super` overrides land on the original last.
+        innermost.superTarget = newExtension
     }
 }

--- a/quarkdown-test/src/test/kotlin/com/quarkdown/test/FunctionExtensionTest.kt
+++ b/quarkdown-test/src/test/kotlin/com/quarkdown/test/FunctionExtensionTest.kt
@@ -365,15 +365,15 @@ class FunctionExtensionTest {
             .extend {mysum} where:{a: .a::islower than:{10}}
                 a:
                 .a
-            
+
             .extend {mysum} where:{b: .b::islower than:{10}}
                 b:
                 .b
-                
+
             .mysum {10} {11} .mysum {4} {12} .mysum {16} {5} .mysum {8} {3}
             """.trimIndent(),
         ) {
-            assertEquals("<p>21 4 5 3</p>", it)
+            assertEquals("<p>21 4 5 8</p>", it)
         }
     }
 
@@ -393,6 +393,30 @@ class FunctionExtensionTest {
             """.trimIndent(),
         ) {
             assertEquals("<p>21 4 3</p>", it)
+        }
+    }
+
+    @Test
+    fun `chained extensions with same override, last declared wins`() {
+        execute(
+            """
+            .function {test}
+                x:
+                .x
+
+            .extend {test}
+                .super x:{blue}
+
+            .extend {test}
+                .super x:{green}
+
+            .extend {test}
+                .super x:{red}
+
+            .test {user}
+            """.trimIndent(),
+        ) {
+            assertEquals("<p>red</p>", it)
         }
     }
 

--- a/quarkdown-test/src/test/kotlin/com/quarkdown/test/primitive/HeadingPrimitiveFunctionTest.kt
+++ b/quarkdown-test/src/test/kotlin/com/quarkdown/test/primitive/HeadingPrimitiveFunctionTest.kt
@@ -253,6 +253,52 @@ class HeadingPrimitiveFunctionTest {
     }
 
     @Test
+    fun `chained extensions apply last-declared styling`() {
+        execute(
+            """
+            .extend {heading}
+                .super foreground:{blue}
+
+            .extend {heading}
+                .super foreground:{green}
+
+            .extend {heading}
+                .super foreground:{red}
+
+            ## Heading
+            """.trimIndent(),
+        ) {
+            assertEquals("<h2 style=\"color: rgba(255, 0, 0, 1.0);\">Heading</h2>", it)
+        }
+    }
+
+    @Test
+    fun `chained extensions with conditional inner extension`() {
+        execute(
+            """
+            .extend {heading}
+                .super foreground:{green}
+
+            .extend {heading}
+                .super foreground:{blue}
+
+            .extend {heading} where:{depth: .depth::equals {2}}
+                .super foreground:{red}
+
+            ## H2
+
+            ### H3
+            """.trimIndent(),
+        ) {
+            assertEquals(
+                "<h2 style=\"color: rgba(255, 0, 0, 1.0);\">H2</h2>" +
+                    "<h3 style=\"color: rgba(0, 0, 255, 1.0);\">H3</h3>",
+                it,
+            )
+        }
+    }
+
+    @Test
     fun `icon can be used as content`() {
         execute(
             """

--- a/quarkdown-test/src/test/kotlin/com/quarkdown/test/primitive/ParagraphPrimitiveFunctionTest.kt
+++ b/quarkdown-test/src/test/kotlin/com/quarkdown/test/primitive/ParagraphPrimitiveFunctionTest.kt
@@ -71,6 +71,26 @@ class ParagraphPrimitiveFunctionTest {
     }
 
     @Test
+    fun `extension body match with nested text call`() {
+        execute(
+            """
+            .extend {paragraph}
+                content:
+                .content::match {[Qq]uark(down|s)?}
+                    .text {.1} decoration:{underline}
+
+            Quarkdown takes its name from quarks
+            """.trimIndent(),
+        ) {
+            assertEquals(
+                "<p><span style=\"text-decoration: underline;\">Quarkdown</span> takes its name from " +
+                    "<span style=\"text-decoration: underline;\">quarks</span></p>",
+                it,
+            )
+        }
+    }
+
+    @Test
     fun `content can be matched against pattern`() {
         execute(
             """


### PR DESCRIPTION
- [X] I have read the [contributing guidelines](https://github.com/iamgio/quarkdown/blob/main/CONTRIBUTING.md).
- [X] I have tested the changes locally.
- [X] An issue for this change exists, and it was discussed with maintainers. This is required for new features and non-trivial changes. If present, append `Closes #ISSUE_NUMBER` at the end of this PR description.
- [X] (Optional) I have added necessary documentation to [`docs`](https://github.com/iamgio/quarkdown/tree/main/docs) and [`CHANGELOG.md`](https://github.com/iamgio/quarkdown/blob/main/CHANGELOG.md)

Partial fix for #594


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Chained function extensions now compose reliably, with the last declared override taking precedence.
  - Conditional extensions preserve earlier behavior when conditions do not match.
  - Extension bodies support nested text matching while retaining surrounding content.

- **Documentation**
  - Added examples and guidance for chaining extensions, declaration order, conditions, and styling outcomes.
  - Updated the unreleased changelog and contributor attribution.

- **Bug Fixes**
  - Corrected rendering behavior for multiple heading and function extensions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->