### PR TITLE
fix(lsp): fix out of bounds on completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ Nested lists that use 4 spaces of indentation at every level now render correctl
 
 Links to subdocuments in HTML output now end with a trailing slash, to minimize 404s on hosts that do not redirect to the trailing-slash form. The `<link rel="canonical">` tag, `sitemap.xml`, and the client-side search index now use the same form too.
 
+#### [lsp] Completion crash on out-of-bounds cursor position
+
+The language server no longer crashes when a completion request arrives with a cursor position outside the document bounds.
+
 ## [2.5.0] - 2026-08-04
 
 This release focuses on enhanced built-in LLM friendliness of sites produced by Quarkdown.  

--- a/quarkdown-lsp/src/main/kotlin/com/quarkdown/lsp/completion/function/AbstractFunctionCompletionSupplier.kt
+++ b/quarkdown-lsp/src/main/kotlin/com/quarkdown/lsp/completion/function/AbstractFunctionCompletionSupplier.kt
@@ -15,8 +15,8 @@ import java.io.File
 /**
  * Provides completion items for function calls by scanning documentation files.
  * @param docsDirectory the directory containing the documentation files to extract function data from
- * @see com.quarkdown.lsp.completion.function.impl.parameter
- * @see com.quarkdown.lsp.completion.function.impl.name
+ * @see com.quarkdown.lsp.completion.function.parameter
+ * @see com.quarkdown.lsp.completion.function.name
  */
 abstract class AbstractFunctionCompletionSupplier(
     protected val docsDirectory: File,
@@ -54,7 +54,7 @@ abstract class AbstractFunctionCompletionSupplier(
         val text = document.text
 
         // The index of the cursor in the source text.
-        val index = params.position.toOffset(text)
+        val index = params.position.toOffset(text).takeIf { it >= 0 } ?: return emptyList()
         val transformedIndex = transformIndex(index, text).takeIf { it >= 0 } ?: return emptyList()
 
         val call: FunctionCall =

--- a/quarkdown-lsp/src/test/kotlin/com/quarkdown/lsp/FunctionCompletionSupplierTest.kt
+++ b/quarkdown-lsp/src/test/kotlin/com/quarkdown/lsp/FunctionCompletionSupplierTest.kt
@@ -60,6 +60,13 @@ class FunctionCompletionSupplierTest {
     }
 
     @Test
+    fun `no completions at out-of-bounds position`() {
+        val text = "hello .$ALIGN_FUNCTION"
+        val completions = getCompletions(text, Position(5, 0))
+        assertTrue(completions.isEmpty())
+    }
+
+    @Test
     fun `no completions in invalid function call position`() {
         val text = "hello."
         val position = Position(0, text.length)


### PR DESCRIPTION
- [x] I have read the [contributing guidelines](https://github.com/iamgio/quarkdown/blob/main/CONTRIBUTING.md).
- [x] I have tested the changes locally.
- [ ] An issue for this change exists, and it was discussed with maintainers. This is required for new features and non-trivial changes. If present, append `Closes #ISSUE_NUMBER` at the end of this PR description.
- [x] (Optional) I have added necessary documentation to [`docs`](https://github.com/iamgio/quarkdown/tree/main/docs) and [`CHANGELOG.md`](https://github.com/iamgio/quarkdown/blob/main/CHANGELOG.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a language server crash when completion requests use cursor positions outside the document.
  * Out-of-bounds cursor positions now return no completion suggestions instead of causing an error.

* **Tests**
  * Added regression coverage for invalid cursor positions.

* **Documentation**
  * Documented the fix in the unreleased changelog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->