### PR TITLE
fix(html): add trailing slash to subdocument links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ An inline link `[text](url)` followed immediately by a closing parenthesis no lo
 
 Nested lists that use 4 spaces of indentation at every level now render correctly at three or more levels.
 
+#### Subdocument links missing a trailing slash
+
+Links to subdocuments in HTML output now end with a trailing slash, to minimize 404s on hosts that do not redirect to the trailing-slash form. The `<link rel="canonical">` tag, `sitemap.xml`, and the client-side search index now use the same form too.
+
 ## [2.5.0] - 2026-08-04
 
 This release focuses on enhanced built-in LLM friendliness of sites produced by Quarkdown.  

--- a/quarkdown-html/src/main/kotlin/com/quarkdown/rendering/html/node/BaseHtmlNodeRenderer.kt
+++ b/quarkdown-html/src/main/kotlin/com/quarkdown/rendering/html/node/BaseHtmlNodeRenderer.kt
@@ -314,7 +314,10 @@ open class BaseHtmlNodeRenderer(
             buildString {
                 append(getPathToRoot())
                 append("/")
-                append(subdocument.getOutputFileName(context))
+                if (subdocument !is Subdocument.Root) {
+                    append(subdocument.getOutputFileName(context))
+                    append("/")
+                }
                 node.anchor?.let { anchor ->
                     append("#")
                     append(anchor)

--- a/quarkdown-html/src/main/kotlin/com/quarkdown/rendering/html/post/document/HtmlDocumentBuilder.kt
+++ b/quarkdown-html/src/main/kotlin/com/quarkdown/rendering/html/post/document/HtmlDocumentBuilder.kt
@@ -117,7 +117,7 @@ class HtmlDocumentBuilder(
         val canonicalUrl =
             when (context.subdocument) {
                 Subdocument.Root -> baseUrl
-                else -> "$baseUrl/${context.subdocument.getOutputFileName(context).let(Escape.Url::escape)}"
+                else -> "$baseUrl/${context.subdocument.getOutputFileName(context).let(Escape.Url::escape)}/"
             }
 
         link(rel = "canonical", href = canonicalUrl)

--- a/quarkdown-html/src/main/kotlin/com/quarkdown/rendering/html/post/resources/SubdocumentMapperPostRendererResource.kt
+++ b/quarkdown-html/src/main/kotlin/com/quarkdown/rendering/html/post/resources/SubdocumentMapperPostRendererResource.kt
@@ -72,7 +72,7 @@ abstract class SubdocumentMapperPostRendererResource(
     /**
      * Absolute URL of a subdocument identified by its output name.
      * @param subdocumentOutputName the subdocument's output file name, before URL escaping
-     * @param extension optional file extension to append after the escaped name (e.g. `.md`), or `null` for none
+     * @param extension optional file extension to append after the escaped name (e.g. `.md`), or `null` for the HTML directory form
      * @return the absolute URL
      */
     protected fun getSubdocumentUrl(
@@ -83,7 +83,10 @@ abstract class SubdocumentMapperPostRendererResource(
             append(baseUrl)
             if (!baseUrl.endsWith('/')) append('/')
             append(Escape.Url.escape(subdocumentOutputName))
-            if (extension != null) append(extension)
+            when {
+                extension != null -> append(extension)
+                else -> append('/')
+            }
         }
 
     /**

--- a/quarkdown-html/src/main/kotlin/com/quarkdown/rendering/html/search/SearchIndexGenerator.kt
+++ b/quarkdown-html/src/main/kotlin/com/quarkdown/rendering/html/search/SearchIndexGenerator.kt
@@ -30,7 +30,7 @@ object SearchIndexGenerator {
                     val context = graph.withContexts[subdocument] ?: return@mapNotNull null
 
                     SearchEntry(
-                        url = "/" + if (subdocument is Subdocument.Root) "" else subdocument.getOutputFileName(context),
+                        url = "/" + if (subdocument is Subdocument.Root) "" else "${subdocument.getOutputFileName(context)}/",
                         title = context.documentInfo.name,
                         description = context.documentInfo.description,
                         keywords = context.documentInfo.keywords,

--- a/quarkdown-html/src/test/kotlin/com/quarkdown/rendering/html/SearchIndexGeneratorTest.kt
+++ b/quarkdown-html/src/test/kotlin/com/quarkdown/rendering/html/SearchIndexGeneratorTest.kt
@@ -114,7 +114,7 @@ class SearchIndexGeneratorTest {
                             headings = emptyList(),
                         ),
                         SearchEntry(
-                            url = "/child",
+                            url = "/child/",
                             title = "Child Document",
                             description = "A child document",
                             keywords = listOf("child", "document"),

--- a/quarkdown-test/src/test/kotlin/com/quarkdown/test/HtmlOutputResourceTest.kt
+++ b/quarkdown-test/src/test/kotlin/com/quarkdown/test/HtmlOutputResourceTest.kt
@@ -171,8 +171,8 @@ class HtmlOutputResourceTest {
                 assertNotNull(sitemap)
                 val content = sitemap.content.toString()
                 assertContains(content, "<loc>https://example.com</loc>")
-                assertContains(content, "<loc>https://example.com/simple-1</loc>")
-                assertContains(content, "<loc>https://example.com/simple-2</loc>")
+                assertContains(content, "<loc>https://example.com/simple-1/</loc>")
+                assertContains(content, "<loc>https://example.com/simple-2/</loc>")
             },
         ) {}
     }
@@ -259,8 +259,9 @@ class HtmlOutputResourceTest {
                 // HTML root is served at the bare base URL, not at `<baseUrl>/index`.
                 assertContains(content, "[My site](https://example.com)")
                 assertFalse("[My site](https://example.com/index)" in content)
-                assertContains(content, "(https://example.com/simple-1)")
-                assertContains(content, "(https://example.com/simple-2)")
+                // Subdocuments are HTML directories, so URLs end with a trailing slash.
+                assertContains(content, "(https://example.com/simple-1/)")
+                assertContains(content, "(https://example.com/simple-2/)")
                 // No .md suffix since markdownavailable=false.
                 assertFalse(".md)" in content)
             },

--- a/quarkdown-test/src/test/kotlin/com/quarkdown/test/SubdocumentTest.kt
+++ b/quarkdown-test/src/test/kotlin/com/quarkdown/test/SubdocumentTest.kt
@@ -237,7 +237,7 @@ class SubdocumentTest {
                 assertContains(rootHtml, "href=\"https://example.com\" rel=\"canonical\"")
 
                 val subdocHtml = getSubdocumentResource(group, simpleSubdoc, this).content
-                assertContains(subdocHtml, "href=\"https://example.com/${simpleSubdoc.name}\" rel=\"canonical\"")
+                assertContains(subdocHtml, "href=\"https://example.com/${simpleSubdoc.name}/\" rel=\"canonical\"")
             },
         ) {}
     }
@@ -273,7 +273,7 @@ class SubdocumentTest {
                 },
             ) {
                 if (subdocument == Subdocument.Root) {
-                    assertEquals("<p>The link is: <a href=\"./simple-1\">1</a></p>", it)
+                    assertEquals("<p>The link is: <a href=\"./simple-1/\">1</a></p>", it)
                 }
             }
         }
@@ -293,7 +293,7 @@ class SubdocumentTest {
                 },
             ) {
                 if (subdocument == Subdocument.Root) {
-                    assertEquals("<p>The link is: <a href=\"./headings-1#a\">1</a></p>", it)
+                    assertEquals("<p>The link is: <a href=\"./headings-1/#a\">1</a></p>", it)
                 }
             }
         }
@@ -313,7 +313,7 @@ class SubdocumentTest {
                 },
             ) {
                 if (subdocument == Subdocument.Root) {
-                    assertEquals("<p>The link is: <a href=\"./simple-1\"></a></p>", it)
+                    assertEquals("<p>The link is: <a href=\"./simple-1/\"></a></p>", it)
                 }
             }
         }
@@ -460,9 +460,9 @@ class SubdocumentTest {
             ) {
                 if (subdocument.name == "nav-includer") {
                     assertEquals(
-                        "<ul><li><a href=\"../simple-1\">1</a></li>" +
-                            "<li><a href=\"../simple-2\">2</a></li>" +
-                            "<li><a href=\"../nav-includer\" aria-current=\"page\">3</a></li></ul>",
+                        "<ul><li><a href=\"../simple-1/\">1</a></li>" +
+                            "<li><a href=\"../simple-2/\">2</a></li>" +
+                            "<li><a href=\"../nav-includer/\" aria-current=\"page\">3</a></li></ul>",
                         it,
                     )
                 }
@@ -506,7 +506,7 @@ class SubdocumentTest {
         ) {
             if (subdocument == Subdocument.Root) {
                 assertEquals(
-                    "<p>..</p><p>..</p><p><a href=\"./subdoc\">1</a></p>",
+                    "<p>..</p><p>..</p><p><a href=\"./subdoc/\">1</a></p>",
                     it,
                 )
             } else {
@@ -526,7 +526,7 @@ class SubdocumentTest {
             useDummyLibraryDirectory = true,
         ) {
             if (subdocument == Subdocument.Root) {
-                assertEquals("<p><a href=\"./include-lib-1\">1</a></p>", it)
+                assertEquals("<p><a href=\"./include-lib-1/\">1</a></p>", it)
             } else {
                 assertEquals("<h2>Title</h2><p>Content</p>", it)
             }
@@ -541,7 +541,7 @@ class SubdocumentTest {
             useDummyLibraryDirectory = true,
         ) {
             if (subdocument == Subdocument.Root) {
-                assertEquals("<p><a href=\"./include-lib-2\">1</a></p>", it)
+                assertEquals("<p><a href=\"./include-lib-2/\">1</a></p>", it)
                 assertNull(getFunctionByName("hellofromlib"))
             } else {
                 assertEquals("", it)
@@ -558,7 +558,7 @@ class SubdocumentTest {
             useDummyLibraryDirectory = true,
         ) {
             if (subdocument == Subdocument.Root) {
-                assertEquals("<h2>Title</h2><p>Content</p><p><a href=\"./simple-1\">1</a></p>", it)
+                assertEquals("<h2>Title</h2><p>Content</p><p><a href=\"./simple-1/\">1</a></p>", it)
             } else {
                 assertEquals("<p>Hello 1</p>", it)
             }
@@ -573,7 +573,7 @@ class SubdocumentTest {
             useDummyLibraryDirectory = true,
         ) {
             if (subdocument == Subdocument.Root) {
-                assertEquals("<p>Hello, <em>X</em>!</p><p><a href=\"./simple-1\">1</a></p>", it)
+                assertEquals("<p>Hello, <em>X</em>!</p><p><a href=\"./simple-1/\">1</a></p>", it)
             } else {
                 assertEquals("<p>Hello 1</p>", it)
             }
@@ -589,7 +589,7 @@ class SubdocumentTest {
             useDummyLibraryDirectory = true,
         ) {
             if (subdocument == Subdocument.Root) {
-                assertEquals("<p><a href=\"./include-lib-2\">1</a></p><p><a href=\"./simple-1\">2</a></p>", it)
+                assertEquals("<p><a href=\"./include-lib-2/\">1</a></p><p><a href=\"./simple-1/\">2</a></p>", it)
                 assertNull(getFunctionByName("hellofromlib"))
             } else if (subdocument.name == "include-lib-2") {
                 assertEquals("", it)
@@ -609,7 +609,7 @@ class SubdocumentTest {
             useDummyLibraryDirectory = true,
         ) {
             if (subdocument == Subdocument.Root) {
-                assertEquals("<h2>Title</h2><p>Content</p><p><a href=\"./include-lib-1\">1</a></p>", it)
+                assertEquals("<h2>Title</h2><p>Content</p><p><a href=\"./include-lib-1/\">1</a></p>", it)
             } else {
                 assertEquals("<h2>Title</h2><p>Content</p>", it)
             }

--- a/quarkdown-test/src/test/resources/data/search-index/search-index-no-headings-no-metadata.json
+++ b/quarkdown-test/src/test/resources/data/search-index/search-index-no-headings-no-metadata.json
@@ -9,7 +9,7 @@
       "headings": []
     },
     {
-      "url": "/simple-1",
+      "url": "/simple-1/",
       "title": null,
       "description": null,
       "keywords": [],
@@ -17,7 +17,7 @@
       "headings": []
     },
     {
-      "url": "/simple-2",
+      "url": "/simple-2/",
       "title": null,
       "description": null,
       "keywords": [],

--- a/quarkdown-test/src/test/resources/data/search-index/search-index-no-headings-with-metadata.json
+++ b/quarkdown-test/src/test/resources/data/search-index/search-index-no-headings-with-metadata.json
@@ -9,7 +9,7 @@
       "headings": []
     },
     {
-      "url": "/simple-1",
+      "url": "/simple-1/",
       "title": "Test",
       "description": null,
       "keywords": [],
@@ -17,7 +17,7 @@
       "headings": []
     },
     {
-      "url": "/metadata",
+      "url": "/metadata/",
       "title": "Subdocument name",
       "description": "Subdocument description",
       "keywords": [

--- a/quarkdown-test/src/test/resources/data/search-index/search-index-with-headings.json
+++ b/quarkdown-test/src/test/resources/data/search-index/search-index-with-headings.json
@@ -9,7 +9,7 @@
       "headings": []
     },
     {
-      "url": "/headings-1",
+      "url": "/headings-1/",
       "title": "Test",
       "description": null,
       "keywords": [],
@@ -38,7 +38,7 @@
       ]
     },
     {
-      "url": "/headings-2",
+      "url": "/headings-2/",
       "title": "Test",
       "description": null,
       "keywords": [],


### PR DESCRIPTION
- [X] I have read the [contributing guidelines](https://github.com/iamgio/quarkdown/blob/main/CONTRIBUTING.md).
- [X] I have tested the changes locally.
- [X] An issue for this change exists, and it was discussed with maintainers. This is required for new features and non-trivial changes. If present, append `Closes #ISSUE_NUMBER` at the end of this PR description.
- [X] (Optional) I have added necessary documentation to [`docs`](https://github.com/iamgio/quarkdown/tree/main/docs) and [`CHANGELOG.md`](https://github.com/iamgio/quarkdown/blob/main/CHANGELOG.md)

Closes #628



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Updated HTML subdocument links to use consistent trailing-slash URLs.
  - Preserved the root document path format while correctly linking nested subdocuments.
  - Improved canonical URLs, anchor links, navigation paths, search results, sitemaps, and `llms.txt` references for subdocuments.
  - Continued supporting file-extension URLs where applicable.

- **Documentation**
  - Added an unreleased changelog entry documenting the updated link format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->