### PR TITLE
fix(lexer): accept backslashes in inline footnotes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,10 @@ Fixed an issue that caused `.css` and `.cssproperties` to produce empty pages in
 
 Thanks @arpitagarwal1301!
 
+#### Backslashes allowed in [all-in-one footnotes](https://quarkdown.com/wiki/footnotes)
+
+Escape sequences and any content containing a backslash, such as math expressions, are now recognized inside the `[^label: ...]` form of footnote definitions.
+
 ## [2.4.0] - 2026-07-13
 
 Quarkdown 2.4 is one of the most impactful releases in the history of the project, introducing a new system for extending Markdown elements behavior and styling.

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/lexer/patterns/BaseMarkdownInlineTokenRegexPatterns.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/lexer/patterns/BaseMarkdownInlineTokenRegexPatterns.kt
@@ -175,7 +175,7 @@ open class BaseMarkdownInlineTokenRegexPatterns {
             regex =
                 RegexBuilder("\\[\\^(label)definition\\]")
                     .withReference("label", LABEL_HELPER)
-                    .withReference("definition", "(?::[ \\t]*((?:`[^`]*`|[^\\[\\]\\\\`])+?))?")
+                    .withReference("definition", "(?::[ \\t]*((?:`[^`]*`|\\\\.|[^\\[\\]\\\\`])+?))?")
                     .build(),
         )
     }

--- a/quarkdown-core/src/test/kotlin/com/quarkdown/core/InlineParserTest.kt
+++ b/quarkdown-core/src/test/kotlin/com/quarkdown/core/InlineParserTest.kt
@@ -15,6 +15,7 @@ import com.quarkdown.core.ast.base.inline.Strong
 import com.quarkdown.core.ast.base.inline.StrongEmphasis
 import com.quarkdown.core.ast.base.inline.SubdocumentLink
 import com.quarkdown.core.ast.base.inline.Text
+import com.quarkdown.core.ast.quarkdown.FunctionCallNode
 import com.quarkdown.core.ast.quarkdown.inline.MathSpan
 import com.quarkdown.core.context.MutableContext
 import com.quarkdown.core.document.size.cm
@@ -222,6 +223,26 @@ class InlineParserTest {
                     .length,
             )
             assertEquals("anonymous with code", definition.toPlainText())
+        }
+        with(nodes.next()) {
+            assertEquals("math", label)
+            val math = definition.filterIsInstance<MathSpan>().single()
+            assertEquals("\\infty", math.expression)
+        }
+        with(nodes.next()) {
+            assertEquals(
+                label.length,
+                UUID
+                    .randomUUID()
+                    .toString()
+                    .length,
+            )
+            val call = definition.filterIsInstance<FunctionCallNode>().single()
+            assertEquals("math", call.name)
+        }
+        with(nodes.next()) {
+            assertEquals("esc", label)
+            assertEquals("[not a bracket]", definition.toPlainText())
         }
     }
 

--- a/quarkdown-core/src/test/resources/parsing/inline/reffootnote-all-in-one.md
+++ b/quarkdown-core/src/test/resources/parsing/inline/reffootnote-all-in-one.md
@@ -5,3 +5,9 @@
 [^code: some `inline code` here]
 
 [^: anonymous with `code`]
+
+[^math: see $ \infty $ here]
+
+[^: .math {\infty} inline]
+
+[^esc: \[not a bracket\]]

--- a/quarkdown-test/src/test/kotlin/com/quarkdown/test/FootnoteTest.kt
+++ b/quarkdown-test/src/test/kotlin/com/quarkdown/test/FootnoteTest.kt
@@ -318,6 +318,57 @@ class FootnoteTest {
     }
 
     @Test
+    fun `all-in-one definition with inline math`() {
+        execute("text[^x: see $ \\infty $ here]") {
+            assertEquals(
+                "<p>text" +
+                    referenceHtml("x", "1") +
+                    definitionHtml(
+                        label = "x",
+                        index = 0,
+                        content = "see <formula>\\infty</formula> here",
+                    ) +
+                    "</p>",
+                it,
+            )
+        }
+    }
+
+    @Test
+    fun `all-in-one definition with math primitive call`() {
+        execute("text[^x: see .math {\\infty} here]") {
+            assertEquals(
+                "<p>text" +
+                    referenceHtml("x", "1") +
+                    definitionHtml(
+                        label = "x",
+                        index = 0,
+                        content = "see <formula>\\infty</formula> here",
+                    ) +
+                    "</p>",
+                it,
+            )
+        }
+    }
+
+    @Test
+    fun `all-in-one definition with escaped brackets`() {
+        execute("text[^x: see \\[not a bracket\\] here]") {
+            assertEquals(
+                "<p>text" +
+                    referenceHtml("x", "1") +
+                    definitionHtml(
+                        label = "x",
+                        index = 0,
+                        content = "see [not a bracket] here",
+                    ) +
+                    "</p>",
+                it,
+            )
+        }
+    }
+
+    @Test
     fun numbered() {
         execute(
             """


### PR DESCRIPTION
- [x] I have read the [contributing guidelines](https://github.com/iamgio/quarkdown/blob/main/CONTRIBUTING.md).
- [x] I have tested the changes locally.
- [x] An issue for this change exists, and it was discussed with maintainers. This is required for new features and non-trivial changes. If present, append `Closes #ISSUE_NUMBER` at the end of this PR description.
- [x] (Optional) I have added necessary documentation to [`docs`](https://github.com/iamgio/quarkdown/tree/main/docs) and [`CHANGELOG.md`](https://github.com/iamgio/quarkdown/blob/main/CHANGELOG.md)

Closes #608

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed all-in-one footnotes so backslashes and escape sequences are handled correctly.
  * Inline math, math expressions, and escaped brackets now render properly within footnote definitions.

* **Documentation**
  * Added an Unreleased changelog entry describing the footnote improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->