### PR TITLE
feat(html): add built-in llmstxt support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,15 @@ See [SEO & AEO optimization](https://quarkdown.com/wiki/seo-aeo-optimization) fo
 
 The new `.markdown` function lets you include raw Markdown content when exporting to Markdown.
 
+#### [Built-in llms.txt support](https://quarkdown.com/wiki/seo-aeo-optimization)
+
+`llms.txt` is a Markdown file at the root of a site that curates the most useful entry points for AI agents and LLM-based crawlers, giving them a reliable map of the documentation.
+The new `.llmstxt` function emits a discoverability directive on every page, pointing AI agents at your site's `llms.txt` and, optionally, at the Markdown counterpart of the current page.
+
+```markdown
+.llmstxt path:{/llms.txt} markdownavailable:{yes}
+```
+
 #### [Code block primitive](https://quarkdown.com/wiki/primitives)
 
 `.code` is now a [primitive](https://quarkdown.com/wiki/primitives), so it can be intercepted via `.extend {code}` to customize the appearance of every code block in the document.

--- a/docs/_setup.qd
+++ b/docs/_setup.qd
@@ -9,6 +9,8 @@
 .numbering
     - example: 1
 
+.llmstxt {/wiki/llms.txt} markdownavailable:{yes}
+
 .html {.read {assets/analytics.html}}
 .css {.read {assets/style.css}}
 

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -1,0 +1,15 @@
+# Quarkdown Wiki
+
+> Official documentation for Quarkdown, a modern, open-source typesetting system that extends Markdown with powerful features inspired by LaTeX. It compiles Markdown-based documents into PDF, HTML, MD, TXT.
+
+Every wiki page is available in raw Markdown as well as HTML. Each rendered page carries a directive that links directly to its `.md` counterpart.
+
+## Navigation
+
+- [Wiki navigation source](https://raw.githubusercontent.com/iamgio/quarkdown/refs/heads/main/docs/_nav.qd): the canonical, human-curated table of contents, grouped by topic. Each entry is a link to a `.qd` source file; replace `.qd` with `.md` in the corresponding wiki URL to fetch the rendered Markdown.
+- [Sitemap](https://quarkdown.com/wiki/sitemap.xml): auto-generated list of every page in the wiki.
+
+## Reference
+
+- [Stdlib API](https://quarkdown.com/docs/quarkdown-stdlib/): full function reference for the latest stable release.
+- [Main website](https://quarkdown.com): the official Quarkdown website, with links to the latest release, installation instructions, and more.

--- a/docs/seo-aeo-optimization.qd
+++ b/docs/seo-aeo-optimization.qd
@@ -49,7 +49,7 @@ By default, every page in a multi-subdocument project shows its own name in sear
 .example
     The HTML title will be *My document*:
     
-    ```
+    ```markdown
     .docname {My document}
     ```
 
@@ -58,7 +58,7 @@ The recommended pattern combines the subdocument's own name with the site name, 
 .example
     The HTML title will be *Subdocument name | My site* for non-root pages:
     
-    ```
+    ```markdown
     .ifnot {.docname::equals {My site}}
         .htmloptions title:{.docname | My site}
     ```
@@ -106,3 +106,23 @@ The second run writes `.md` files alongside the HTML output, so the result is a 
 
 .example
     This very page is readable in Markdown at [/wiki/seo-aeo-optimization.md](/wiki/seo-aeo-optimization.md?).
+
+## Pointing agents at `llms.txt`
+
+The [llms.txt convention](https://llmstxt.org) proposes a single Markdown file at the root of a site (`/llms.txt`) that curates the most useful entry points for LLM-based crawlers. Ship it as a [static asset](html-static-assets.qd) in `public/`, alongside `robots.txt`.
+
+Agents that fetch a rendered page, however, have no built-in way to discover that an index exists. To bridge this, add a short discoverability directive on every page using the **`.llmstxt`** function. This emits two variants of the same pointer:
+
+- A visually hidden HTML paragraph that stays out of the visual layout but remains in the DOM, so agents that fetch the HTML still see it.
+- A Markdown blockquote, emitted only when the target is Markdown, carrying the same pointer for agents that consume the `.md` version.
+
+Place the call in a shared setup file, so it appears on every subdocument:
+
+.example
+    > `_setup.qd`
+
+    ```markdown
+    .llmstxt path:{/llms.txt} markdownavailable:{yes}
+    ```
+
+Set `markdownavailable` to `yes` when the site also ships `.md` files (see [Shipping a Markdown copy](#shipping-a-markdown-copy)). In that case, the directive also tells agents how to fetch the raw Markdown of the current page.

--- a/quarkdown-html/src/main/scss/global.scss
+++ b/quarkdown-html/src/main/scss/global.scss
@@ -216,3 +216,15 @@
   --r-block-margin: var(--qd-block-margin);
   --r-heading-margin: var(--qd-heading-margin);
 }
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+  border: 0;
+}

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Html.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Html.kt
@@ -2,11 +2,15 @@
 
 package com.quarkdown.stdlib
 
+import com.quarkdown.core.ast.AstGroup
 import com.quarkdown.core.ast.base.block.Html
+import com.quarkdown.core.ast.quarkdown.block.Markdown
 import com.quarkdown.core.context.Context
 import com.quarkdown.core.context.MutableContext
 import com.quarkdown.core.context.options.HtmlOptions
 import com.quarkdown.core.context.options.merge
+import com.quarkdown.core.document.sub.Subdocument
+import com.quarkdown.core.document.sub.getOutputFileName
 import com.quarkdown.core.function.reflect.annotation.Injected
 import com.quarkdown.core.function.reflect.annotation.LikelyBody
 import com.quarkdown.core.function.value.NodeValue
@@ -15,6 +19,7 @@ import com.quarkdown.core.function.value.VoidValue
 import com.quarkdown.core.function.value.wrappedAsValue
 import com.quarkdown.core.permissions.Permission
 import com.quarkdown.core.permissions.requirePermission
+import com.quarkdown.core.util.Escape
 import com.quarkdown.processor.annotation.Name
 import com.quarkdown.processor.annotation.QFunction
 import com.quarkdown.processor.annotation.QModule
@@ -157,3 +162,56 @@ fun cssProperties(
         append("}")
     },
 )
+
+/**
+ * Emits a discoverability directive that points AI agents and LLM-based crawlers to the site's `llms.txt`.
+ *
+ * - A visually hidden HTML paragraph (`<p class="sr-only">`) that lets agents find it.
+ * - A Markdown blockquote, emitted only when the target is Markdown, carrying the same pointer for agents that consume the raw `.md` version of the page.
+ *
+ * Placing this call in a shared setup file (such as `_setup.qd` in `docs` projects) makes the directive appear on every page.
+ *
+ * @param path absolute URL of the `llms.txt` file, relative to the site root. Defaults to `/llms.txt`.
+ * @param isMarkdownAvailable whether the site also serves a Markdown counterpart for each page.
+ *                            When `true`, the HTML directive also links to this page's raw Markdown counterpart,
+ *                            computed automatically from the current subdocument.
+ * @return a compound node containing both the HTML directive and the Markdown directive
+ * @wiki seo-aeo-optimization
+ */
+@QFunction
+@Name("llmstxt")
+fun llmsTxt(
+    @Injected context: Context,
+    path: String = "/llms.txt",
+    @Name("markdownavailable") isMarkdownAvailable: Boolean,
+): NodeValue {
+    val markdownUrl = if (isMarkdownAvailable) getCurrentPageMarkdownUrl(context) else null
+    return AstGroup(
+        listOf(
+            Markdown("> For the complete documentation index, see [llms.txt]($path)."),
+            Html(
+                buildString {
+                    append("<p class=\"sr-only\" data-hidden=\"\">")
+                    append("For the complete documentation index, see <a href=\"$path\">llms.txt</a>.")
+                    if (markdownUrl != null) {
+                        append(" This page is also available as <a href=\"$markdownUrl\">Markdown</a>.")
+                    }
+                    append("</p>")
+                },
+            ),
+        ),
+    ).wrappedAsValue()
+}
+
+/**
+ * Page-relative URL of the current subdocument's Markdown counterpart.
+ * - Root: `index.md` sits next to `index.html`.
+ * - Subdocument: `<name>.md` sits one directory above `<name>/index.html`.
+ */
+private fun getCurrentPageMarkdownUrl(context: Context): String {
+    val name = context.subdocument.getOutputFileName(context).let(Escape.Url::escape)
+    return when (context.subdocument) {
+        Subdocument.Root -> "index.md"
+        else -> "../$name.md"
+    }
+}


### PR DESCRIPTION
- [x] I have read the [contributing guidelines](https://github.com/iamgio/quarkdown/blob/main/CONTRIBUTING.md).
- [x] I have tested the changes locally.
- [ ] An issue for this change exists, and it was discussed with maintainers. This is required for new features and non-trivial changes. If present, append `Closes #ISSUE_NUMBER` at the end of this PR description.
- [x] (Optional) I have added necessary documentation to [`docs`](https://github.com/iamgio/quarkdown/tree/main/docs) and [`CHANGELOG.md`](https://github.com/iamgio/quarkdown/blob/main/CHANGELOG.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added built-in support for publishing `llms.txt` resources.
  - Added the `.llmstxt` directive to expose `llms.txt` links in HTML and Markdown.
  - Added optional links to raw Markdown versions of pages.

- **Documentation**
  - Documented the `llms.txt` convention, configuration options, discoverability, and usage examples.
  - Added an `llms.txt` resource describing available documentation and API references.

- **Accessibility**
  - Added support for visually hidden content that remains readable by assistive technologies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->