### PR TITLE
refactor(cli): move timeout raising from command to runQuarkdown

### DIFF
--- a/quarkdown-cli/src/main/kotlin/com/quarkdown/cli/CliOptions.kt
+++ b/quarkdown-cli/src/main/kotlin/com/quarkdown/cli/CliOptions.kt
@@ -16,6 +16,8 @@ import java.io.File
  * @param npmPath path to the npm executable
  * @param exportPdf whether to generate a PDF file
  * @param noPdfSandbox whether to disable the Chrome sandbox for PDF export
+ * @param timeoutSeconds maximum time, in seconds, allowed for the pipeline execution to complete.
+ * `null` (default) or non-positive disables the timeout and runs the pipeline inline on the current thread.
  */
 data class CliOptions(
     val source: File?,
@@ -28,6 +30,7 @@ data class CliOptions(
     val npmPath: String,
     val exportPdf: Boolean = false,
     val noPdfSandbox: Boolean = false,
+    val timeoutSeconds: Int? = null,
 ) {
     /**
      * The rendering target to generate the output for.

--- a/quarkdown-cli/src/main/kotlin/com/quarkdown/cli/exec/Execute.kt
+++ b/quarkdown-cli/src/main/kotlin/com/quarkdown/cli/exec/Execute.kt
@@ -5,6 +5,7 @@ import com.quarkdown.cli.PipelineInitialization
 import com.quarkdown.cli.exec.strategy.PipelineExecutionStrategy
 import com.quarkdown.cli.lib.QdLibraries
 import com.quarkdown.cli.util.cleanDirectory
+import com.quarkdown.cli.util.runWithTimeout
 import com.quarkdown.core.flavor.MarkdownFlavor
 import com.quarkdown.core.flavor.quarkdown.QuarkdownFlavor
 import com.quarkdown.core.function.library.LibraryExporter
@@ -19,12 +20,14 @@ import com.quarkdown.core.pipeline.output.visitor.saveTo
  *
  * This is the entry point used by both the CLI and any in-process embedder.
  * On any [PipelineException] the exception propagates to the caller, for embedders to catch and handle.
+ * If [CliOptions.timeoutSeconds] is set and expires, an [ExecutionTimeoutException] is raised instead.
  *
  * @param executionStrategy launch strategy of the pipeline, e.g. from file or REPL
- * @param cliOptions options that define the behavior of the CLI, especially I/O
+ * @param cliOptions options that define the behavior of the CLI, especially I/O and the execution timeout
  * @param pipelineOptions options that define the behavior of the pipeline
  * @return the outcome of the executed pipeline, carrying the produced resource and directory (if any)
  * @throws PipelineException if the pipeline fails and its error handler rethrows the error
+ * @throws ExecutionTimeoutException if [CliOptions.timeoutSeconds] is set and the execution exceeds it
  */
 fun runQuarkdown(
     executionStrategy: PipelineExecutionStrategy,
@@ -62,10 +65,10 @@ fun runQuarkdown(
         outputDirectory?.cleanDirectory()
     }
 
-    // Pipeline execution and output resource retrieving.
-    val resource = executionStrategy.execute(pipeline)
-    // Exports the generated resources to file if enabled in options.
-    val childDirectory = outputDirectory?.let { resource?.saveTo(it) }
-
-    return ExecutionOutcome(resource, childDirectory, pipeline)
+    // Pipeline execution.
+    return runWithTimeout(cliOptions.timeoutSeconds) {
+        val resource = executionStrategy.execute(pipeline)
+        val childDirectory = outputDirectory?.let { resource?.saveTo(it) }
+        ExecutionOutcome(resource, childDirectory, pipeline)
+    }
 }

--- a/quarkdown-cli/src/main/kotlin/com/quarkdown/cli/exec/ExecuteCommand.kt
+++ b/quarkdown-cli/src/main/kotlin/com/quarkdown/cli/exec/ExecuteCommand.kt
@@ -14,7 +14,6 @@ import com.quarkdown.cli.CliOptions
 import com.quarkdown.cli.exec.strategy.PipelineExecutionStrategy
 import com.quarkdown.cli.server.DEFAULT_SERVER_PORT
 import com.quarkdown.cli.util.checkCleanSafety
-import com.quarkdown.cli.util.runWithTimeout
 import com.quarkdown.cli.watcher.DirectoryWatcher
 import com.quarkdown.core.TIMEOUT_EXIT_CODE
 import com.quarkdown.core.document.sub.SubdocumentOutputNaming
@@ -221,6 +220,7 @@ abstract class ExecuteCommand(
             pipe = false,
             nodePath,
             npmPath,
+            timeoutSeconds = timeoutSeconds,
         ).let(::finalizeCliOptions)
 
     /**
@@ -314,7 +314,8 @@ abstract class ExecuteCommand(
     /**
      * Executes the Quarkdown pipeline: compiles and generates output files.
      * [preExecute] and [postExecute] are called before and after the execution respectively.
-     * If [timeoutSeconds] is set, the execution is bounded by the specified duration.
+     * The optional timeout carried in [CliOptions.timeoutSeconds] is applied inside [runQuarkdown];
+     * this boundary only translates the resulting exceptions into CLI exit codes.
      */
     private fun execute(
         cliOptions: CliOptions,
@@ -326,15 +327,10 @@ abstract class ExecuteCommand(
 
         val outcome: ExecutionOutcome =
             try {
-                runWithTimeout(
-                    timeoutSeconds,
-                    onTimeout = { e ->
-                        Log.error("Execution timed out (--timeout ${e.timeoutSeconds}).")
-                        throw ProgramResult(TIMEOUT_EXIT_CODE)
-                    },
-                ) {
-                    runQuarkdown(strategy, cliOptions, pipelineOptions)
-                }
+                runQuarkdown(strategy, cliOptions, pipelineOptions)
+            } catch (e: ExecutionTimeoutException) {
+                Log.error("Execution timed out (--timeout ${e.timeoutSeconds}).")
+                throw ProgramResult(TIMEOUT_EXIT_CODE)
             } catch (e: PipelineException) {
                 val targetException = (e as? FunctionCallRuntimeException)?.cause ?: e
                 targetException.printStackTrace()

--- a/quarkdown-cli/src/test/kotlin/com/quarkdown/cli/ExecuteTest.kt
+++ b/quarkdown-cli/src/test/kotlin/com/quarkdown/cli/ExecuteTest.kt
@@ -1,11 +1,15 @@
 package com.quarkdown.cli
 
+import com.quarkdown.cli.exec.ExecutionTimeoutException
 import com.quarkdown.cli.exec.runQuarkdown
 import com.quarkdown.cli.exec.strategy.FileExecutionStrategy
+import com.quarkdown.cli.exec.strategy.PipelineExecutionStrategy
 import com.quarkdown.core.UNRESOLVED_REFERENCE_EXIT_CODE
+import com.quarkdown.core.pipeline.Pipeline
 import com.quarkdown.core.pipeline.PipelineOptions
 import com.quarkdown.core.pipeline.error.PipelineException
 import com.quarkdown.core.pipeline.error.StrictPipelineErrorHandler
+import com.quarkdown.core.pipeline.output.OutputResource
 import java.io.File
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -82,5 +86,34 @@ class ExecuteTest : TempDirectory() {
             }
 
         assertEquals(UNRESOLVED_REFERENCE_EXIT_CODE, exception.code)
+    }
+
+    @Test
+    fun `runQuarkdown enforces timeoutSeconds from CliOptions`() {
+        val blockingStrategy =
+            object : PipelineExecutionStrategy {
+                override fun execute(pipeline: Pipeline): OutputResource? {
+                    Thread.sleep(60_000)
+                    return null
+                }
+            }
+
+        val cli = cliOptions().copy(timeoutSeconds = 1)
+
+        val exception =
+            assertFailsWith<ExecutionTimeoutException> {
+                runQuarkdown(blockingStrategy, cli, pipelineOptions(strict = false))
+            }
+
+        assertEquals(1, exception.timeoutSeconds)
+    }
+
+    @Test
+    fun `null timeoutSeconds runs inline without wrapping`() {
+        source.writeText("Trivial body.")
+        val cli = cliOptions().copy(timeoutSeconds = null)
+        // Should complete without a timeout firing.
+        val outcome = runQuarkdown(FileExecutionStrategy(source), cli, pipelineOptions(strict = false))
+        assertNotNull(outcome.resource)
     }
 }


### PR DESCRIPTION
- [X] I have read the [contributing guidelines](https://github.com/iamgio/quarkdown/blob/main/CONTRIBUTING.md).
- [X] I have tested the changes locally.
- [ ] An issue for this change exists, and it was discussed with maintainers. This is required for new features and non-trivial changes. If present, append `Closes #ISSUE_NUMBER` at the end of this PR description.
- [ ] (Optional) I have added necessary documentation to [`docs`](https://github.com/iamgio/quarkdown/tree/main/docs) and [`CHANGELOG.md`](https://github.com/iamgio/quarkdown/blob/main/CHANGELOG.md)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable pipeline execution timeouts in seconds.
  * Timeouts can be disabled by leaving the setting empty or using a non-positive value.
* **Bug Fixes**
  * Improved timeout handling so exceeded execution limits produce the appropriate CLI message and exit status.
* **Tests**
  * Added coverage for timed-out executions and disabled-timeout behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->