### PR TITLE
feat(stdlib): add .markdown native-content function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ quarkdown c document.qd -r markdown
 This plays an important role in AEO optimization, as AI agents usually prefer Markdown to HTML. Multi-target compilation allows shipping sites in both formats from the same source.  
 See [SEO & AEO optimization](https://quarkdown.com/wiki/seo-aeo-optimization) for more details.
 
+The new `.markdown` function lets you include raw Markdown content when exporting to Markdown.
+
 #### [Code block primitive](https://quarkdown.com/wiki/primitives)
 
 `.code` is now a [primitive](https://quarkdown.com/wiki/primitives), so it can be intercepted via `.extend {code}` to customize the appearance of every code block in the document.

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/quarkdown/block/Markdown.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/quarkdown/block/Markdown.kt
@@ -1,0 +1,15 @@
+package com.quarkdown.core.ast.quarkdown.block
+
+import com.quarkdown.core.ast.Node
+import com.quarkdown.core.visitor.node.NodeVisitor
+
+/**
+ * A block of raw Markdown content that is emitted verbatim, without any additional processing or escaping,
+ * only when the rendering target is Markdown.
+ * @param content raw Markdown content
+ */
+class Markdown(
+    val content: String,
+) : Node {
+    override fun <T> accept(visitor: NodeVisitor<T>) = visitor.visit(this)
+}

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/rewriter/NodeNewChildrenVisitor.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/rewriter/NodeNewChildrenVisitor.kt
@@ -49,6 +49,7 @@ import com.quarkdown.core.ast.quarkdown.block.Container
 import com.quarkdown.core.ast.quarkdown.block.Figure
 import com.quarkdown.core.ast.quarkdown.block.FileTree
 import com.quarkdown.core.ast.quarkdown.block.Landscape
+import com.quarkdown.core.ast.quarkdown.block.Markdown
 import com.quarkdown.core.ast.quarkdown.block.Math
 import com.quarkdown.core.ast.quarkdown.block.MermaidDiagram
 import com.quarkdown.core.ast.quarkdown.block.NavigationContainer
@@ -128,6 +129,8 @@ private class NodeNewChildrenVisitor(
     override fun visit(node: ListItem) = node.diverge(newChildren)
 
     override fun visit(node: Html) = node
+
+    override fun visit(node: Markdown) = node
 
     override fun visit(node: Table) = node
 

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/rendering/textual/TextualNodeRenderer.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/rendering/textual/TextualNodeRenderer.kt
@@ -32,6 +32,7 @@ import com.quarkdown.core.ast.quarkdown.block.Figure
 import com.quarkdown.core.ast.quarkdown.block.FileTree
 import com.quarkdown.core.ast.quarkdown.block.FileTreeEntry
 import com.quarkdown.core.ast.quarkdown.block.Landscape
+import com.quarkdown.core.ast.quarkdown.block.Markdown
 import com.quarkdown.core.ast.quarkdown.block.NavigationContainer
 import com.quarkdown.core.ast.quarkdown.block.Numbered
 import com.quarkdown.core.ast.quarkdown.block.PageBreak
@@ -168,6 +169,8 @@ abstract class TextualNodeRenderer(
     override fun visit(node: SlidesFragment) = node.visitChildren()
 
     override fun visit(node: SubdocumentGraph) = ""
+
+    override fun visit(node: Markdown) = ""
 
     override fun visit(node: PageMarginContentInitializer) = ""
 

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/visitor/node/NodeVisitor.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/visitor/node/NodeVisitor.kt
@@ -43,6 +43,7 @@ import com.quarkdown.core.ast.quarkdown.block.Container
 import com.quarkdown.core.ast.quarkdown.block.Figure
 import com.quarkdown.core.ast.quarkdown.block.FileTree
 import com.quarkdown.core.ast.quarkdown.block.Landscape
+import com.quarkdown.core.ast.quarkdown.block.Markdown
 import com.quarkdown.core.ast.quarkdown.block.Math
 import com.quarkdown.core.ast.quarkdown.block.MermaidDiagram
 import com.quarkdown.core.ast.quarkdown.block.NavigationContainer
@@ -184,6 +185,8 @@ interface NodeVisitor<T> {
     fun visit(node: FileTree): T
 
     fun visit(node: SubdocumentGraph): T
+
+    fun visit(node: Markdown): T
 
     // Quarkdown inline
 

--- a/quarkdown-html/src/main/kotlin/com/quarkdown/rendering/html/node/BaseHtmlNodeRenderer.kt
+++ b/quarkdown-html/src/main/kotlin/com/quarkdown/rendering/html/node/BaseHtmlNodeRenderer.kt
@@ -48,6 +48,7 @@ import com.quarkdown.core.ast.quarkdown.block.Container
 import com.quarkdown.core.ast.quarkdown.block.Figure
 import com.quarkdown.core.ast.quarkdown.block.FileTree
 import com.quarkdown.core.ast.quarkdown.block.Landscape
+import com.quarkdown.core.ast.quarkdown.block.Markdown
 import com.quarkdown.core.ast.quarkdown.block.Math
 import com.quarkdown.core.ast.quarkdown.block.MermaidDiagram
 import com.quarkdown.core.ast.quarkdown.block.NavigationContainer
@@ -234,6 +235,8 @@ open class BaseHtmlNodeRenderer(
         }
 
     override fun visit(node: Html) = node.content
+
+    override fun visit(node: Markdown) = ""
 
     /**
      * Table tag builder, enhanceable by subclasses.

--- a/quarkdown-markdown/src/main/kotlin/com/quarkdown/rendering/markdown/node/GfmNodeRenderer.kt
+++ b/quarkdown-markdown/src/main/kotlin/com/quarkdown/rendering/markdown/node/GfmNodeRenderer.kt
@@ -28,6 +28,7 @@ import com.quarkdown.core.ast.base.inline.Strong
 import com.quarkdown.core.ast.base.inline.StrongEmphasis
 import com.quarkdown.core.ast.base.inline.Text
 import com.quarkdown.core.ast.quarkdown.block.Box
+import com.quarkdown.core.ast.quarkdown.block.Markdown
 import com.quarkdown.core.ast.quarkdown.block.Math
 import com.quarkdown.core.ast.quarkdown.block.MermaidDiagram
 import com.quarkdown.core.ast.quarkdown.inline.Keybinding
@@ -160,6 +161,8 @@ class GfmNodeRenderer(
     override fun visit(node: ListItem) = node.visitChildren().toString().trimEnd()
 
     override fun visit(node: Html) = ""
+
+    override fun visit(node: Markdown) = node.content.blockNode
 
     override fun visit(node: Table) =
         buildString {

--- a/quarkdown-markdown/src/test/kotlin/com/quarkdown/rendering/markdown/GfmNodeRendererTest.kt
+++ b/quarkdown-markdown/src/test/kotlin/com/quarkdown/rendering/markdown/GfmNodeRendererTest.kt
@@ -25,6 +25,7 @@ import com.quarkdown.core.ast.dsl.buildInline
 import com.quarkdown.core.ast.quarkdown.block.Box
 import com.quarkdown.core.ast.quarkdown.block.FileTree
 import com.quarkdown.core.ast.quarkdown.block.FileTreeEntry
+import com.quarkdown.core.ast.quarkdown.block.Markdown
 import com.quarkdown.core.ast.quarkdown.block.Math
 import com.quarkdown.core.ast.quarkdown.block.MermaidDiagram
 import com.quarkdown.core.ast.quarkdown.block.toc.TableOfContentsView
@@ -243,6 +244,14 @@ class GfmNodeRendererTest {
         assertEquals(
             "",
             Html("<div>Hello</div>").render(),
+        )
+    }
+
+    @Test
+    fun markdown() {
+        assertEquals(
+            "> A blockquote only visible in Markdown output.\n\n",
+            Markdown("> A blockquote only visible in Markdown output.").render(),
         )
     }
 
@@ -572,7 +581,7 @@ class GfmNodeRendererTest {
         assertEquals("\\[note", Text("[note").render())
         assertEquals("\\<div>", Text("<div>").render())
         assertEquals("path\\\\to", Text("path\\to").render())
-        assertEquals("\\\$5", Text("\$5").render())
+        assertEquals("\\$5", Text("$5").render())
     }
 
     @Test

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Markdown.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Markdown.kt
@@ -1,0 +1,41 @@
+@file:QModule
+
+package com.quarkdown.stdlib
+
+import com.quarkdown.core.ast.quarkdown.block.Markdown
+import com.quarkdown.core.context.Context
+import com.quarkdown.core.function.reflect.annotation.Injected
+import com.quarkdown.core.function.reflect.annotation.LikelyBody
+import com.quarkdown.core.function.value.NodeValue
+import com.quarkdown.core.function.value.wrappedAsValue
+import com.quarkdown.core.permissions.Permission
+import com.quarkdown.core.permissions.requirePermission
+import com.quarkdown.processor.annotation.QFunction
+import com.quarkdown.processor.annotation.QModule
+
+/**
+ * Creates a block of raw Markdown content that is emitted verbatim only when the rendering target is Markdown.
+ * Non-Markdown targets, such as HTML and plain text, discard the content.
+ *
+ * ```markdown
+ * .markdown
+ *     > This blockquote only appears in Markdown output.
+ * ```
+ *
+ * @param content raw Markdown content to inject
+ * @return a new [Markdown] node
+ * @permission [Permission.NativeContent] to inject native Markdown content
+ * @throws com.quarkdown.core.permissions.MissingPermissionException if [Permission.NativeContent] is not granted
+ * @wiki markdown-content
+ */
+@QFunction
+fun markdown(
+    @Injected context: Context,
+    @LikelyBody content: String,
+): NodeValue {
+    context.requirePermission(
+        Permission.NativeContent,
+        message = "Cannot inject native Markdown content",
+    )
+    return Markdown(content).wrappedAsValue()
+}

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Stdlib.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Stdlib.kt
@@ -43,6 +43,7 @@ object Stdlib : LibraryExporter {
                     Slides.Module,
                     Ecosystem.Module,
                     Html.Module,
+                    Markdown.Module,
                     Mermaid.Module,
                     Reference.Module,
                     Bibliography.Module,

--- a/quarkdown-test/src/test/kotlin/com/quarkdown/test/PermissionTest.kt
+++ b/quarkdown-test/src/test/kotlin/com/quarkdown/test/PermissionTest.kt
@@ -134,6 +134,24 @@ class PermissionTest {
         }
     }
 
+    @Test
+    fun `markdown with NativeContent succeeds`() {
+        execute(
+            ".markdown {> hello}",
+            permissions = setOf(NativeContent),
+        ) {}
+    }
+
+    @Test
+    fun `markdown without NativeContent fails`() {
+        assertFailsWith<MissingPermissionException> {
+            execute(
+                ".markdown {> hello}",
+                permissions = emptySet(),
+            ) {}
+        }
+    }
+
     // Subdocument read permissions
 
     @Test


### PR DESCRIPTION
- [x] I have read the [contributing guidelines](https://github.com/iamgio/quarkdown/blob/main/CONTRIBUTING.md).
- [x] I have tested the changes locally.
- [ ] An issue for this change exists, and it was discussed with maintainers. This is required for new features and non-trivial changes. If present, append `Closes #ISSUE_NUMBER` at the end of this PR description.
- [x] (Optional) I have added necessary documentation to [`docs`](https://github.com/iamgio/quarkdown/tree/main/docs) and [`CHANGELOG.md`](https://github.com/iamgio/quarkdown/blob/main/CHANGELOG.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
    - Added a `.markdown` function for inserting raw Markdown content during Markdown export.
    - Raw Markdown is ignored when exporting to other formats.
    - Access requires native-content permission.
- **Documentation**
    - Documented the new `.markdown` function in the unreleased changelog.
- **Tests**
    - Added coverage for rendering raw Markdown content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->