### PR TITLE
feat(cli): resolve install dir from QUARKDOWN_HOME

### DIFF
--- a/quarkdown-install-layout-navigator/src/main/kotlin/com/quarkdown/installlayout/InstallDirectoryResolver.kt
+++ b/quarkdown-install-layout-navigator/src/main/kotlin/com/quarkdown/installlayout/InstallDirectoryResolver.kt
@@ -6,13 +6,16 @@ import java.io.File
 /**
  * Resolves the Quarkdown install `lib/` directory and wraps it as an [InstallLayout].
  *
- * Two environments are supported:
- * - **Distribution** (`installDist`): the module's JAR sits inside `<install>/lib/`,
- *   detected by the parent directory being named `lib`.
- * - **Development** (`./gradlew run`, test runs): the module's JAR lives at
- *   `<module>/build/libs/<module>.jar`. A fixed relative path leads from there to
- *   `<rootProject>/build/dev-lib`, a mirrored layout produced by the `assembleDevLib`
- *   Gradle task.
+ * Strategies are tried in order, and the first one that yields a directory wins:
+ *
+ * 1. **Explicit**: the `quarkdown.home` system property or the `QUARKDOWN_HOME` environment
+ *    variable. Set by a packager, or by anyone running Quarkdown in a form where the code
+ *    location says nothing useful about where the installation lives.
+ * 2. **Code source**: where this module's code was loaded from, which covers both a
+ *    distribution (`installDist`) and a development run.
+ * 3. **Running executable**: the directory of the running process's binary, assuming the
+ *    distribution's `<install>/bin/<executable>` layout. This is the case when there is no JAR
+ *    to inspect at all, as in a GraalVM native image.
  */
 internal object InstallDirectoryResolver {
     /** Name of the install `lib/` directory in a Quarkdown distribution. */
@@ -25,37 +28,101 @@ internal object InstallDirectoryResolver {
      */
     private const val DEV_INSTALL_DIR_RELATIVE_PATH = "../../../../build/dev-lib"
 
-    fun resolve(): InstallLayout {
-        val executable =
-            thisExecutableFile
-                ?: error("Cannot determine the Quarkdown executable location. The JAR's code source may be unavailable.")
+    /** System property naming the install directory, taking precedence over [HOME_ENV_VARIABLE]. */
+    private const val HOME_SYSTEM_PROPERTY = "quarkdown.home"
 
-        val directory = resolveFrom(executable)
+    /** Environment variable naming the install directory. */
+    private const val HOME_ENV_VARIABLE = "QUARKDOWN_HOME"
+
+    /**
+     * Subdirectories that identify a directory as a Quarkdown install layout.
+     */
+    private val LAYOUT_MARKERS = listOf("html", "qd")
+
+    fun resolve(): InstallLayout {
+        val directory =
+            fromExplicitHome()
+                ?: fromCodeSource()
+                ?: fromRunningExecutable()
+                ?: error(unresolvedMessage())
 
         Log.debug { "Resolved install directory: $directory" }
         return InstallLayout(InstallLayoutDirectory(directory))
     }
 
-    private fun resolveFrom(executable: File): File {
+    /**
+     * Reads the install directory from the explicit property or environment variable.
+     *
+     * The value may name either the installation root (the directory containing `lib/`) or the
+     * `lib/` directory itself. A value that names neither is an error rather than a fall-through:
+     * having asked for a specific installation, the caller should hear that it was not usable.
+     *
+     * @return the install `lib/` directory, or `null` when neither is set
+     */
+    private fun fromExplicitHome(): File? {
+        val source =
+            System.getProperty(HOME_SYSTEM_PROPERTY)?.let { HOME_SYSTEM_PROPERTY to it }
+                ?: System.getenv(HOME_ENV_VARIABLE)?.let { HOME_ENV_VARIABLE to it }
+                ?: return null
+        val (name, path) = source
+
+        val root = File(path)
+        return root.resolve(INSTALL_LIB_DIR_NAME).takeIfInstallLayout()
+            ?: root.takeIfInstallLayout()
+            ?: error("$name points to '$path', which is not a Quarkdown installation ")
+    }
+
+    /**
+     * Resolves from the location this module's code was loaded from.
+     *
+     * @return the install `lib/` directory, or `null` when the code location is unavailable
+     */
+    private fun fromCodeSource(): File? {
+        val executable = thisExecutableFile ?: return null
+
         // Distribution: the JAR sits inside <install>/lib/.
         val parent = executable.parentFile
         if (parent?.name == INSTALL_LIB_DIR_NAME) {
-            return parent
+            parent.takeIfInstallLayout()?.let { return it }
         }
 
         // Dev: navigate from this module's JAR to the root project's `build/dev-lib`.
-        val devLib = executable.resolve(DEV_INSTALL_DIR_RELATIVE_PATH).canonicalFile
-        if (devLib.isDirectory) {
-            return devLib
-        }
-
-        error(
-            """
-            Cannot resolve the Quarkdown install directory.
-            Executable: $executable
-            Tried distribution (parent named '$INSTALL_LIB_DIR_NAME'): ${parent?.absolutePath}
-            Tried dev-lib: ${devLib.absolutePath}
-            """.trimIndent(),
-        )
+        return executable.resolve(DEV_INSTALL_DIR_RELATIVE_PATH).canonicalFile.takeIfInstallLayout()
     }
+
+    /**
+     * Resolves from the running process's own binary, assuming a distribution's
+     * `<install>/bin/<executable>` layout.
+     *
+     * The result is validated, because this strategy runs for any process, including a plain
+     * `java` launch whose sibling `lib/` belongs to the JDK.
+     *
+     * @return the install `lib/` directory, or `null` when the binary's location is unavailable
+     *         or is not part of an installation
+     */
+    private fun fromRunningExecutable(): File? =
+        ProcessHandle
+            .current()
+            .info()
+            .command()
+            .orElse(null)
+            ?.let(::File)
+            ?.parentFile
+            ?.parentFile
+            ?.resolve(INSTALL_LIB_DIR_NAME)
+            ?.takeIfInstallLayout()
+
+    /**
+     * @return this directory if it holds a Quarkdown install layout, `null` otherwise
+     */
+    private fun File.takeIfInstallLayout(): File? =
+        this.takeIf { it.isDirectory && LAYOUT_MARKERS.any { marker -> it.resolve(marker).isDirectory } }
+
+    private fun unresolvedMessage(): String =
+        """
+        Cannot resolve the Quarkdown install directory.
+        Code source: ${thisExecutableFile?.absolutePath ?: "unavailable"}
+        Running executable: ${ProcessHandle.current().info().command().orElse("unavailable")}
+        Set $HOME_ENV_VARIABLE or -D$HOME_SYSTEM_PROPERTY to the Quarkdown installation directory.
+        """.trimIndent()
 }

--- a/quarkdown-install-layout-navigator/src/main/kotlin/com/quarkdown/installlayout/ThisExecutableFile.kt
+++ b/quarkdown-install-layout-navigator/src/main/kotlin/com/quarkdown/installlayout/ThisExecutableFile.kt
@@ -11,6 +11,9 @@ import java.io.File
  * determined by Gradle's dependency resolution: consumers see it as the module's JAR
  * (e.g. `quarkdown-install-layout-navigator/build/libs/...`) in dev, or as one of the JARs
  * inside `<install>/lib/` in a distribution.
+ *
+ * `null` where the code was not loaded from a file at all, as in a GraalVM native image.
+ * [InstallDirectoryResolver] falls back to other strategies in that case.
  */
 val thisExecutableFile: File? by lazy {
     object {}

--- a/quarkdown-install-layout-navigator/src/test/kotlin/com/quarkdown/installlayout/InstallDirectoryResolverTest.kt
+++ b/quarkdown-install-layout-navigator/src/test/kotlin/com/quarkdown/installlayout/InstallDirectoryResolverTest.kt
@@ -1,0 +1,74 @@
+package com.quarkdown.installlayout
+
+import java.io.File
+import kotlin.io.path.createTempDirectory
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+/**
+ * Tests for [InstallDirectoryResolver]'s explicit-home strategy, which is what lets a packager,
+ * or a build with no inspectable code location such as a native image, name its installation.
+ */
+class InstallDirectoryResolverTest {
+    private companion object {
+        const val HOME_PROPERTY = "quarkdown.home"
+    }
+
+    @AfterTest
+    fun tearDown() {
+        System.clearProperty(HOME_PROPERTY)
+    }
+
+    /**
+     * @param markerName subdirectory identifying the directory as an install layout
+     * @return a temporary directory containing a `lib/<markerName>` subtree
+     */
+    private fun installRoot(markerName: String = "html"): File =
+        createTempDirectory("quarkdown-install").toFile().also {
+            it.resolve("lib").resolve(markerName).mkdirs()
+        }
+
+    @Test
+    fun `the install root resolves to its lib directory`() {
+        val root = installRoot()
+        System.setProperty(HOME_PROPERTY, root.absolutePath)
+
+        val layout = InstallDirectoryResolver.resolve()
+
+        assertEquals(root.resolve("lib").canonicalFile, layout.file.canonicalFile)
+    }
+
+    @Test
+    fun `the lib directory itself is accepted`() {
+        val lib = installRoot().resolve("lib")
+        System.setProperty(HOME_PROPERTY, lib.absolutePath)
+
+        val layout = InstallDirectoryResolver.resolve()
+
+        assertEquals(lib.canonicalFile, layout.file.canonicalFile)
+    }
+
+    @Test
+    fun `a directory holding only quarkdown libraries is accepted`() {
+        val root = installRoot(markerName = "qd")
+        System.setProperty(HOME_PROPERTY, root.absolutePath)
+
+        assertEquals(
+            root.resolve("lib").canonicalFile,
+            InstallDirectoryResolver.resolve().file.canonicalFile,
+        )
+    }
+
+    @Test
+    fun `a directory that is not an installation is reported rather than ignored`() {
+        val empty = createTempDirectory("quarkdown-not-an-install").toFile()
+        System.setProperty(HOME_PROPERTY, empty.absolutePath)
+
+        val exception = assertFailsWith<IllegalStateException> { InstallDirectoryResolver.resolve() }
+        assertTrue(HOME_PROPERTY in exception.message!!)
+        assertTrue(empty.absolutePath in exception.message!!)
+    }
+}


### PR DESCRIPTION
- [X] I have read the [contributing guidelines](https://github.com/iamgio/quarkdown/blob/main/CONTRIBUTING.md).
- [X] I have tested the changes locally.
- [ ] An issue for this change exists, and it was discussed with maintainers. This is required for new features and non-trivial changes. If present, append `Closes #ISSUE_NUMBER` at the end of this PR description.
- [ ] (Optional) I have added necessary documentation to [`docs`](https://github.com/iamgio/quarkdown/tree/main/docs) and [`CHANGELOG.md`](https://github.com/iamgio/quarkdown/blob/main/CHANGELOG.md)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved installation directory detection using configured paths, application location, and running executable details.
  * Supports configuration pointing to either the installation directory or its `lib` directory.
  * Recognizes valid installation layouts using available `html` or `qd` markers.
  * Provides clearer errors for invalid or unresolved installation paths, including configuration guidance.
  * Improved compatibility when running in environments where the application’s source file location is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->