### PR TITLE
test(extension): test arg defaulting via None

### DIFF
--- a/docs/extending-functions.qd
+++ b/docs/extending-functions.qd
@@ -121,3 +121,26 @@ You can call `.extend` more than once on the same function, with each new extens
     ### H3
 
 When extensions carry `where` conditions, the outer (first-declared) condition is checked first, so declaration order matters if two conditions can both apply to the same call.
+
+### Resetting values in a chain
+
+Passing [None](none.qd) as an argument to a nullable parameter restores it to its default.
+
+.exampleoutput {
+    .heading {H2} depth:{2} indexed:{no} background:{teal}
+
+    .heading {H3} depth:{3} indexed:{no}
+
+    .heading {H4} depth:{4} indexed:{no} background:{teal}
+} prelude:{Here, the outer extension colors every heading, and the inner one resets the styling on depth-3 headings only.}
+    .extend {heading}
+        .super background:{teal}
+
+    .extend {heading} where:{depth: .depth::equals {3}}
+        .super background:{.none}
+
+    ## H2
+
+    ### H3
+
+    #### H4

--- a/quarkdown-test/src/test/kotlin/com/quarkdown/test/primitive/HeadingPrimitiveFunctionTest.kt
+++ b/quarkdown-test/src/test/kotlin/com/quarkdown/test/primitive/HeadingPrimitiveFunctionTest.kt
@@ -273,6 +273,34 @@ class HeadingPrimitiveFunctionTest {
     }
 
     @Test
+    fun `chained extensions can reset styling via none`() {
+        execute(
+            """
+            .noautopagebreak
+
+            .extend {heading}
+                .super foreground:{red} background:{blue}
+
+            .extend {heading} where:{depth: .depth::equals {2}}
+                .super foreground:{.none} background:{.none}
+
+            # A
+
+            ## B
+
+            ### C
+            """.trimIndent(),
+        ) {
+            assertEquals(
+                "<h1 style=\"color: rgba(255, 0, 0, 1.0); background-color: rgba(0, 0, 255, 1.0);\">A</h1>" +
+                    "<h2>B</h2>" +
+                    "<h3 style=\"color: rgba(255, 0, 0, 1.0); background-color: rgba(0, 0, 255, 1.0);\">C</h3>",
+                it,
+            )
+        }
+    }
+
+    @Test
     fun `chained extensions with conditional inner extension`() {
         execute(
             """


### PR DESCRIPTION
- [x] I have read the [contributing guidelines](https://github.com/iamgio/quarkdown/blob/main/CONTRIBUTING.md).
- [x] I have tested the changes locally.
- [x] An issue for this change exists, and it was discussed with maintainers. This is required for new features and non-trivial changes. If present, append `Closes #ISSUE_NUMBER` at the end of this PR description.
- [x] (Optional) I have added necessary documentation to [`docs`](https://github.com/iamgio/quarkdown/tree/main/docs) and [`CHANGELOG.md`](https://github.com/iamgio/quarkdown/blob/main/CHANGELOG.md)

Ref #594

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that when multiple function extensions include overlapping `where` conditions, the first-declared (outer) condition is evaluated first, so declaration order matters.
  * Added guidance on resetting nullable parameters back to their default values (with a styling example in a heading chain).

* **Tests**
  * Added coverage to confirm chained heading extensions can conditionally remove previously applied styling using `none` via `.super`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->