### PR TITLE
fix(lexer): fix swallowed parentheses in link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+### Fixed
+
+#### Unbalanced parentheses in links
+
+An inline link `[text](url)` followed immediately by a closing parenthesis no longer swallows the trailing `)`. Plain link destinations now require parentheses to be either backslash-escaped or balanced, matching the CommonMark spec.
+
 ## [2.5.0] - 2026-08-04
 
 This release focuses on enhanced built-in LLM friendliness of sites produced by Quarkdown.  

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/lexer/patterns/BaseMarkdownInlineTokenRegexPatterns.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/lexer/patterns/BaseMarkdownInlineTokenRegexPatterns.kt
@@ -103,7 +103,7 @@ open class BaseMarkdownInlineTokenRegexPatterns {
             regex =
                 RegexBuilder("\\[(label)\\]\\(\\s*(href)(?:\\s+(title))?\\s*\\)")
                     .withReference("label", LABEL_HELPER)
-                    .withReference("href", "<(?:\\\\.|[^\\n<>\\\\])+>|[^\\s\\x00-\\x1f]*")
+                    .withReference("href", "<(?:\\\\.|[^\\n<>\\\\])+>|$PLAIN_HREF_HELPER")
                     .withReference("title", PatternHelpers.DELIMITED_TITLE)
                     .build(),
         )
@@ -327,6 +327,14 @@ private const val PUNCTUATION_HELPER = "\\p{P}\\p{S}"
 private const val LABEL_HELPER = "(?:\\[(?:\\\\.|[^\\[\\]\\\\])*\\]|\\\\.|`[^`]*`|[^\\[\\]\\\\`])*?"
 
 private const val BLOCK_LABEL_HELPER = "(?!\\s*\\])(?:\\\\.|[^\\[\\]\\\\])+"
+
+// A single character allowed inside a plain (non-angle-bracket) link destination:
+// any non-whitespace, non-control, non-paren, non-backslash character, or an escaped character.
+private const val PLAIN_HREF_CHAR = "(?:[^\\s\\x00-\\x1f()\\\\]|\\\\.)"
+
+// CommonMark 6.4 requires parentheses in a plain link destination to be either backslash-escaped or balanced.
+private const val PLAIN_HREF_HELPER =
+    "(?:$PLAIN_HREF_CHAR|\\((?:$PLAIN_HREF_CHAR|\\((?:$PLAIN_HREF_CHAR)*\\))*\\))*"
 
 // Width and height separator in images.
 private const val IMAGE_SIZE_DIVIDER_HELPER = "(?:[* \\t]|(?<![a-zA-Z])x)" // 1*1, 1cm*1cm, 1 1, 1cm 1cm, 1x1 but not 1cmx1cm

--- a/quarkdown-core/src/test/kotlin/com/quarkdown/core/InlineParserTest.kt
+++ b/quarkdown-core/src/test/kotlin/com/quarkdown/core/InlineParserTest.kt
@@ -129,6 +129,36 @@ class InlineParserTest {
         }
 
         assertFalse(nodes.hasNext())
+
+        // Destination stops at an unbalanced closing paren, and the trailing `)` becomes text.
+        val unbalanced = inlineIterator<Node>("text ([link](https://example.com)).", assertType = false)
+        assertEquals("text (", (unbalanced.next() as Text).text)
+        with(unbalanced.next()) {
+            assertIs<Link>(this)
+            assertEquals("https://example.com", url)
+        }
+        assertEquals(").", (unbalanced.next() as Text).text)
+        assertFalse(unbalanced.hasNext())
+
+        // Whitespace before a trailing `)` doesn't rescue the destination either.
+        val trailingSpace = inlineIterator<Node>("([link](https://example.com) )", assertType = false)
+        assertEquals("(", (trailingSpace.next() as Text).text)
+        with(trailingSpace.next()) {
+            assertIs<Link>(this)
+            assertEquals("https://example.com", url)
+        }
+        assertEquals(" )", (trailingSpace.next() as Text).text)
+        assertFalse(trailingSpace.hasNext())
+
+        // Balanced parens (single and nested) are preserved inside the destination.
+        assertEquals(
+            "https://en.wikipedia.org/wiki/Markdown_(software)",
+            inlineIterator<Link>("[link](https://en.wikipedia.org/wiki/Markdown_(software))").next().url,
+        )
+        assertEquals(
+            "foo(and(bar))",
+            inlineIterator<Link>("[link](foo(and(bar)))").next().url,
+        )
     }
 
     @Test

--- a/quarkdown-test/src/test/kotlin/com/quarkdown/test/LinkTest.kt
+++ b/quarkdown-test/src/test/kotlin/com/quarkdown/test/LinkTest.kt
@@ -59,6 +59,13 @@ class LinkTest {
     }
 
     @Test
+    fun `link in parenthetical does not swallow trailing paren`() {
+        execute("text ([link](https://example.com)).") {
+            assertEquals("<p>text (<a href=\"https://example.com\">link</a>).</p>", it)
+        }
+    }
+
+    @Test
     fun `reference link`() {
         execute(
             """


### PR DESCRIPTION
- [x] I have read the [contributing guidelines](https://github.com/iamgio/quarkdown/blob/main/CONTRIBUTING.md).
- [x] I have tested the changes locally.
- [x] An issue for this change exists, and it was discussed with maintainers. This is required for new features and non-trivial changes. If present, append `Closes #ISSUE_NUMBER` at the end of this PR description.
- [x] (Optional) I have added necessary documentation to [`docs`](https://github.com/iamgio/quarkdown/tree/main/docs) and [`CHANGELOG.md`](https://github.com/iamgio/quarkdown/blob/main/CHANGELOG.md)

Closes #624

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Markdown links followed immediately by a closing parenthesis so the parenthesis is preserved correctly.
  * Improved parsing of plain link destinations with balanced or escaped parentheses.
  * Prevented trailing whitespace and unmatched parentheses from being incorrectly included in link URLs.

* **Tests**
  * Added coverage for nested parentheses, trailing text, whitespace, and links enclosed in parentheses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->