### PR TITLE
refactor(ci): use simple-release action

### DIFF
--- a/.github/workflows/gradle-deploy.yml
+++ b/.github/workflows/gradle-deploy.yml
@@ -29,42 +29,17 @@ jobs:
         full-checkout: true
         checkout-token: ${{ secrets.COMMITTER_TOKEN }}
 
-    # Writes the new version (tag name without the leading 'v') to version.txt
-    - name: Bump version
+    # Bumps version.txt and updates CHANGELOG.md so the following build embeds
+    # the release version, then commits both files back to main. The rest of the
+    # release publishing happens after the build in the second simple-release step below.
+    - name: Prepare release
       if: github.ref_type == 'tag'
-      run: printf "%s" "${GITHUB_REF_NAME#v}" > version.txt
-
-    - name: Update changelog
-      uses: thomaseizinger/keep-a-changelog-new-release@v2
-      if: github.ref_type == 'tag'
+      uses: iamgio/simple-release@v1
       with:
-        tag: ${{ github.ref_name }}
-
-    - name: Extract release notes
-      id: release-notes
-      if: github.ref_type == 'tag'
-      uses: ffurrer2/extract-release-notes@v3
-
-    # Reads SPONSORS.md into a step output, to be appended to the release notes.
-    - name: Read sponsors
-      id: sponsors
-      if: github.ref_type == 'tag' && hashFiles('SPONSORS.md') != ''
-      run: |
-        {
-          echo 'content<<SPONSORS_EOF'
-          cat SPONSORS.md
-          echo SPONSORS_EOF
-        } >> "$GITHUB_OUTPUT"
-
-    - name: Commit release updates
-      uses: stefanzweifel/git-auto-commit-action@v7
-      if: github.ref_type == 'tag'
-      with:
-        commit_message: "chore: release ${{ github.ref_name }}"
-        commit_user_name: "github-actions"
-        commit_user_email: "github-actions[bot]@users.noreply.github.com"
-        file_pattern: version.txt CHANGELOG.md
-        branch: main
+        version-file: version.txt
+        changelog-file: CHANGELOG.md
+        commit: 'true'
+        release: 'false'
 
     - name: Build per-platform distributions
       uses: burrunan/gradle-cache-action@v3
@@ -94,32 +69,18 @@ jobs:
         name: quarkdown
         path: build/distributions/quarkdown-*.zip
 
-    - name: Move devbuild tag to latest commit
-      run: |
-        git tag -d latest || true
-        git tag -f latest
-        git push origin +latest
-
-    - name: Create devbuild release
-      uses: softprops/action-gh-release@v2.2.2
+    # Moves the rolling `latest` tag, publishes a devbuild prerelease,
+    # and on tag publishes the tagged release.
+    - name: Publish devbuild and release
+      uses: iamgio/simple-release@v1
       with:
-        token: "${{ secrets.GITHUB_TOKEN }}"
-        tag_name: "latest"
-        prerelease: true
-        generate_release_notes: true
-        name: Development build
-        files: build/distributions/quarkdown-*.zip
-
-    - name: Create release
-      uses: softprops/action-gh-release@v2
-      if: github.ref_type == 'tag'
-      with:
-        token: "${{ secrets.GITHUB_TOKEN }}"
-        body: |
-          ${{ steps.release-notes.outputs.release_notes }}
-
-          ${{ steps.sponsors.outputs.content }}
-        files: build/distributions/quarkdown-*.zip
+        changelog-file: CHANGELOG.md
+        update-changelog: 'false'
+        body-append-file: SPONSORS.md
+        insert-changelog-spacers: 'true'
+        devbuild-tag: latest
+        devbuild-files: build/distributions/quarkdown-*.zip
+        release-files: build/distributions/quarkdown-*.zip
 
     - name: Generate docs
       uses: burrunan/gradle-cache-action@v3
@@ -174,9 +135,12 @@ jobs:
       with:
         persist-credentials: false
 
-    # Writes the new version (tag name without the leading 'v') to version.txt
     - name: Bump version
-      run: printf "%s" "${GITHUB_REF_NAME#v}" > version.txt
+      uses: iamgio/simple-release@v1
+      with:
+        version-file: version.txt
+        commit: 'false'
+        release: 'false'
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,19 +4,13 @@
 
 ### Added
 
-&nbsp;
-
 #### [`em` size units](https://quarkdown.com/wiki/sizes)
 
 Size values now support the font-relative `em` unit, including decimal values such as `0.7em` and `0.15em`.
 
 Thanks @arpitagarwal1301!
 
-&nbsp;
-
 ### Fixed
-
-&nbsp;
 
 #### Inline replacement lambdas accept nested function calls
 
@@ -26,8 +20,6 @@ Node-returning function calls, such as `.text`, can now be used in `.match` and 
 .match {Quarkdown takes its name from quarks} pattern:{[Qq]uark(down|s)?}
     .1::text color:{purple} decoration:{underline}
 ```
-
-&nbsp;
 
 #### Chained `.extend` composes in declaration order
 
@@ -45,8 +37,6 @@ Multiple extensions on the same function now stack in the correct LIFO declarati
 
 ## Heading
 ```
-
-&nbsp;
 
 #### `.match` in chained extensions sees content correctly
 
@@ -66,8 +56,6 @@ Fixed the ability to chain multiple `.match` calls onto the same content:
             .1::text color:{red}
 ```
 
-&nbsp;
-
 #### Fixed empty pages on CSS declarations
 
 Fixed an issue that caused `.css` and `.cssproperties` to produce empty pages in `paged` documents when the declaration was before an H1.
@@ -80,8 +68,6 @@ Quarkdown 2.4 is one of the most impactful releases in the history of the projec
 You can read in detail about this powerful feature in its [blog post](https://quarkdown.com/blog/quarkdown-2-4).
 
 ### Added
-
- 
 
 #### [Element styling](https://quarkdown.com/wiki/element-styling) (show-rules)
 
@@ -103,13 +89,9 @@ This is one of the biggest milestones for Quarkdown, on par with Typst's `#show`
 
 This release ships with a handful of primitives as an experimental feature: headings, paragraphs, links, figures, images, math, page breaks. The plan is to eventually have every Markdown element type backed by a primitive function.
 
- 
-
 #### [New primitives: `.paragraph`, `.math`, `.link`](https://quarkdown.com/wiki/primitives)
 
 The new `.paragraph` primitive backs Markdown paragraphs, `.math` backs `$`-delimited math blocks, and `.link` backs Markdown links, enabling extensions via `.extend`.
-
- 
 
 #### [Full styling options on `.heading`, `.paragraph`, `.math` and `.link`](https://quarkdown.com/wiki/element-styling-properties)
 
@@ -126,8 +108,6 @@ This plays particularly well with the new primitive extension system:
     content:
     .super background:{red} foreground:{white} padding:{10px}
 ```
-
- 
 
 #### [Conditional `.extend`](https://quarkdown.com/wiki/extending-functions)
 
@@ -148,8 +128,6 @@ The following snippet adds an icon to all external links:
     .super
         .content .icon {box-arrow-up-right}
 ```
-
- 
 
 #### [Regex match](https://quarkdown.com/wiki/regex-match)
 
@@ -176,11 +154,7 @@ This is particularly useful for element styling:
 Quarkdown takes its name from quarks
 ```
 
- 
-
 ### Changed
-
- 
 
 #### [Inline lambdas without `@lambda`](https://quarkdown.com/wiki/lambda#inline-lambda)
 
@@ -199,8 +173,6 @@ Inline lambdas passed as arguments no longer require the `@lambda` prefix. When 
 ````
 
 The `@lambda` prefix is still accepted for backward compatibility with older documents.
-
- 
 
 #### [Body argument binding](https://quarkdown.com/wiki/syntax-of-a-function-call#block-vs-inline-function-calls)
 
@@ -224,8 +196,6 @@ Inline binding keeps working as before, so the following is still valid:
 #### Optimized argument binding
 
 Parameter lookup now performs a single pass over the arguments, improving performance.
-
- 
 
 #### Body arguments for inline function calls
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -377,7 +377,6 @@ make sure to also update the documentation accordingly, along with [CHANGELOG](C
 The changelog follows the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format,
 uses [Semantic Versioning](https://semver.org/), uses extensive description for each major change,
 with links to the corresponding documentation at `https://quarkdown.com/wiki/Page`.
-Each `###` and `####` entry of the changelog must be preceded by a blank line, `&nbsp;`, and another blank line, including first entries.
 
 When writing documentation and changelog entries, you're an expert technical writer who follows these guidelines:
 - Use American English spelling.


### PR DESCRIPTION
- [X] I have read the [contributing guidelines](https://github.com/iamgio/quarkdown/blob/main/CONTRIBUTING.md).
- [X] I have tested the changes locally.
- [ ] An issue for this change exists, and it was discussed with maintainers. This is required for new features and non-trivial changes. If present, append `Closes #ISSUE_NUMBER` at the end of this PR description.
- [ ] (Optional) I have added necessary documentation to [`docs`](https://github.com/iamgio/quarkdown/tree/main/docs) and [`CHANGELOG.md`](https://github.com/iamgio/quarkdown/blob/main/CHANGELOG.md)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved inline replacement lambdas used by `.match` to support nested function calls.
  * Fixed chaining behavior for `.extend` wrappers (correct LIFO/declaration order).
  * Corrected content when chaining multiple `.match` calls within the same chained `.extend` context.
  * Fixed `paged` documents that could generate empty pages when `.css` / `.cssproperties` appeared before the H1.
* **Documentation**
  * Cleaned up `CHANGELOG.md` formatting for **[Unreleased]** and **2.4.0** (spacing and section boundary alignment).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->