### PR TITLE
fix(extension): fix multiple .match on same primitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,26 @@ Multiple extensions on the same function now stack in the correct LIFO declarati
 ## Heading
 ```
 
+&nbsp;
+
+#### `.match` in chained extensions sees content correctly
+
+Fixed the ability to chain multiple `.match` calls onto the same content:
+
+```markdown
+.extend {paragraph}
+    content:
+    .super
+        .content::match {A}
+            .1::text color:{blue}
+
+.extend {paragraph}
+    content:
+    .super
+        .content::match {B}
+            .1::text color:{red}
+```
+
 ## [2.4.0] - 2026-07-13
 
 Quarkdown 2.4 is one of the most impactful releases in the history of the project, introducing a new system for extending Markdown elements behavior and styling.

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/internal/RegexMatch.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/internal/RegexMatch.kt
@@ -1,6 +1,7 @@
 package com.quarkdown.stdlib.internal
 
 import com.quarkdown.core.ast.InlineContent
+import com.quarkdown.core.ast.NestableNode
 import com.quarkdown.core.ast.Node
 import com.quarkdown.core.ast.base.TextNode
 import com.quarkdown.core.ast.base.inline.Text
@@ -11,7 +12,10 @@ import com.quarkdown.core.ast.rewriter.withChildren
  * found within plain [Text] leaves is replaced by the output of [replacement].
  *
  * Non-text children are returned unchanged. [TextNode]s are descended into, preserving their structure
- * around the transformed inner content.
+ * around the transformed inner content. Other nestable nodes are transparent wrappers whose semantic
+ * content lives entirely in their children (e.g. an expanded function call), and are flattened so that
+ * matches inside them are reachable; this is what lets chained function extensions apply text
+ * transformations to content already produced by an outer extension.
  *
  * @param regex pattern to match in plain text leaves
  * @param replacement maps each matched substring to the inline content that should replace it
@@ -24,6 +28,7 @@ internal fun Node.replaceMatches(
     when (this) {
         is Text -> this.text.replaceMatches(regex, replacement)
         is TextNode -> listOf(this.withChildren(this.text.flatMap { it.replaceMatches(regex, replacement) }))
+        is NestableNode -> children.flatMap { it.replaceMatches(regex, replacement) }
         else -> listOf(this)
     }
 

--- a/quarkdown-test/src/test/kotlin/com/quarkdown/test/primitive/ParagraphPrimitiveFunctionTest.kt
+++ b/quarkdown-test/src/test/kotlin/com/quarkdown/test/primitive/ParagraphPrimitiveFunctionTest.kt
@@ -99,11 +99,61 @@ class ParagraphPrimitiveFunctionTest {
                 .super
                     .content::match {[Qq]uark(down|s)?}
                         **.1**
-            
+
             Quarkdown takes its name from quarks
             """.trimIndent(),
         ) {
             assertEquals("<p><strong>Quarkdown</strong> takes its name from <strong>quarks</strong></p>", it)
+        }
+    }
+
+    @Test
+    fun `chained extensions match complementary patterns on the same content`() {
+        execute(
+            """
+            .extend {paragraph}
+                content:
+                .super
+                    .content::match {A}
+                        .1::text color:{blue}
+
+            .extend {paragraph}
+                content:
+                .super
+                    .content::match {B}
+                        .1::text color:{red}
+
+            A B C
+            """.trimIndent(),
+        ) {
+            assertEquals(
+                "<p><span style=\"color: rgba(0, 0, 255, 1.0);\">A</span> " +
+                    "<span style=\"color: rgba(255, 0, 0, 1.0);\">B</span> C</p>",
+                it,
+            )
+        }
+    }
+
+    @Test
+    fun `chained extensions preserve semantic inline wrappers around a re-matched substring`() {
+        execute(
+            """
+            .extend {paragraph}
+                content:
+                .super
+                    .content::match {A}
+                        *.1*
+
+            .extend {paragraph}
+                content:
+                .super
+                    .content::match {A}
+                        **.1**
+
+            A B C
+            """.trimIndent(),
+        ) {
+            assertEquals("<p><em><strong>A</strong></em> B C</p>", it)
         }
     }
 }


### PR DESCRIPTION
- [x] I have read the [contributing guidelines](https://github.com/iamgio/quarkdown/blob/main/CONTRIBUTING.md).
- [x] I have tested the changes locally.
- [x] An issue for this change exists, and it was discussed with maintainers. This is required for new features and non-trivial changes. If present, append `Closes #ISSUE_NUMBER` at the end of this PR description.
- [x] (Optional) I have added necessary documentation to [`docs`](https://github.com/iamgio/quarkdown/tree/main/docs) and [`CHANGELOG.md`](https://github.com/iamgio/quarkdown/blob/main/CHANGELOG.md)

Closes #594

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed chained paragraph extensions so multiple `.match` applications on the same content work correctly.
  - Ensured regex matches inside nested structures are properly found and can be styled independently without altering surrounding text.
- **Documentation**
  - Updated the unreleased changelog notes with a Markdown example demonstrating two chained `.content::match` scenarios and their expected styled output.
- **Tests**
  - Added coverage for chained extensions using complementary patterns, as well as re-matching the same substring with different inline markup, verifying the rendered result.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->