### PR TITLE
fix: fix compact footnote rendering in textual targets

### DIFF
--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/AstGroup.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/AstGroup.kt
@@ -1,0 +1,13 @@
+package com.quarkdown.core.ast
+
+import com.quarkdown.amber.annotations.Diverge
+import com.quarkdown.core.visitor.node.NodeVisitor
+
+/**
+ * A generic grouping of nodes that behaves like a sub-root.
+ */
+class AstGroup(
+    @Diverge override val children: List<Node>,
+) : NestableNode {
+    override fun <T> accept(visitor: NodeVisitor<T>): T = visitor.visit(this)
+}

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/MarkdownContent.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/MarkdownContent.kt
@@ -11,7 +11,7 @@ import com.quarkdown.core.visitor.node.NodeVisitor
 class MarkdownContent(
     override val children: List<Node>,
 ) : NestableNode {
-    override fun <T> accept(visitor: NodeVisitor<T>) = visitor.visit(AstRoot(children))
+    override fun <T> accept(visitor: NodeVisitor<T>): T = visitor.visit(AstGroup(children))
 }
 
 /**
@@ -21,5 +21,5 @@ class MarkdownContent(
 class InlineMarkdownContent(
     override val children: InlineContent,
 ) : NestableNode {
-    override fun <T> accept(visitor: NodeVisitor<T>) = visitor.visit(AstRoot(children))
+    override fun <T> accept(visitor: NodeVisitor<T>): T = visitor.visit(AstGroup(children))
 }

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/base/inline/ReferenceFootnote.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/base/inline/ReferenceFootnote.kt
@@ -1,6 +1,6 @@
 package com.quarkdown.core.ast.base.inline
 
-import com.quarkdown.core.ast.AstRoot
+import com.quarkdown.core.ast.AstGroup
 import com.quarkdown.core.ast.InlineContent
 import com.quarkdown.core.ast.NestableNode
 import com.quarkdown.core.ast.Node
@@ -43,5 +43,5 @@ class ReferenceDefinitionFootnote(
             ),
         )
 
-    override fun <T> accept(visitor: NodeVisitor<T>): T = AstRoot(children).accept(visitor)
+    override fun <T> accept(visitor: NodeVisitor<T>): T = AstGroup(children).accept(visitor)
 }

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/rewriter/NodeNewChildrenVisitor.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/rewriter/NodeNewChildrenVisitor.kt
@@ -1,5 +1,6 @@
 package com.quarkdown.core.ast.rewriter
 
+import com.quarkdown.core.ast.AstGroup
 import com.quarkdown.core.ast.AstRoot
 import com.quarkdown.core.ast.NestableNode
 import com.quarkdown.core.ast.Node
@@ -105,6 +106,8 @@ private class NodeNewChildrenVisitor(
     private val newChildren: List<Node>,
 ) : NodeVisitor<Node> {
     override fun visit(node: AstRoot) = node.diverge(newChildren)
+
+    override fun visit(node: AstGroup) = node.diverge(newChildren)
 
     override fun visit(node: Newline) = node
 

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/rendering/textual/TextualNodeRenderer.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/rendering/textual/TextualNodeRenderer.kt
@@ -1,5 +1,6 @@
 package com.quarkdown.core.rendering.textual
 
+import com.quarkdown.core.ast.AstGroup
 import com.quarkdown.core.ast.AstRoot
 import com.quarkdown.core.ast.InlineContent
 import com.quarkdown.core.ast.NestableNode
@@ -10,6 +11,7 @@ import com.quarkdown.core.ast.attributes.reference.getCitationLabel
 import com.quarkdown.core.ast.attributes.reference.getDefinition
 import com.quarkdown.core.ast.base.TextNode
 import com.quarkdown.core.ast.base.block.BlankNode
+import com.quarkdown.core.ast.base.block.FootnoteDefinition
 import com.quarkdown.core.ast.base.block.Newline
 import com.quarkdown.core.ast.base.block.Paragraph
 import com.quarkdown.core.ast.base.inline.CheckBox
@@ -56,6 +58,7 @@ import com.quarkdown.core.context.Context
 import com.quarkdown.core.context.localization.localizeOrNull
 import com.quarkdown.core.context.toc.TableOfContents
 import com.quarkdown.core.rendering.NodeRenderer
+import java.util.concurrent.ConcurrentLinkedQueue
 
 /**
  * Base class for node renderers that produce plain-textual output,
@@ -64,6 +67,9 @@ import com.quarkdown.core.rendering.NodeRenderer
 abstract class TextualNodeRenderer(
     context: Context,
 ) : NodeRenderer(context) {
+    // Footnote definitions are queued and rendered as blocks at the end of every AstRoot.
+    private val queuedFootnoteDefinitions = ConcurrentLinkedQueue<FootnoteDefinition>()
+
     /**
      * Renders all children of this [NestableNode] and joins the results.
      */
@@ -88,7 +94,26 @@ abstract class TextualNodeRenderer(
 
     override fun createMediaPassthroughPrefixReplacement(): String = "."
 
-    override fun visit(node: AstRoot) = node.visitChildren()
+    override fun visit(node: FootnoteDefinition): CharSequence {
+        queuedFootnoteDefinitions += node
+        return ""
+    }
+
+    override fun visit(node: AstRoot): CharSequence {
+        queuedFootnoteDefinitions.clear()
+        val body = node.visitChildren()
+        val defs =
+            generateSequence { queuedFootnoteDefinitions.poll() }
+                .joinToString(separator = "") { renderFootnoteDefinition(it) }
+        return body.toString() + defs
+    }
+
+    override fun visit(node: AstGroup) = node.visitChildren()
+
+    /**
+     * Renders a queued [FootnoteDefinition] as its final block-level output.
+     */
+    protected open fun renderFootnoteDefinition(node: FootnoteDefinition): CharSequence = ""
 
     override fun visit(node: Newline) = ""
 
@@ -175,8 +200,7 @@ abstract class TextualNodeRenderer(
     }
 
     /**
-     * URL a table-of-contents entry links to. Defaults to empty (suitable for plaintext);
-     * subclasses that support anchors (e.g. GFM) override to point at the target heading.
+     * URL a table-of-contents entry links to.
      */
     protected open fun tableOfContentsItemUrl(item: TableOfContents.Item): String = ""
 

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/util/node/NodeUtils.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/util/node/NodeUtils.kt
@@ -1,6 +1,6 @@
 package com.quarkdown.core.util.node
 
-import com.quarkdown.core.ast.AstRoot
+import com.quarkdown.core.ast.AstGroup
 import com.quarkdown.core.ast.InlineContent
 import com.quarkdown.core.ast.NestableNode
 import com.quarkdown.core.ast.Node
@@ -12,10 +12,10 @@ import com.quarkdown.core.ast.quarkdown.inline.TextSymbol
 import com.quarkdown.core.visitor.node.NodeVisitor
 
 /**
- * Groups nodes into an [AstRoot] container.
- * @return an empty [AstRoot] if `null`
+ * Groups nodes into a sub-root [NestableNode] container.
+ * @return an empty grouping if `null`
  */
-fun List<Node>?.group(): AstRoot = AstRoot(this.orEmpty())
+fun List<Node>?.group(): NestableNode = AstGroup(this.orEmpty())
 
 /**
  * Returns a sequence of all nodes in the tree, where [this] is the root node.
@@ -79,7 +79,7 @@ fun InlineContent.toPlainText(renderer: NodeVisitor<CharSequence>? = null): Stri
     val builder = StringBuilder()
 
     // Visits the tree and appends the text content of each node.
-    AstRoot(this).flattenedChildren().forEach {
+    AstGroup(this).flattenedChildren().forEach {
         when (it) {
             is CriticalContent if renderer != null -> builder.append(renderer.visit(it))
             is TextSymbol if renderer != null -> builder.append(renderer.visit(it))

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/visitor/node/NodeVisitor.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/visitor/node/NodeVisitor.kt
@@ -1,5 +1,6 @@
 package com.quarkdown.core.visitor.node
 
+import com.quarkdown.core.ast.AstGroup
 import com.quarkdown.core.ast.AstRoot
 import com.quarkdown.core.ast.base.block.BlankNode
 import com.quarkdown.core.ast.base.block.BlockQuote
@@ -73,6 +74,8 @@ import com.quarkdown.core.ast.quarkdown.reference.CrossReference
  */
 interface NodeVisitor<T> {
     fun visit(node: AstRoot): T
+
+    fun visit(node: AstGroup): T
 
     // Base block
 

--- a/quarkdown-core/src/test/kotlin/com/quarkdown/core/TreeTraversalTest.kt
+++ b/quarkdown-core/src/test/kotlin/com/quarkdown/core/TreeTraversalTest.kt
@@ -49,7 +49,7 @@ class TreeTraversalTest {
                     "BlockQuote",
                     "Paragraph",
                     "Text",
-                    "AstRoot", // Empty attribution group
+                    "AstGroup", // Empty attribution group
                     "Paragraph",
                     "Strong",
                     "Text",
@@ -57,7 +57,7 @@ class TreeTraversalTest {
                     "Emphasis",
                     "Text",
                     "Code",
-                    "AstRoot", // Empty caption group
+                    "AstGroup", // Empty caption group
                 ),
                 this,
             )
@@ -105,7 +105,7 @@ class TreeTraversalTest {
                 listOf(
                     "Paragraph",
                     "Text",
-                    "AstRoot", // Caption group
+                    "AstGroup", // Caption group
                     "Text",
                     "Strong",
                     "Text",
@@ -133,7 +133,7 @@ class TreeTraversalTest {
                 listOf(
                     "Text", // Cell
                     "Text", // Header
-                    "AstRoot", // Caption group
+                    "AstGroup", // Caption group
                     "Text",
                     "Strong",
                     "Text",
@@ -148,7 +148,7 @@ class TreeTraversalTest {
         with(code.flattenedChildren().map { it::class.simpleName }.toList()) {
             assertEquals(
                 listOf(
-                    "AstRoot", // Caption group
+                    "AstGroup", // Caption group
                     "Text",
                     "Strong",
                     "Text",

--- a/quarkdown-html/src/main/kotlin/com/quarkdown/rendering/html/node/BaseHtmlNodeRenderer.kt
+++ b/quarkdown-html/src/main/kotlin/com/quarkdown/rendering/html/node/BaseHtmlNodeRenderer.kt
@@ -1,5 +1,6 @@
 package com.quarkdown.rendering.html.node
 
+import com.quarkdown.core.ast.AstGroup
 import com.quarkdown.core.ast.AstRoot
 import com.quarkdown.core.ast.attributes.id.getId
 import com.quarkdown.core.ast.attributes.reference.getDefinition
@@ -122,9 +123,14 @@ open class BaseHtmlNodeRenderer(
 
     override fun createMediaPassthroughPrefixReplacement(): String = getPathToRoot()
 
-    // Root
+    // Group
 
     override fun visit(node: AstRoot) =
+        buildMultiTag {
+            +node.children
+        }
+
+    override fun visit(node: AstGroup) =
         buildMultiTag {
             +node.children
         }

--- a/quarkdown-html/src/main/kotlin/com/quarkdown/rendering/html/node/QuarkdownHtmlNodeRenderer.kt
+++ b/quarkdown-html/src/main/kotlin/com/quarkdown/rendering/html/node/QuarkdownHtmlNodeRenderer.kt
@@ -1,6 +1,6 @@
 package com.quarkdown.rendering.html.node
 
-import com.quarkdown.core.ast.AstRoot
+import com.quarkdown.core.ast.AstGroup
 import com.quarkdown.core.ast.Node
 import com.quarkdown.core.ast.attributes.id.Identifiable
 import com.quarkdown.core.ast.attributes.id.getId
@@ -172,7 +172,7 @@ class QuarkdownHtmlNodeRenderer(
     // Quarkdown node rendering
 
     // The function was already expanded by previous stages: its output nodes are stored in its children.
-    override fun visit(node: FunctionCallNode): CharSequence = visit(AstRoot(node.children))
+    override fun visit(node: FunctionCallNode): CharSequence = visit(AstGroup(node.children))
 
     // Block
 

--- a/quarkdown-markdown/src/main/kotlin/com/quarkdown/rendering/markdown/node/GfmNodeRenderer.kt
+++ b/quarkdown-markdown/src/main/kotlin/com/quarkdown/rendering/markdown/node/GfmNodeRenderer.kt
@@ -115,7 +115,7 @@ class GfmNodeRenderer(
             append(formatTitle(node.title))
         }.blockNode
 
-    override fun visit(node: FootnoteDefinition) = ("[^${node.label}]: " + node.text.visitAll()).blockNode
+    override fun renderFootnoteDefinition(node: FootnoteDefinition) = ("[^${node.label}]: " + node.text.visitAll()).blockNode
 
     override fun visit(node: OrderedList) =
         buildString {

--- a/quarkdown-plaintext/src/main/kotlin/com/quarkdown/rendering/plaintext/node/PlainTextNodeRenderer.kt
+++ b/quarkdown-plaintext/src/main/kotlin/com/quarkdown/rendering/plaintext/node/PlainTextNodeRenderer.kt
@@ -2,7 +2,6 @@ package com.quarkdown.rendering.plaintext.node
 
 import com.quarkdown.core.ast.base.block.BlockQuote
 import com.quarkdown.core.ast.base.block.Code
-import com.quarkdown.core.ast.base.block.FootnoteDefinition
 import com.quarkdown.core.ast.base.block.Heading
 import com.quarkdown.core.ast.base.block.HorizontalRule
 import com.quarkdown.core.ast.base.block.Html
@@ -53,8 +52,6 @@ class PlainTextNodeRenderer(
     override fun visit(node: Heading) = node.visitChildren().toString().blockNode
 
     override fun visit(node: LinkDefinition) = ""
-
-    override fun visit(node: FootnoteDefinition) = ""
 
     override fun visit(node: OrderedList) =
         buildString {

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Bibliography.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Bibliography.kt
@@ -2,7 +2,7 @@
 
 package com.quarkdown.stdlib
 
-import com.quarkdown.core.ast.AstRoot
+import com.quarkdown.core.ast.AstGroup
 import com.quarkdown.core.ast.InlineMarkdownContent
 import com.quarkdown.core.ast.base.block.Heading
 import com.quarkdown.core.ast.base.block.createSectionHeading
@@ -53,7 +53,7 @@ internal const val DEFAULT_CSL_STYLE = "ieee"
  *                             Implicitly enabled when [indexHeading] is enabled.
  * @param indexHeading whether the heading preceding the bibliography should itself be indexed
  *                     in the document's table of contents.
- * @return an [AstRoot] containing an optional heading and a [BibliographyView]
+ * @return an [AstGroup] containing an optional heading and a [BibliographyView]
  * @see cite to cite bibliography entries
  * @throws java.io.IOException if the bibliography file cannot be read or parsed
  * @throws IllegalArgumentException if the specified style does not exist or is invalid
@@ -86,7 +86,7 @@ fun bibliography(
             includeInTableOfContents = indexHeading,
         )
 
-    return AstRoot(
+    return AstGroup(
         listOfNotNull(
             heading,
             BibliographyView(

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Document.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Document.kt
@@ -2,7 +2,7 @@
 
 package com.quarkdown.stdlib
 
-import com.quarkdown.core.ast.AstRoot
+import com.quarkdown.core.ast.AstGroup
 import com.quarkdown.core.ast.InlineMarkdownContent
 import com.quarkdown.core.ast.MarkdownContent
 import com.quarkdown.core.ast.attributes.style.NodeStyle
@@ -1023,7 +1023,7 @@ fun navigationContainer(
  * @param focusedItem if set, adds focus to the item of the table of contents with the same text content as this argument.
  *                    Inline style (strong, emphasis, etc.) is ignored when comparing the text content.
  *                    When at least one item is focused, non-focused items are visually de-emphasized.
- * @return an [AstRoot] containing an optional heading and a [TableOfContentsView]
+ * @return an [AstGroup] containing an optional heading and a [TableOfContentsView]
  * @wiki table-of-contents
  */
 @QFunction
@@ -1040,7 +1040,7 @@ fun tableOfContents(
 ): NodeValue {
     val isDocs = context.documentInfo.type == DocumentType.DOCS
 
-    return AstRoot(
+    return AstGroup(
         listOfNotNull(
             Heading.createSectionHeading(
                 title?.children,

--- a/quarkdown-test/src/test/kotlin/com/quarkdown/test/FootnoteTest.kt
+++ b/quarkdown-test/src/test/kotlin/com/quarkdown/test/FootnoteTest.kt
@@ -54,12 +54,14 @@ class FootnoteTest {
     @Test
     fun `all-in-one anonymous footnote (gfm)`() {
         execute(
-            "See[^: A footnote].",
+            "See[^: A footnote] and [^: Another footnote].",
             options = DEFAULT_OPTIONS.copy(uuidSupplier = { "42" }),
             renderer = { factory, ctx -> factory.gfm(ctx) },
         ) {
             assertEquals(
-                "See[^42][^42]: A footnote\n\n.\n\n",
+                "See[^42] and [^42].\n\n" +
+                    "[^42]: A footnote\n\n" +
+                    "[^42]: Another footnote\n\n",
                 it,
             )
         }


### PR DESCRIPTION
- [X] I have read the [contributing guidelines](https://github.com/iamgio/quarkdown/blob/main/CONTRIBUTING.md).
- [X] I have tested the changes locally.
- [ ] An issue for this change exists, and it was discussed with maintainers. This is required for new features and non-trivial changes. If present, append `Closes #ISSUE_NUMBER` at the end of this PR description.
- [ ] (Optional) I have added necessary documentation to [`docs`](https://github.com/iamgio/quarkdown/tree/main/docs) and [`CHANGELOG.md`](https://github.com/iamgio/quarkdown/blob/main/CHANGELOG.md)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for grouping related content while preserving correct traversal and rendering.
  - Improved HTML rendering for grouped content, including expanded function output.
  - Added more reliable handling of footnote definitions in textual and Markdown output.

- **Bug Fixes**
  - Footnotes now appear in the appropriate output location and support multiple anonymous references.
  - Improved rendering of captions, attributions, bibliographies, and tables.

- **Tests**
  - Expanded traversal and footnote coverage to validate updated behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->