### PR TITLE
fix(extension): isolate chained extensions by scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-#### Scoped function extensions
+#### [Scoped function extensions](https://quarkdown.com/wiki/extending-functions)
 
 Function extensions declared in a nested scope now compose with inherited extensions only within that scope, without leaking into parent or sibling scopes.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+### Fixed
+
+#### Scoped function extensions
+
+Function extensions declared in a nested scope now compose with inherited extensions only within that scope, without leaking into parent or sibling scopes.
+
 ## [2.5.1] - 2026-08-12
 
 ### Changed

--- a/docs/extending-functions.qd
+++ b/docs/extending-functions.qd
@@ -18,6 +18,26 @@ You can extend any previously-declared function using the **`.extend`** .docslin
 
     .greet {world}
 
+## Scoping extensions
+
+Extensions follow the usual [scope](lambda.qd) rules. A nested scope inherits extensions from its parent, while extensions declared inside it only apply there and do not leak back out.
+
+.examplemirror
+    .function {greet}
+        name:
+        Hello, .name!
+
+    .extend {greet}
+        outer[.super]
+
+    .if {yes}
+        .extend {greet}
+            inner[.super]
+
+        .greet {inside}
+
+    .greet {outside}
+
 ## Accessing the original
 
 Within the wrapper body, the original function is exposed as **`.super`**. Calling it invokes the original with the same arguments.

--- a/docs/extending-functions.qd
+++ b/docs/extending-functions.qd
@@ -18,26 +18,6 @@ You can extend any previously-declared function using the **`.extend`** .docslin
 
     .greet {world}
 
-## Scoping extensions
-
-Extensions follow the usual [scope](lambda.qd) rules. A nested scope inherits extensions from its parent, while extensions declared inside it only apply there and do not leak back out.
-
-.examplemirror
-    .function {greet}
-        name:
-        Hello, .name!
-
-    .extend {greet}
-        outer[.super]
-
-    .if {yes}
-        .extend {greet}
-            inner[.super]
-
-        .greet {inside}
-
-    .greet {outside}
-
 ## Accessing the original
 
 Within the wrapper body, the original function is exposed as **`.super`**. Calling it invokes the original with the same arguments.
@@ -164,3 +144,19 @@ Passing [None](none.qd) as an argument to a nullable parameter restores it to it
     ### H3
 
     #### H4
+
+## Scoping extensions
+
+Extensions declared inside a [lambda](lambda.qd) only apply within that scope, and do not leak back out.
+
+.examplemirror
+    .function {greet}
+        Hello
+
+    .if {yes}
+        .extend {greet}
+            Hi
+
+        .greet
+
+    .greet

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/internal/FunctionExtension.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/internal/FunctionExtension.kt
@@ -25,7 +25,7 @@ private const val SUPER_NAME = "super"
 
 /**
  * Function produced by an [extend] call. It exposes its body as the callable target and
- * a rewireable [superTarget] as the function invoked by `.${SUPER_NAME}` within the body.
+ * [superTarget] as the function invoked by `.${SUPER_NAME}` within the body.
  *
  * @param name name of the function being extended
  * @param parameters parameters of the function being extended, all marked optional
@@ -39,15 +39,29 @@ private class ExtensionFunction(
     override val parameters: List<FunctionParameter<*>>,
     private val body: Lambda,
     private val condition: Lambda?,
-    initialSuperTarget: Function<*>,
+    val superTarget: Function<*>,
 ) : Function<OutputValue<*>> {
     override val validators: List<FunctionCallValidator<OutputValue<*>>> = emptyList()
 
     /**
-     * Function that `.${SUPER_NAME}` inside [body] delegates to. Mutated when a new extension
-     * is chained after this one, so `.super` transparently walks down toward the original.
+     * Returns a copy of this chain with [extension] inserted immediately before the original function.
+     *
+     * Rebuilding rather than mutating the chain keeps extensions local when the visible chain is
+     * inherited from a parent context. Existing lambdas are retained so each wrapper preserves the
+     * lexical context in which it was declared.
      */
-    var superTarget: Function<*> = initialSuperTarget
+    fun withInnermostExtension(extension: ExtensionFunction): ExtensionFunction =
+        ExtensionFunction(
+            name = name,
+            parameters = parameters,
+            body = body,
+            condition = condition,
+            superTarget =
+                when (val target = superTarget) {
+                    is ExtensionFunction -> target.withInnermostExtension(extension)
+                    else -> extension
+                },
+        )
 
     override val invoke: (ArgumentBindings, FunctionCall<OutputValue<*>>) -> OutputValue<*> = { outerBindings, call ->
         val args: List<Value<*>> = parameters.map { outerBindings[it]?.value ?: NoneValue }
@@ -75,19 +89,9 @@ private class ExtensionFunction(
 }
 
 /**
- * Follows any [ExtensionFunction] chain rooted at this function until it reaches a
- * non-extension function.
- *
- * @return the innermost [ExtensionFunction] (whose `superTarget` is the original), paired
- *         with that original function; or `null to this` if this function is not extended.
+ * Follows any [ExtensionFunction] chain rooted at this function to its original target.
  */
-private fun Function<*>.followExtensionChain(): Pair<ExtensionFunction?, Function<*>> {
-    val innermost =
-        generateSequence(this as? ExtensionFunction) { it.superTarget as? ExtensionFunction }
-            .lastOrNull()
-            ?: return null to this
-    return innermost to innermost.superTarget
-}
+private fun Function<*>.originalFunction(): Function<*> = generateSequence(this) { (it as? ExtensionFunction)?.superTarget }.last()
 
 /**
  * Merges [outerBindings] with [overrides] into a list of named arguments, with [overrides]
@@ -137,7 +141,7 @@ internal fun extendFunction(
         context.getFunctionByName(targetName)
             ?: throw IllegalArgumentException("Cannot extend function $targetName because it does not exist.")
 
-    val (innermost, originalFunction) = existing.followExtensionChain()
+    val originalFunction = existing.originalFunction()
 
     // The wrapper mirrors the original's non-injected parameters, all marked optional.
     val wrapperParameters =
@@ -165,17 +169,17 @@ internal fun extendFunction(
             parameters = wrapperParameters,
             body = bodyLambda,
             condition = conditionLambda,
-            initialSuperTarget = originalFunction,
+            superTarget = originalFunction,
         )
 
     context.markFunctionAsExtended(targetName)
 
-    if (innermost == null) {
-        // First extension for this name: register the wrapper as the callable target.
-        declareFunction(context, newExtension)
-    } else {
-        // Splice the new extension between the previous innermost wrapper and the original,
-        // so its `.super` overrides land on the original last.
-        innermost.superTarget = newExtension
-    }
+    // Always register a new root in the current context. If the visible chain belongs to a parent
+    // scope, the rebuilt chain shadows it locally without modifying the parent's function objects.
+    val newRoot =
+        when (existing) {
+            is ExtensionFunction -> existing.withInnermostExtension(newExtension)
+            else -> newExtension
+        }
+    declareFunction(context, newRoot)
 }

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/internal/FunctionExtension.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/internal/FunctionExtension.kt
@@ -32,7 +32,7 @@ private const val SUPER_NAME = "super"
  * @param body extension body invoked when the target is called
  * @param condition optional predicate; when it returns `false`, the call transparently
  *                  delegates to [superTarget] instead of running [body]
- * @param initialSuperTarget target of `.${SUPER_NAME}` at construction time (usually the original function)
+ * @param superTarget target of `.${SUPER_NAME}` at invocation time (possibly a chain of extensions)
  */
 private class ExtensionFunction(
     override val name: String,
@@ -45,10 +45,7 @@ private class ExtensionFunction(
 
     /**
      * Returns a copy of this chain with [extension] inserted immediately before the original function.
-     *
-     * Rebuilding rather than mutating the chain keeps extensions local when the visible chain is
-     * inherited from a parent context. Existing lambdas are retained so each wrapper preserves the
-     * lexical context in which it was declared.
+     * Existing lambdas are retained so each wrapper preserves the lexical context in which it was declared.
      */
     fun withInnermostExtension(extension: ExtensionFunction): ExtensionFunction =
         ExtensionFunction(
@@ -174,8 +171,7 @@ internal fun extendFunction(
 
     context.markFunctionAsExtended(targetName)
 
-    // Always register a new root in the current context. If the visible chain belongs to a parent
-    // scope, the rebuilt chain shadows it locally without modifying the parent's function objects.
+    // Register a new root in the current context. If the visible chain belongs to a parent scope, the rebuilt chain shadows it locally.
     val newRoot =
         when (existing) {
             is ExtensionFunction -> existing.withInnermostExtension(newExtension)

--- a/quarkdown-test/src/test/kotlin/com/quarkdown/test/FunctionExtensionTest.kt
+++ b/quarkdown-test/src/test/kotlin/com/quarkdown/test/FunctionExtensionTest.kt
@@ -279,6 +279,38 @@ class FunctionExtensionTest {
     }
 
     @Test
+    fun `scoped extension composes with inherited extension without leaking`() {
+        execute(
+            """
+            .function {test}
+                base
+
+            .extend {test}
+                outer[.super]
+
+            .if {yes}
+                .extend {test}
+                    first[.super]
+
+                .test
+
+            .if {yes}
+                .extend {test}
+                    second[.super]
+
+                .test
+
+            .test
+            """.trimIndent(),
+        ) {
+            assertEquals(
+                "<p>outer[first[base]]</p><p>outer[second[base]]</p><p>outer[base]</p>",
+                it,
+            )
+        }
+    }
+
+    @Test
     fun `super argument override, single param`() {
         execute(
             """


### PR DESCRIPTION
## Summary
- rebuild extension chains instead of mutating inherited wrappers
- keep nested extensions local while preserving extension order
- document scope behavior and cover parent and sibling isolation

## Testing
- `./gradlew ktlintCheck`
- `./gradlew test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
- Fixed function extensions in nested scopes so they inherit applicable extensions without affecting parent or sibling scopes.
- Ensured multiple extensions compose consistently while preserving behavior outside the nested scope.

## Documentation
- Added guidance explaining extension inheritance and scope-local behavior.

## Tests
- Added coverage for nested and conditional scope extension behavior, including verification that changes remain isolated to the defining scope.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->