### PR TITLE
feat(primitives): add code block primitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@
 
 ### Added
 
+#### [Code block primitive](https://quarkdown.com/wiki/primitives)
+
+`.code` is now a [primitive](https://quarkdown.com/wiki/primitives), so it can be intercepted via `.extend {code}` to customize the appearance of every code block in the document.
+
+The following snippet hides line numbers on every JavaScript code block:
+
+```markdown
+.extend {code} where:{lang: .lang::equals {javascript}}
+    .super linenumbers:{no}
+```
+
 #### [Load data from JSON files](https://quarkdown.com/wiki/data-from-json)
 
 The new `.json {path}` function loads a JSON file and returns its content in a shape you can query and iterate.

--- a/docs/code.qd
+++ b/docs/code.qd
@@ -10,7 +10,7 @@ You can create code blocks using the standard Markdown specification: either wit
     }
     ```
 
-Quarkdown also provides a more powerful **`.code`** .docslink {quarkdown-stdlib/com.quarkdown.stdlib.module.Text/code.html} block function.
+Quarkdown also provides a more powerful **`.code`** .docslink {quarkdown-stdlib/com.quarkdown.stdlib.module.Primitives/code.html} block function.
 
 .examplemirror
     .code lang:{javascript}
@@ -53,6 +53,22 @@ The `.code` function allows you to focus on a [`Range`](range.qd) of lines, star
 .examplemirror
     .code focus:{5..8}
         .read {assets/point.ts}
+
+### Extending
+
+`.code` is a [primitive](primitives.qd), so [extending it](element-styling.qd) affects every code block in the document at once, including fenced and indented blocks.
+
+.example
+    ~~~markdown
+    .extend {code} where:{lang: .lang::equals {javascript}}
+        .super linenumbers:{no}
+
+    ```javascript
+    function greet(name) {
+        return `Hello, ${name}!`;
+    }
+    ```
+    ~~~
 
 ## Inline code
 

--- a/docs/primitives.qd
+++ b/docs/primitives.qd
@@ -19,4 +19,6 @@ For example, extending `.heading` affects every `#`, `##`, and so on. Extending 
 
 - [**`.math`**](tex-formulae.qd) .docslink {quarkdown-stdlib/com.quarkdown.stdlib.module.Primitives/math.html} backs `$ ... $` and `$$$ ... $$$` formulas.
 
+- [**`.code`**](code.qd) .docslink {quarkdown-stdlib/com.quarkdown.stdlib.module.Primitives/code.html} backs fenced and indented code blocks.
+
 - [**`.pagebreak`**](page-break.qd) .docslink {quarkdown-stdlib/com.quarkdown.stdlib.module.Primitives/pagebreak.html} backs `<<<`. Can be extended to decorate every forced page break in the document.

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/base/block/Code.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/base/block/Code.kt
@@ -4,8 +4,10 @@ import com.quarkdown.core.ast.InlineContent
 import com.quarkdown.core.ast.attributes.localization.LocalizedKind
 import com.quarkdown.core.ast.attributes.localization.LocalizedKindKeys
 import com.quarkdown.core.ast.attributes.location.LocationTrackableNode
+import com.quarkdown.core.ast.attributes.primitive.PrimitiveFunctionBackedNode
 import com.quarkdown.core.ast.quarkdown.CaptionableNode
 import com.quarkdown.core.ast.quarkdown.reference.CrossReferenceableNode
+import com.quarkdown.core.function.dsl.functionCallArguments
 import com.quarkdown.core.function.value.data.Range
 import com.quarkdown.core.visitor.node.NodeVisitor
 
@@ -30,9 +32,23 @@ class Code(
 ) : LocationTrackableNode,
     CrossReferenceableNode,
     CaptionableNode,
-    LocalizedKind {
+    LocalizedKind,
+    PrimitiveFunctionBackedNode {
     override val kindLocalizationKey: String
         get() = LocalizedKindKeys.CODE_BLOCK
+
+    override val backingFunctionName: String
+        get() = "code"
+
+    override fun toFunctionCallArguments() =
+        functionCallArguments {
+            arg("lang", string(language))
+            arg("caption", inline(caption))
+            arg("linenumbers", boolean(showLineNumbers))
+            arg("focus", obj(focusedLines))
+            arg("ref", string(referenceId))
+            arg("code", evaluable(content))
+        }
 
     override fun <T> accept(visitor: NodeVisitor<T>) = visitor.visit(this)
 }

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Primitives.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Primitives.kt
@@ -4,6 +4,7 @@ package com.quarkdown.stdlib
 
 import com.quarkdown.core.ast.InlineMarkdownContent
 import com.quarkdown.core.ast.MarkdownContent
+import com.quarkdown.core.ast.base.block.Code
 import com.quarkdown.core.ast.base.block.Heading
 import com.quarkdown.core.ast.base.block.Paragraph
 import com.quarkdown.core.ast.base.inline.Image
@@ -17,9 +18,11 @@ import com.quarkdown.core.document.size.Size
 import com.quarkdown.core.function.call.FunctionCall
 import com.quarkdown.core.function.reflect.annotation.Body
 import com.quarkdown.core.function.reflect.annotation.Injected
+import com.quarkdown.core.function.reflect.annotation.LikelyBody
 import com.quarkdown.core.function.reflect.annotation.LikelyNamed
 import com.quarkdown.core.function.value.NodeValue
 import com.quarkdown.core.function.value.data.EvaluableString
+import com.quarkdown.core.function.value.data.Range
 import com.quarkdown.core.function.value.wrappedAsValue
 import com.quarkdown.processor.annotation.Name
 import com.quarkdown.processor.annotation.QFunction
@@ -216,6 +219,52 @@ fun image(
 @QFunction
 @Name("pagebreak")
 fun pageBreak() = PageBreak().wrappedAsValue()
+
+/**
+ * Creates a code block. Contrary to its standard Markdown implementation with backtick/tilde fences,
+ * this function accepts function calls within its [code] argument,
+ * hence it can be used - for example - in combination with [read] to load code from file.
+ *
+ * Example of a code block loaded from file via [read]:
+ *
+ * ```markdown
+ * .code lang:{kotlin} focus:{2..5}
+ *     .read {snippet.kt}
+ * ```
+ *
+ * As a [Code] primitive, this function can be used in `.extend` to affect every code block in the document,
+ * including those introduced by the standard triple-backtick and triple-tilde fences:
+ *
+ * ```markdown
+ * .extend {code} where:{lang: .lang::equals {javascript}}
+ *     .super linenumbers:{no}
+ * ```
+ *
+ * @param language optional language of the code
+ * @param caption optional caption
+ * @param showLineNumbers whether to show line numbers
+ * @param focusedLines range of lines to focus on. No lines are focused if unset. Supports open ranges.
+ * Note: HTML rendering requires [showLineNumbers] to be enabled.
+ * @param referenceId optional identifier for cross-referencing this code block elsewhere via [reference]
+ * @param code code content
+ */
+@QFunction
+fun code(
+    @Name("lang") language: String? = null,
+    @LikelyNamed caption: InlineMarkdownContent? = null,
+    @Name("linenumbers") showLineNumbers: Boolean = true,
+    @Name("focus") focusedLines: Range? = null,
+    @Name("ref") referenceId: String? = null,
+    @LikelyBody code: EvaluableString,
+): NodeValue =
+    Code(
+        content = code.content,
+        language = language,
+        showLineNumbers = showLineNumbers,
+        focusedLines = focusedLines,
+        caption = caption?.children,
+        referenceId = referenceId,
+    ).wrappedAsValue()
 
 /**
  * Creates a math (TeX) node, either inline or as a block.

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Text.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Text.kt
@@ -4,20 +4,16 @@ package com.quarkdown.stdlib
 
 import com.quarkdown.core.ast.InlineContent
 import com.quarkdown.core.ast.InlineMarkdownContent
-import com.quarkdown.core.ast.base.block.Code
 import com.quarkdown.core.ast.base.inline.CodeSpan
 import com.quarkdown.core.ast.base.inline.LineBreak
 import com.quarkdown.core.ast.base.inline.Link
 import com.quarkdown.core.ast.quarkdown.inline.TextTransform
 import com.quarkdown.core.ast.quarkdown.inline.TextTransformData
 import com.quarkdown.core.function.reflect.annotation.Body
-import com.quarkdown.core.function.reflect.annotation.LikelyBody
 import com.quarkdown.core.function.reflect.annotation.LikelyNamed
 import com.quarkdown.core.function.value.InlineMarkdownContentValue
 import com.quarkdown.core.function.value.NodeValue
-import com.quarkdown.core.function.value.data.EvaluableString
 import com.quarkdown.core.function.value.data.Lambda
-import com.quarkdown.core.function.value.data.Range
 import com.quarkdown.core.function.value.wrappedAsValue
 import com.quarkdown.core.misc.color.Color
 import com.quarkdown.core.util.node.toPlainText
@@ -86,44 +82,6 @@ fun text(
 @QFunction
 @Name("br")
 fun lineBreak() = LineBreak.wrappedAsValue()
-
-/**
- * Creates a code block. Contrary to its standard Markdown implementation with backtick/tilde fences,
- * this function accepts function calls within its [code] argument,
- * hence it can be used - for example - in combination with [read] to load code from file.
- *
- * Example of a code block loaded from file via [read]:
- *
- * ```
- * .code lang:{kotlin} focus:{2..5}
- *     .read {snippet.kt}
- * ```
- *
- * @param language optional language of the code
- * @param caption optional caption
- * @param showLineNumbers whether to show line numbers
- * @param focusedLines range of lines to focus on. No lines are focused if unset. Supports open ranges.
- * Note: HTML rendering requires [showLineNumbers] to be enabled.
- * @param referenceId optional identifier for cross-referencing this code block elsewhere via [reference]
- * @param code code content
- */
-@QFunction
-fun code(
-    @Name("lang") language: String? = null,
-    @LikelyNamed caption: InlineMarkdownContent? = null,
-    @Name("linenumbers") showLineNumbers: Boolean = true,
-    @Name("focus") focusedLines: Range? = null,
-    @Name("ref") referenceId: String? = null,
-    @LikelyBody code: EvaluableString,
-): NodeValue =
-    Code(
-        content = code.content,
-        language = language,
-        showLineNumbers = showLineNumbers,
-        focusedLines = focusedLines,
-        caption = caption?.children,
-        referenceId = referenceId,
-    ).wrappedAsValue()
 
 /**
  * Creates an inline code span.

--- a/quarkdown-test/src/test/kotlin/com/quarkdown/test/primitive/CodePrimitiveFunctionTest.kt
+++ b/quarkdown-test/src/test/kotlin/com/quarkdown/test/primitive/CodePrimitiveFunctionTest.kt
@@ -1,0 +1,125 @@
+package com.quarkdown.test.primitive
+
+import com.quarkdown.test.util.execute
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Tests for `.extend` applied to [com.quarkdown.core.ast.base.block.Code] blocks.
+ */
+class CodePrimitiveFunctionTest {
+    @Test
+    fun `no extension renders unchanged`() {
+        execute("```\nHello\n```") {
+            assertEquals("<pre><code>Hello</code></pre>", it)
+        }
+    }
+
+    @Test
+    fun `extension wraps every fenced code block`() {
+        execute(
+            """
+            .extend {code}
+                .container
+                    .super
+
+            ```
+            Hello
+            ```
+            """.trimIndent(),
+        ) {
+            assertEquals(
+                "<div class=\"container\"><pre><code>Hello</code></pre></div>",
+                it,
+            )
+        }
+    }
+
+    @Test
+    fun `extension can disable line numbers via super`() {
+        execute(
+            """
+            .extend {code}
+                .super linenumbers:{no}
+
+            ```kotlin
+            println("Hello")
+            println("Hello")
+            ```
+            """.trimIndent(),
+        ) {
+            assertEquals(
+                "<pre><code class=\"language-kotlin nohljsln\">" +
+                    "println(&quot;Hello&quot;)\nprintln(&quot;Hello&quot;)" +
+                    "</code></pre>",
+                it,
+            )
+        }
+    }
+
+    @Test
+    fun `language can be matched and conditionally wrapped`() {
+        execute(
+            """
+            .extend {code} where:{lang: .lang::equals {kotlin}}
+                .container
+                    .super
+
+            ```kotlin
+            println("Match")
+            ```
+
+            ```
+            No match
+            ```
+            """.trimIndent(),
+        ) {
+            assertEquals(
+                "<div class=\"container\"><pre><code class=\"language-kotlin\">println(&quot;Match&quot;)</code></pre></div>" +
+                    "<pre><code>No match</code></pre>",
+                it,
+            )
+        }
+    }
+
+    @Test
+    fun `language can be set via super`() {
+        execute(
+            """
+            .extend {code}
+                .super lang:{kotlin}
+
+            ```
+            println("Hello")
+            ```
+            """.trimIndent(),
+        ) {
+            assertEquals(
+                "<pre><code class=\"language-kotlin\">println(&quot;Hello&quot;)</code></pre>",
+                it,
+            )
+        }
+    }
+
+    @Test
+    fun `focus range can be set via super`() {
+        execute(
+            """
+            .extend {code}
+                .super focus:{2..3}
+
+            ```
+            a
+            b
+            c
+            d
+            ```
+            """.trimIndent(),
+        ) {
+            assertEquals(
+                "<pre><code class=\"focus-lines\" data-focus-start=\"2\" data-focus-end=\"3\">a\nb\nc\nd</code></pre>",
+                it,
+            )
+        }
+    }
+}


### PR DESCRIPTION
- [x] I have read the [contributing guidelines](https://github.com/iamgio/quarkdown/blob/main/CONTRIBUTING.md).
- [x] I have tested the changes locally.
- [ ] An issue for this change exists, and it was discussed with maintainers. This is required for new features and non-trivial changes. If present, append `Closes #ISSUE_NUMBER` at the end of this PR description.
- [x] (Optional) I have added necessary documentation to [`docs`](https://github.com/iamgio/quarkdown/tree/main/docs) and [`CHANGELOG.md`](https://github.com/iamgio/quarkdown/blob/main/CHANGELOG.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
    - Added `.code` as an extensible primitive for fenced and indented code blocks.
    - Added support for configuring languages, captions, line numbers, focused lines, and references.
    - Enabled conditional code-block customization, including hiding line numbers and matching or changing languages.
- **Documentation**
    - Updated primitive and code-block documentation with API references and extension examples.
    - Added an Unreleased changelog entry describing the new capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->