### PR TITLE
refactor(cli): make pipeline error handling embedding-friendly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+### Changed
+
+#### [dev] Embedding-friendly pipeline error handling
+
+The programmatic pipeline entry point `runQuarkdown` no longer terminates the host JVM on pipeline errors, in favor of propagation to the caller.
+
 ### Fixed
 
 #### Unbalanced parentheses in links

--- a/quarkdown-cli/src/main/kotlin/com/quarkdown/cli/exec/Execute.kt
+++ b/quarkdown-cli/src/main/kotlin/com/quarkdown/cli/exec/Execute.kt
@@ -7,21 +7,24 @@ import com.quarkdown.cli.lib.QdLibraries
 import com.quarkdown.cli.util.cleanDirectory
 import com.quarkdown.core.flavor.MarkdownFlavor
 import com.quarkdown.core.flavor.quarkdown.QuarkdownFlavor
-import com.quarkdown.core.function.error.FunctionCallRuntimeException
 import com.quarkdown.core.function.library.LibraryExporter
 import com.quarkdown.core.log.Log
 import com.quarkdown.core.pipeline.Pipeline
 import com.quarkdown.core.pipeline.PipelineOptions
 import com.quarkdown.core.pipeline.error.PipelineException
 import com.quarkdown.core.pipeline.output.visitor.saveTo
-import kotlin.system.exitProcess
 
 /**
  * Executes a complete Quarkdown pipeline.
+ *
+ * This is the entry point used by both the CLI and any in-process embedder.
+ * On any [PipelineException] the exception propagates to the caller, for embedders to catch and handle.
+ *
  * @param executionStrategy launch strategy of the pipeline, e.g. from file or REPL
  * @param cliOptions options that define the behavior of the CLI, especially I/O
  * @param pipelineOptions options that define the behavior of the pipeline
- * @return the output file or directory, if any, associated with the executed pipeline
+ * @return the outcome of the executed pipeline, carrying the produced resource and directory (if any)
+ * @throws PipelineException if the pipeline fails and its error handler rethrows the error
  */
 fun runQuarkdown(
     executionStrategy: PipelineExecutionStrategy,
@@ -54,21 +57,15 @@ fun runQuarkdown(
     // Output directory to save the generated resources in.
     val outputDirectory = cliOptions.outputDirectory
 
-    try {
-        // Cleans the output directory if enabled in options.
-        if (cliOptions.clean) {
-            outputDirectory?.cleanDirectory()
-        }
-
-        // Pipeline execution and output resource retrieving.
-        val resource = executionStrategy.execute(pipeline)
-        // Exports the generated resources to file if enabled in options.
-        val childDirectory = outputDirectory?.let { resource?.saveTo(it) }
-
-        return ExecutionOutcome(resource, childDirectory, pipeline)
-    } catch (e: PipelineException) {
-        val targetException = (e as? FunctionCallRuntimeException)?.cause ?: e
-        targetException.printStackTrace()
-        exitProcess(e.code)
+    // Cleans the output directory if enabled in options.
+    if (cliOptions.clean) {
+        outputDirectory?.cleanDirectory()
     }
+
+    // Pipeline execution and output resource retrieving.
+    val resource = executionStrategy.execute(pipeline)
+    // Exports the generated resources to file if enabled in options.
+    val childDirectory = outputDirectory?.let { resource?.saveTo(it) }
+
+    return ExecutionOutcome(resource, childDirectory, pipeline)
 }

--- a/quarkdown-cli/src/main/kotlin/com/quarkdown/cli/exec/ExecuteCommand.kt
+++ b/quarkdown-cli/src/main/kotlin/com/quarkdown/cli/exec/ExecuteCommand.kt
@@ -18,11 +18,13 @@ import com.quarkdown.cli.util.runWithTimeout
 import com.quarkdown.cli.watcher.DirectoryWatcher
 import com.quarkdown.core.TIMEOUT_EXIT_CODE
 import com.quarkdown.core.document.sub.SubdocumentOutputNaming
+import com.quarkdown.core.function.error.FunctionCallRuntimeException
 import com.quarkdown.core.log.Log
 import com.quarkdown.core.media.storage.options.ReadOnlyMediaStorageOptions
 import com.quarkdown.core.permissions.Permission
 import com.quarkdown.core.pipeline.PipelineOptions
 import com.quarkdown.core.pipeline.error.BasePipelineErrorHandler
+import com.quarkdown.core.pipeline.error.PipelineException
 import com.quarkdown.core.pipeline.error.StrictPipelineErrorHandler
 import com.quarkdown.core.util.kebabCaseName
 import com.quarkdown.installlayout.InstallLayout
@@ -323,14 +325,20 @@ abstract class ExecuteCommand(
         this.preExecute(cliOptions, pipelineOptions)
 
         val outcome: ExecutionOutcome =
-            runWithTimeout(
-                timeoutSeconds,
-                onTimeout = { e ->
-                    Log.error("Execution timed out (--timeout ${e.timeoutSeconds}).")
-                    throw ProgramResult(TIMEOUT_EXIT_CODE)
-                },
-            ) {
-                runQuarkdown(strategy, cliOptions, pipelineOptions)
+            try {
+                runWithTimeout(
+                    timeoutSeconds,
+                    onTimeout = { e ->
+                        Log.error("Execution timed out (--timeout ${e.timeoutSeconds}).")
+                        throw ProgramResult(TIMEOUT_EXIT_CODE)
+                    },
+                ) {
+                    runQuarkdown(strategy, cliOptions, pipelineOptions)
+                }
+            } catch (e: PipelineException) {
+                val targetException = (e as? FunctionCallRuntimeException)?.cause ?: e
+                targetException.printStackTrace()
+                throw ProgramResult(e.code)
             }
 
         this.postExecute(outcome, cliOptions, pipelineOptions)

--- a/quarkdown-cli/src/test/kotlin/com/quarkdown/cli/CompileCommandTest.kt
+++ b/quarkdown-cli/src/test/kotlin/com/quarkdown/cli/CompileCommandTest.kt
@@ -5,6 +5,7 @@ import com.github.ajalt.clikt.testing.CliktCommandTestResult
 import com.github.ajalt.clikt.testing.test
 import com.quarkdown.cli.exec.CompileCommand
 import com.quarkdown.core.TIMEOUT_EXIT_CODE
+import com.quarkdown.core.UNRESOLVED_REFERENCE_EXIT_CODE
 import com.quarkdown.core.permissions.Permission
 import com.quarkdown.core.pipeline.PipelineOptions
 import com.quarkdown.core.pipeline.error.BasePipelineErrorHandler
@@ -132,6 +133,26 @@ class CompileCommandTest : TempDirectory() {
         val (_, pipelineOptions) = test("--strict")
         assertHtmlContentPresent()
         assertIs<StrictPipelineErrorHandler>(pipelineOptions.errorHandler)
+    }
+
+    @Test
+    fun `strict-mode pipeline error surfaces the exit code without killing the JVM`() {
+        main.writeText(
+            """
+            .docname {Failing document}
+            .doctype {plain}
+
+            .thisFunctionDoesNotExist
+            """.trimIndent(),
+        )
+        val result =
+            CompileCommand().test(
+                main.absolutePath,
+                "-o",
+                outputDirectory.absolutePath,
+                "--strict",
+            )
+        assertEquals(UNRESOLVED_REFERENCE_EXIT_CODE, result.statusCode)
     }
 
     @Test

--- a/quarkdown-cli/src/test/kotlin/com/quarkdown/cli/ExecuteTest.kt
+++ b/quarkdown-cli/src/test/kotlin/com/quarkdown/cli/ExecuteTest.kt
@@ -1,0 +1,86 @@
+package com.quarkdown.cli
+
+import com.quarkdown.cli.exec.runQuarkdown
+import com.quarkdown.cli.exec.strategy.FileExecutionStrategy
+import com.quarkdown.core.UNRESOLVED_REFERENCE_EXIT_CODE
+import com.quarkdown.core.pipeline.PipelineOptions
+import com.quarkdown.core.pipeline.error.PipelineException
+import com.quarkdown.core.pipeline.error.StrictPipelineErrorHandler
+import java.io.File
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
+
+/**
+ * Tests for the programmatic pipeline entry point [runQuarkdown].
+ *
+ * These tests guard the embedding contract: `runQuarkdown` must never terminate the JVM.
+ * On success it returns an outcome; on failure it propagates a [PipelineException] so an
+ * in-process embedder (LSP, preview server, test harness) can catch and recover.
+ */
+class ExecuteTest : TempDirectory() {
+    private val source = File(directory, "main.qd")
+    private val outputDirectory = File(directory, "out")
+
+    @BeforeTest
+    fun setup() {
+        super.reset()
+    }
+
+    private fun cliOptions() =
+        CliOptions(
+            source = source,
+            outputDirectory = outputDirectory,
+            libraryDirectory = null,
+            rendererName = "html",
+            clean = false,
+            pipe = false,
+            nodePath = "",
+            npmPath = "",
+        )
+
+    private fun pipelineOptions(strict: Boolean) =
+        PipelineOptions(
+            workingDirectory = source.absoluteFile.parentFile,
+            enableMediaStorage = false,
+            errorHandler = if (strict) StrictPipelineErrorHandler() else PipelineOptions().errorHandler,
+        )
+
+    @Test
+    fun `runQuarkdown returns an outcome on success`() {
+        source.writeText(
+            """
+            .docname {Programmatic entry test}
+            .doctype {plain}
+
+            Hello world.
+            """.trimIndent(),
+        )
+
+        val outcome = runQuarkdown(FileExecutionStrategy(source), cliOptions(), pipelineOptions(strict = false))
+
+        assertNotNull(outcome.resource)
+        assertNotNull(outcome.directory)
+    }
+
+    @Test
+    fun `runQuarkdown propagates PipelineException in strict mode instead of exiting`() {
+        source.writeText(
+            """
+            .docname {Failing document}
+            .doctype {plain}
+
+            .thisFunctionDoesNotExist
+            """.trimIndent(),
+        )
+
+        val exception =
+            assertFailsWith<PipelineException> {
+                runQuarkdown(FileExecutionStrategy(source), cliOptions(), pipelineOptions(strict = true))
+            }
+
+        assertEquals(UNRESOLVED_REFERENCE_EXIT_CODE, exception.code)
+    }
+}


### PR DESCRIPTION
- [x] I have read the [contributing guidelines](https://github.com/iamgio/quarkdown/blob/main/CONTRIBUTING.md).
- [x] I have tested the changes locally.
- [ ] An issue for this change exists, and it was discussed with maintainers. This is required for new features and non-trivial changes. If present, append `Closes #ISSUE_NUMBER` at the end of this PR description.
- [x] (Optional) I have added necessary documentation to [`docs`](https://github.com/iamgio/quarkdown/tree/main/docs) and [`CHANGELOG.md`](https://github.com/iamgio/quarkdown/blob/main/CHANGELOG.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Pipeline errors now propagate correctly when running Quarkdown programmatically, without terminating the host application.
  - CLI execution still reports appropriate error codes and displays useful stack traces.

- **Tests**
  - Added coverage for successful in-process execution.
  - Added regression tests for strict-mode unresolved references and expected exit codes.

- **Documentation**
  - Documented improved error handling for embedded and in-process usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->