### PR TITLE
refactor: support virtual filesystems

### DIFF
--- a/quarkdown-cli/src/main/kotlin/com/quarkdown/cli/exec/ExecuteCommand.kt
+++ b/quarkdown-cli/src/main/kotlin/com/quarkdown/cli/exec/ExecuteCommand.kt
@@ -17,6 +17,7 @@ import com.quarkdown.cli.util.checkCleanSafety
 import com.quarkdown.cli.watcher.DirectoryWatcher
 import com.quarkdown.core.TIMEOUT_EXIT_CODE
 import com.quarkdown.core.document.sub.SubdocumentOutputNaming
+import com.quarkdown.core.filesystem.DiskFileSystem
 import com.quarkdown.core.function.error.FunctionCallRuntimeException
 import com.quarkdown.core.log.Log
 import com.quarkdown.core.media.storage.options.ReadOnlyMediaStorageOptions
@@ -257,7 +258,7 @@ abstract class ExecuteCommand(
             resourceName = resolveResourceName(cliOptions),
             prettyOutput = prettyOutput,
             wrapOutput = !noWrap,
-            workingDirectory = cliOptions.source?.absoluteFile?.parentFile,
+            fileSystem = DiskFileSystem(cliOptions.source?.absoluteFile?.parentFile),
             enableMediaStorage = !noMediaStorage,
             forbidFunctionOverwriting = forbidFunctionOverwriting,
             subdocumentNaming = subdocumentNaming,

--- a/quarkdown-cli/src/main/kotlin/com/quarkdown/cli/util/CleanSafety.kt
+++ b/quarkdown-cli/src/main/kotlin/com/quarkdown/cli/util/CleanSafety.kt
@@ -1,6 +1,6 @@
 package com.quarkdown.cli.util
 
-import com.quarkdown.core.util.IOUtils
+import com.quarkdown.core.filesystem.DiskFileSystem
 import java.io.File
 
 /**
@@ -83,7 +83,8 @@ fun File.checkCleanSafety(
     if (workingDirectory != null && target == workingDirectory) return CleanRefusal.WorkingDirectory
     if (PROJECT_ROOT_MARKERS.any { File(target, it).exists() }) return CleanRefusal.RepositoryRoot
 
-    if (sourceFile != null && IOUtils.isSubPath(parent = target, child = sourceFile)) {
+    val disk = DiskFileSystem()
+    if (sourceFile != null && disk.resolve(sourceFile.absolutePath).isSubPathOf(disk.resolve(target.absolutePath))) {
         return CleanRefusal.ContainsSourceFile(sourceFile.canonicalFile)
     }
 

--- a/quarkdown-cli/src/test/kotlin/com/quarkdown/cli/CompileCommandTest.kt
+++ b/quarkdown-cli/src/test/kotlin/com/quarkdown/cli/CompileCommandTest.kt
@@ -69,7 +69,7 @@ class CompileCommandTest : TempDirectory() {
         val pipelineOptions = command.createPipelineOptions(cliOptions)
 
         assertEquals(main, cliOptions.source)
-        assertEquals(directory, pipelineOptions.workingDirectory)
+        assertEquals(directory, pipelineOptions.fileSystem.workingDirectory?.toFileOrNull())
         assertEquals(
             outputDirectory.takeUnless { cliOptions.pipe },
             cliOptions.outputDirectory,

--- a/quarkdown-cli/src/test/kotlin/com/quarkdown/cli/ExecuteTest.kt
+++ b/quarkdown-cli/src/test/kotlin/com/quarkdown/cli/ExecuteTest.kt
@@ -5,6 +5,7 @@ import com.quarkdown.cli.exec.runQuarkdown
 import com.quarkdown.cli.exec.strategy.FileExecutionStrategy
 import com.quarkdown.cli.exec.strategy.PipelineExecutionStrategy
 import com.quarkdown.core.UNRESOLVED_REFERENCE_EXIT_CODE
+import com.quarkdown.core.filesystem.DiskFileSystem
 import com.quarkdown.core.pipeline.Pipeline
 import com.quarkdown.core.pipeline.PipelineOptions
 import com.quarkdown.core.pipeline.error.PipelineException
@@ -47,7 +48,7 @@ class ExecuteTest : TempDirectory() {
 
     private fun pipelineOptions(strict: Boolean) =
         PipelineOptions(
-            workingDirectory = source.absoluteFile.parentFile,
+            fileSystem = DiskFileSystem(source.absoluteFile.parentFile),
             enableMediaStorage = false,
             errorHandler = if (strict) StrictPipelineErrorHandler() else PipelineOptions().errorHandler,
         )

--- a/quarkdown-core/build.gradle.kts
+++ b/quarkdown-core/build.gradle.kts
@@ -14,6 +14,8 @@ dependencies {
     testImplementation(testFixtures(project))
     testCompileOnly(project(":quarkdown-native-library-processor"))
     kspTest(project(":quarkdown-native-library-processor"))
+    implementation("com.squareup.okio:okio:3.18.1")
+    implementation("com.squareup.okio:okio-fakefilesystem:3.18.1")
     implementation("com.github.h0tk3y.betterParse:better-parse:0.4.4")
     implementation("org.apache.logging.log4j:log4j-core:2.25.3")
     implementation("org.apache.commons:commons-text:1.15.0")

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/base/LinkNode.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/base/LinkNode.kt
@@ -2,7 +2,7 @@ package com.quarkdown.core.ast.base
 
 import com.quarkdown.core.ast.InlineContent
 import com.quarkdown.core.ast.attributes.error.ErrorCapableNode
-import com.quarkdown.core.context.file.FileSystem
+import com.quarkdown.core.filesystem.FileSystem
 
 /**
  * A general link node.

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/base/block/LinkDefinition.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/base/block/LinkDefinition.kt
@@ -4,7 +4,7 @@ import com.quarkdown.amber.annotations.Diverge
 import com.quarkdown.core.ast.InlineContent
 import com.quarkdown.core.ast.base.LinkNode
 import com.quarkdown.core.ast.base.TextNode
-import com.quarkdown.core.context.file.FileSystem
+import com.quarkdown.core.filesystem.FileSystem
 import com.quarkdown.core.pipeline.error.PipelineErrorHandler
 import com.quarkdown.core.visitor.node.NodeVisitor
 

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/base/inline/Link.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/base/inline/Link.kt
@@ -10,7 +10,7 @@ import com.quarkdown.core.ast.attributes.style.StylableNode
 import com.quarkdown.core.ast.base.LinkNode
 import com.quarkdown.core.ast.base.TextNode
 import com.quarkdown.core.ast.base.block.LinkDefinition
-import com.quarkdown.core.context.file.FileSystem
+import com.quarkdown.core.filesystem.FileSystem
 import com.quarkdown.core.function.dsl.functionCallArguments
 import com.quarkdown.core.pipeline.error.PipelineErrorHandler
 import com.quarkdown.core.util.stripAnchor

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/dsl/InlineAstBuilder.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/dsl/InlineAstBuilder.kt
@@ -13,8 +13,8 @@ import com.quarkdown.core.ast.base.inline.Text
 import com.quarkdown.core.ast.quarkdown.inline.InlineCollapse
 import com.quarkdown.core.ast.quarkdown.inline.TextTransform
 import com.quarkdown.core.ast.quarkdown.inline.TextTransformData
-import com.quarkdown.core.context.file.SimpleFileSystem
 import com.quarkdown.core.document.size.Size
+import com.quarkdown.core.filesystem.DiskFileSystem
 
 /**
  * A builder of inline nodes.
@@ -73,7 +73,7 @@ class InlineAstBuilder : AstBuilder() {
         referenceId: String? = null,
         label: InlineAstBuilder.() -> Unit = {},
     ) = +Image(
-        Link(buildInline(label), url, title?.let { listOf(Text(it)) }, fileSystem = SimpleFileSystem()),
+        Link(buildInline(label), url, title?.let { listOf(Text(it)) }, fileSystem = DiskFileSystem()),
         width,
         height,
         referenceId,

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/context/BaseContext.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/context/BaseContext.kt
@@ -2,15 +2,15 @@ package com.quarkdown.core.context
 
 import com.quarkdown.core.ast.attributes.AstAttributes
 import com.quarkdown.core.ast.quarkdown.FunctionCallNode
-import com.quarkdown.core.context.file.FileSystem
-import com.quarkdown.core.context.file.RootGranularity
-import com.quarkdown.core.context.file.SimpleFileSystem
-import com.quarkdown.core.context.file.getRootFileSystem
 import com.quarkdown.core.context.options.ContextOptions
 import com.quarkdown.core.context.options.MutableContextOptions
 import com.quarkdown.core.context.subdocument.SubdocumentsData
 import com.quarkdown.core.document.DocumentInfo
 import com.quarkdown.core.document.sub.Subdocument
+import com.quarkdown.core.filesystem.DiskFileSystem
+import com.quarkdown.core.filesystem.FileSystem
+import com.quarkdown.core.filesystem.RootGranularity
+import com.quarkdown.core.filesystem.getRootFileSystem
 import com.quarkdown.core.flavor.MarkdownFlavor
 import com.quarkdown.core.function.Function
 import com.quarkdown.core.function.call.FunctionCall
@@ -66,10 +66,11 @@ open class BaseContext(
         )
 
     override val fileSystem: FileSystem by lazy {
+        val base = attachedPipeline?.options?.fileSystem ?: DiskFileSystem()
         val workingDirectory =
             (subdocument as? Subdocument.Resource)?.workingDirectory
-                ?: attachedPipeline?.options?.workingDirectory
-        SimpleFileSystem(workingDirectory)
+                ?: base.workingDirectory
+        base.reroot(workingDirectory)
     }
 
     override val permissions: Set<Permission> by lazy {

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/context/Context.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/context/Context.kt
@@ -2,11 +2,11 @@ package com.quarkdown.core.context
 
 import com.quarkdown.core.ast.attributes.AstAttributes
 import com.quarkdown.core.ast.quarkdown.FunctionCallNode
-import com.quarkdown.core.context.file.FileSystem
 import com.quarkdown.core.context.options.ContextOptions
 import com.quarkdown.core.context.subdocument.SubdocumentsData
 import com.quarkdown.core.document.DocumentInfo
 import com.quarkdown.core.document.sub.Subdocument
+import com.quarkdown.core.filesystem.FileSystem
 import com.quarkdown.core.flavor.MarkdownFlavor
 import com.quarkdown.core.function.Function
 import com.quarkdown.core.function.call.FunctionCall

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/context/ScopeContext.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/context/ScopeContext.kt
@@ -1,6 +1,6 @@
 package com.quarkdown.core.context
 
-import com.quarkdown.core.context.file.FileSystem
+import com.quarkdown.core.filesystem.FileSystem
 
 /**
  * A context that is the result of a fork from an original parent [Context].

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/context/SharedContext.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/context/SharedContext.kt
@@ -1,6 +1,6 @@
 package com.quarkdown.core.context
 
-import com.quarkdown.core.context.file.FileSystem
+import com.quarkdown.core.filesystem.FileSystem
 import com.quarkdown.core.function.Function
 
 /**

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/context/SubdocumentContext.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/context/SubdocumentContext.kt
@@ -1,8 +1,8 @@
 package com.quarkdown.core.context
 
-import com.quarkdown.core.context.file.FileSystem
 import com.quarkdown.core.document.DocumentInfo
 import com.quarkdown.core.document.sub.Subdocument
+import com.quarkdown.core.filesystem.FileSystem
 import com.quarkdown.core.function.Function
 import com.quarkdown.core.pipeline.Pipeline
 

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/context/hooks/LinkUrlResolverHook.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/context/hooks/LinkUrlResolverHook.kt
@@ -7,11 +7,10 @@ import com.quarkdown.core.ast.base.inline.Image
 import com.quarkdown.core.ast.iterator.AstIteratorHook
 import com.quarkdown.core.ast.iterator.ObservableAstIterator
 import com.quarkdown.core.context.MutableContext
+import com.quarkdown.core.filesystem.FsEntry
+import com.quarkdown.core.filesystem.FsPaths
 import com.quarkdown.core.media.passthrough.MediaPassthrough
 import com.quarkdown.core.util.isURL
-import java.nio.file.Path
-import kotlin.io.path.Path
-import kotlin.io.path.invariantSeparatorsPathString
 
 /**
  * Hook that resolves relative link paths based on their file system.
@@ -39,16 +38,16 @@ class LinkUrlResolverHook(
 
         if (fileSystem == null || fileSystem.isRoot) return // No need to resolve paths.
         if (MediaPassthrough.isPassthroughPath(link.url)) return // No need to resolve passthrough paths.
-        if (link.url.isURL || Path(link.url).isAbsolute) return // Not a relative path.
+        if (link.url.isURL || FsPaths.isAbsolute(link.url)) return // Not a relative path.
 
-        val resolved: Path? =
+        val resolved: FsEntry? =
             context.fileSystem
                 .relativePathTo(fileSystem)
                 ?.resolve(link.url)
-                ?.normalize()
+                ?.normalized
 
         resolved?.let {
-            link.setResolvedUrl(context, it.invariantSeparatorsPathString)
+            link.setResolvedUrl(context, it.invariantSeparatorsPath)
         }
     }
 

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/context/hooks/MediaStorerHook.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/context/hooks/MediaStorerHook.kt
@@ -43,7 +43,7 @@ class MediaStorerHook(
             try {
                 context.mediaStorage.register(
                     url,
-                    context.fileSystem.workingDirectory,
+                    context.fileSystem,
                 )
             } catch (_: IllegalArgumentException) {
                 Log.warn("Media cannot be resolved: ${link.url}")

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/context/hooks/SubdocumentRegistrationHook.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/context/hooks/SubdocumentRegistrationHook.kt
@@ -27,7 +27,7 @@ class SubdocumentRegistrationHook(
             val fileSystem = link.fileSystem ?: context.fileSystem
             val file = fileSystem.resolve(path = link.url)
 
-            if (!file.exists()) {
+            if (!file.exists) {
                 link.setError(UnresolvedSubdocumentException(link), context)
                 return@on
             }
@@ -39,7 +39,8 @@ class SubdocumentRegistrationHook(
                 return@on
             }
 
-            val path = file.canonicalFile.absolutePath
+            val canonical = file.canonical
+            val path = canonical.fullPath
 
             // Reuse an already-registered subdocument to avoid redundant file I/O.
             val subdocument =
@@ -47,7 +48,7 @@ class SubdocumentRegistrationHook(
                     ?: Subdocument.Resource(
                         name = file.nameWithoutExtension,
                         path = path,
-                        workingDirectory = file.parentFile.canonicalFile,
+                        workingDirectory = canonical.parent,
                         content = file.readText(),
                     )
 

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/document/sub/Subdocument.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/document/sub/Subdocument.kt
@@ -1,6 +1,6 @@
 package com.quarkdown.core.document.sub
 
-import java.io.File
+import com.quarkdown.core.filesystem.FsEntry
 
 private const val ROOT_NAME = "index"
 private const val UNIQUE_NAME_FORMAT = "%s@%d"
@@ -51,13 +51,13 @@ sealed interface Subdocument {
      * @param path the absolute path to the subdocument file or resource
      * @param workingDirectory the working directory to be used to resolve relative file paths within the subdocument.
      * Note that if this is `null`, then the pipeline's working directory should be used.
-     * To get consistent results, rely on the context's [com.quarkdown.core.context.file.FileSystem.workingDirectory].
+     * To get consistent results, rely on the context's [com.quarkdown.core.filesystem.FileSystem.workingDirectory].
      * @param content the subdocument text content
      */
     class Resource(
         override val name: String,
         val path: String,
-        val workingDirectory: File? = null,
+        val workingDirectory: FsEntry? = null,
         val content: CharSequence,
     ) : Subdocument {
         override val uniqueName: String

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/filesystem/DiskFileSystem.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/filesystem/DiskFileSystem.kt
@@ -1,0 +1,18 @@
+package com.quarkdown.core.filesystem
+
+import okio.Path.Companion.toOkioPath
+import java.io.File
+import okio.FileSystem as OkioBackend
+
+/**
+ * A [FileSystem] backed by the physical disk file system.
+ * This is the default file system used by the pipeline and the CLI.
+ * @param workingDirectory optional working directory to resolve relative paths from;
+ * if relative, it is made absolute against the process working directory
+ */
+class DiskFileSystem(
+    workingDirectory: File? = null,
+) : OkioBackedFileSystem(
+        OkioBackend.SYSTEM,
+        workingDirectory?.let { FsEntry(it.absoluteFile.toOkioPath(), OkioBackend.SYSTEM) },
+    )

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/filesystem/FileSystem.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/filesystem/FileSystem.kt
@@ -1,9 +1,4 @@
-package com.quarkdown.core.context.file
-
-import com.quarkdown.core.util.IOUtils
-import java.io.File
-import java.nio.file.Path
-import kotlin.io.path.absolute
+package com.quarkdown.core.filesystem
 
 /**
  * A file system abstraction which can retrieve files,
@@ -15,7 +10,7 @@ interface FileSystem {
      * If not `null`, [resolve] will be able to resolve relative paths
      * from this directory.
      */
-    val workingDirectory: File?
+    val workingDirectory: FsEntry?
 
     /**
      * The root file system that originated this one via [branch] calls.
@@ -33,9 +28,9 @@ interface FileSystem {
      * Resolves a local file path, either absolutely or relatively from [workingDirectory].
      * This does not perform any check for file existence.
      * @param path absolute or relative file path to resolve
-     * @return the resolved file
+     * @return the resolved entry
      */
-    fun resolve(path: String): File
+    fun resolve(path: String): FsEntry
 
     /**
      * Creates a new [FileSystem] branched from this one, with the given [workingDirectory].
@@ -46,36 +41,21 @@ interface FileSystem {
      * @param workingDirectory new working directory
      * @return the branched file system
      */
-    fun branch(workingDirectory: File?): FileSystem
+    fun branch(workingDirectory: FsEntry?): FileSystem
+
+    /**
+     * Creates a new root [FileSystem] on the same backend, with the given [workingDirectory]
+     * and no branch lineage, so that [isRoot] holds for the result.
+     * @param workingDirectory new working directory
+     * @return the new root file system
+     */
+    fun reroot(workingDirectory: FsEntry?): FileSystem
 
     /**
      * Computes the relative path from this file system's [workingDirectory] to [other]'s.
      * @param other the target file system
-     * @return the relative path from this working directory to the other,
-     *         or `null` if either working directory is `null`
+     * @return the relative entry from this working directory to the other,
+     *         or `null` if either working directory is `null` or no relative path exists
      */
-    fun relativePathTo(other: FileSystem): Path?
-}
-
-/**
- * A simple [FileSystem] implementation that resolves paths
- * based on an optional working directory.
- */
-internal data class SimpleFileSystem(
-    override val workingDirectory: File? = null,
-    override val root: FileSystem? = null,
-) : FileSystem {
-    override fun branch(workingDirectory: File?): FileSystem = SimpleFileSystem(workingDirectory, root ?: this)
-
-    override fun resolve(path: String): File = IOUtils.resolvePath(path, workingDirectory)
-
-    override fun relativePathTo(other: FileSystem): Path? {
-        val from = this.workingDirectory?.toPath()?.absolute() ?: return null
-        val to = other.workingDirectory?.toPath()?.absolute() ?: return null
-        return try {
-            from.relativize(to)
-        } catch (_: IllegalArgumentException) {
-            null
-        }
-    }
+    fun relativePathTo(other: FileSystem): FsEntry?
 }

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/filesystem/FsEntry.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/filesystem/FsEntry.kt
@@ -1,0 +1,159 @@
+package com.quarkdown.core.filesystem
+
+import okio.IOException
+import okio.Path
+import okio.Path.Companion.toOkioPath
+import java.io.File
+import okio.FileSystem as OkioBackend
+
+/**
+ * A platform-neutral handle to a file or directory, bound to the [FileSystem] backend that created it.
+ * An entry provides path math, existence and metadata queries, content reading, and directory listing,
+ * without exposing the underlying I/O engine.
+ *
+ * Entries are created via [FileSystem.resolve] or derived from other entries ([resolve], [parent], [children]).
+ */
+class FsEntry internal constructor(
+    internal val path: Path,
+    internal val backend: OkioBackend,
+) {
+    /** The file or directory name, including any extension. */
+    val name: String
+        get() = path.name
+
+    /** The file name without its last extension. */
+    val nameWithoutExtension: String
+        get() = name.substringBeforeLast('.')
+
+    /** The file extension, without the leading dot, or an empty string if there is none. */
+    val extension: String
+        get() = name.substringAfterLast('.', "")
+
+    /** The parent entry, or `null` if this entry has no parent. */
+    val parent: FsEntry?
+        get() = path.parent?.let { FsEntry(it, backend) }
+
+    /** Whether this entry's path is absolute. */
+    val isAbsolute: Boolean
+        get() = path.isAbsolute
+
+    /** The full path string of this entry, suitable for display and error messages. */
+    val fullPath: String
+        get() = path.toString()
+
+    /** [fullPath] with `/` as the separator on every platform, suitable for URLs. */
+    val invariantSeparatorsPath: String
+        get() = fullPath.replace('\\', '/')
+
+    /** This entry with redundant path segments (`.`, `..`) resolved lexically. */
+    val normalized: FsEntry
+        get() = FsEntry(path.normalized(), backend)
+
+    /**
+     * This entry with symbolic links resolved, if it exists;
+     * falls back to its absolute, [normalized] form otherwise.
+     *
+     * Disk-backed entries resolve through the platform's real-path lookup so to resolve symbolic links on Windows.
+     */
+    val canonical: FsEntry
+        get() {
+            toFileOrNull()?.let { file ->
+                val real =
+                    try {
+                        file.toPath().toRealPath()
+                    } catch (_: IOException) {
+                        file.toPath().toAbsolutePath().normalize()
+                    }
+                return FsEntry(real.toFile().toOkioPath(), backend)
+            }
+            return try {
+                FsEntry(backend.canonicalize(path), backend)
+            } catch (_: IOException) {
+                normalized
+            }
+        }
+
+    /** Whether this entry exists. */
+    val exists: Boolean
+        get() = backend.exists(path)
+
+    /** Whether this entry exists and is a regular file. */
+    val isFile: Boolean
+        get() = backend.metadataOrNull(path)?.isRegularFile == true
+
+    /** Whether this entry exists and is a directory. */
+    val isDirectory: Boolean
+        get() = backend.metadataOrNull(path)?.isDirectory == true
+
+    /** The last modification timestamp in epoch milliseconds, if available. */
+    val lastModifiedAtMillis: Long?
+        get() = backend.metadataOrNull(path)?.lastModifiedAtMillis
+
+    /**
+     * Resolves a [child] path against this entry.
+     * @param child relative path to resolve
+     * @return the resolved entry, on the same backend
+     */
+    fun resolve(child: String): FsEntry = FsEntry(path / child, backend)
+
+    /**
+     * Computes this entry's path relative to [other].
+     * @param other the base entry
+     * @return the relative entry, or `null` if a relative path cannot be computed
+     *         or the entries belong to different backends
+     */
+    fun relativeTo(other: FsEntry): FsEntry? {
+        if (backend != other.backend) return null
+        return try {
+            FsEntry(path.relativeTo(other.path), backend)
+        } catch (_: IllegalArgumentException) {
+            null
+        }
+    }
+
+    /**
+     * Whether this entry is located in [ancestor] or any of its subdirectories.
+     * Both paths are canonicalized when possible, so a symbolic link inside [ancestor]
+     * pointing outside it is correctly detected as not being a sub-path.
+     */
+    fun isSubPathOf(ancestor: FsEntry): Boolean {
+        if (backend != ancestor.backend) return false
+        val ancestorPath = ancestor.canonical.path
+        return generateSequence(canonical.path) { it.parent }.any { it == ancestorPath }
+    }
+
+    /**
+     * Lists the direct children of this directory entry.
+     * @return the children, or an empty list if this entry is not a listable directory
+     */
+    fun children(): List<FsEntry> = backend.listOrNull(path).orEmpty().map { FsEntry(it, backend) }
+
+    /**
+     * Walks this directory entry recursively.
+     * @return all descendant entries, excluding this entry itself
+     */
+    fun descendants(): Sequence<FsEntry> = children().asSequence().flatMap { sequenceOf(it) + it.descendants() }
+
+    /** @return the full text content of this file, decoded as UTF-8 */
+    fun readText(): String = backend.read(path) { readUtf8() }
+
+    /** @return the lines of this file, decoded as UTF-8, without line terminators */
+    fun readLines(): List<String> = backend.read(path) { generateSequence(::readUtf8Line).toList() }
+
+    /** @return the raw byte content of this file */
+    fun readBytes(): ByteArray = backend.read(path) { readByteArray() }
+
+    /**
+     * Converts this entry to a [File], if it is backed by the physical disk file system.
+     * This is the boundary between the platform-neutral input abstraction and JVM-only
+     * output or process-level code; input-side code must not use it.
+     * @return the corresponding [File], or `null` if this entry is virtual
+     */
+    fun toFileOrNull(): File? = if (backend === OkioBackend.SYSTEM) path.toFile() else null
+
+    override fun equals(other: Any?): Boolean = other is FsEntry && path == other.path && backend == other.backend
+
+    override fun hashCode(): Int = 31 * path.hashCode() + backend.hashCode()
+
+    override fun toString(): String = fullPath
+}

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/filesystem/FsPaths.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/filesystem/FsPaths.kt
@@ -1,0 +1,19 @@
+package com.quarkdown.core.filesystem
+
+import okio.Path.Companion.toPath
+
+/**
+ * Utilities for raw path strings, backing checks that do not require a [FileSystem].
+ */
+object FsPaths {
+    /**
+     * Matches a Windows drive-letter prefix (e.g. `C:\` or `C:/`).
+     */
+    private val WINDOWS_DRIVE_REGEX = Regex("""^[A-Za-z]:[/\\]""")
+
+    /**
+     * @param path a raw path string
+     * @return whether [path] is absolute (Unix or Windows style, with either separator)
+     */
+    fun isAbsolute(path: String): Boolean = WINDOWS_DRIVE_REGEX.containsMatchIn(path) || path.toPath().isAbsolute
+}

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/filesystem/OkioFileSystem.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/filesystem/OkioFileSystem.kt
@@ -1,0 +1,106 @@
+package com.quarkdown.core.filesystem
+
+import okio.Path.Companion.toPath
+import okio.FileSystem as OkioBackend
+
+/**
+ * The Okio-backed [FileSystem] engine shared by [DiskFileSystem] and [VirtualFileSystem],
+ * which differ only in the backend they delegate I/O to.
+ * @param backend the Okio engine performing the actual I/O
+ * @param workingDirectory optional working directory to resolve relative paths from
+ * @param root the file system this one was branched from, if any
+ * @param owner the public file system this engine backs, used as the lineage root of its branches
+ */
+internal class OkioFileSystem(
+    internal val backend: OkioBackend,
+    override val workingDirectory: FsEntry?,
+    override val root: FileSystem? = null,
+    private val owner: FileSystem? = null,
+) : FileSystem {
+    /**
+     * The file system that branches of this one consider their [FileSystem.root]:
+     * the original root if already branched, otherwise the public [owner] (or this engine itself).
+     */
+    private val lineageRoot: FileSystem
+        get() = root ?: owner ?: this
+
+    override fun resolve(path: String): FsEntry =
+        when {
+            workingDirectory != null && !path.toPath().isAbsolute -> workingDirectory.resolve(path)
+            else -> FsEntry(path.toPath(), backend)
+        }
+
+    override fun branch(workingDirectory: FsEntry?): FileSystem {
+        requireSameBackend(workingDirectory)
+        return OkioFileSystem(backend, workingDirectory, lineageRoot)
+    }
+
+    override fun reroot(workingDirectory: FsEntry?): FileSystem {
+        requireSameBackend(workingDirectory)
+        return OkioFileSystem(backend, workingDirectory)
+    }
+
+    /**
+     * Ensures that a working directory candidate belongs to this file system's backend.
+     * @throws IllegalArgumentException if [entry] was produced by a different backend
+     */
+    private fun requireSameBackend(entry: FsEntry?) {
+        require(entry == null || entry.backend == backend) {
+            "The working directory belongs to a different file system backend."
+        }
+    }
+
+    override fun relativePathTo(other: FileSystem): FsEntry? {
+        val from = this.workingDirectory?.canonical ?: return null
+        val to = other.workingDirectory?.canonical ?: return null
+        return to.relativeTo(from)
+    }
+
+    override fun equals(other: Any?): Boolean {
+        val otherEngine =
+            when (other) {
+                is OkioBackedFileSystem -> other.engine
+                is OkioFileSystem -> other
+                else -> return false
+            }
+        return backend == otherEngine.backend &&
+            workingDirectory == otherEngine.workingDirectory &&
+            root == otherEngine.root
+    }
+
+    override fun hashCode(): Int = 31 * backend.hashCode() + workingDirectory.hashCode()
+}
+
+/**
+ * Base class for the public [FileSystem] entry points ([DiskFileSystem], [VirtualFileSystem]),
+ * which are always root file systems and delegate their behavior to the internal [OkioFileSystem] engine,
+ * while acting themselves as the lineage root of their [branch]es.
+ */
+abstract class OkioBackedFileSystem internal constructor(
+    backend: OkioBackend,
+    workingDirectory: FsEntry?,
+) : FileSystem {
+    internal val engine = OkioFileSystem(backend, workingDirectory, root = null, owner = this)
+
+    final override val workingDirectory: FsEntry?
+        get() = engine.workingDirectory
+
+    final override val root: FileSystem?
+        get() = null
+
+    final override fun resolve(path: String): FsEntry = engine.resolve(path)
+
+    final override fun branch(workingDirectory: FsEntry?): FileSystem = engine.branch(workingDirectory)
+
+    final override fun reroot(workingDirectory: FsEntry?): FileSystem = engine.reroot(workingDirectory)
+
+    final override fun relativePathTo(other: FileSystem): FsEntry? = engine.relativePathTo(other)
+
+    /**
+     * File systems are compared by value: same backend, working directory, and branch lineage.
+     * This mirrors the behavior expected by recursive AST comparisons.
+     */
+    final override fun equals(other: Any?): Boolean = engine == other
+
+    final override fun hashCode(): Int = engine.hashCode()
+}

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/filesystem/RootFileSystem.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/filesystem/RootFileSystem.kt
@@ -1,4 +1,4 @@
-package com.quarkdown.core.context.file
+package com.quarkdown.core.filesystem
 
 import com.quarkdown.core.context.ChildContext
 import com.quarkdown.core.context.Context
@@ -42,6 +42,7 @@ fun Context.getRootFileSystem(granularity: RootGranularity = RootGranularity.PRO
             val rootContext = (context as? ChildContext<*>)?.root ?: context
             rootContext.attachedPipeline
                 ?.options
+                ?.fileSystem
                 ?.workingDirectory
                 ?.let(context.fileSystem::branch)
         }

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/filesystem/VirtualFileSystem.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/filesystem/VirtualFileSystem.kt
@@ -1,0 +1,53 @@
+package com.quarkdown.core.filesystem
+
+import okio.Path.Companion.toPath
+import okio.fakefilesystem.FakeFileSystem
+
+/**
+ * An in-memory [FileSystem], detached from the physical disk.
+ * Entries produced by this file system return `null` from [FsEntry.toFileOrNull].
+ * @param workingDirectoryPath absolute path of the working directory within the virtual tree
+ */
+class VirtualFileSystem private constructor(
+    private val backend: FakeFileSystem,
+    workingDirectoryPath: String?,
+) : OkioBackedFileSystem(
+        backend,
+        workingDirectoryPath?.let { FsEntry(it.toPath(), backend) },
+    ) {
+    constructor(workingDirectoryPath: String? = "/") : this(FakeFileSystem(), workingDirectoryPath)
+
+    /**
+     * Creates a directory at [path] (relative to the working directory, or absolute),
+     * including any missing parent directories.
+     */
+    fun mkdirs(path: String) {
+        backend.createDirectories(resolve(path).path)
+    }
+
+    /**
+     * Writes UTF-8 [content] to the file at [path] (relative to the working directory, or absolute),
+     * creating missing parent directories.
+     */
+    fun write(
+        path: String,
+        content: String,
+    ) {
+        val entry = resolve(path)
+        entry.parent?.let { backend.createDirectories(it.path, mustCreate = false) }
+        backend.write(entry.path) { writeUtf8(content) }
+    }
+
+    /**
+     * Writes raw [content] bytes to the file at [path] (relative to the working directory, or absolute),
+     * creating missing parent directories.
+     */
+    fun writeBytes(
+        path: String,
+        content: ByteArray,
+    ) {
+        val entry = resolve(path)
+        entry.parent?.let { backend.createDirectories(it.path, mustCreate = false) }
+        backend.write(entry.path) { write(content) }
+    }
+}

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/media/LocalMedia.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/media/LocalMedia.kt
@@ -1,13 +1,13 @@
 package com.quarkdown.core.media
 
-import java.io.File
+import com.quarkdown.core.filesystem.FsEntry
 
 /**
- * A media that lives on the local filesystem.
- * @param file the local file where the media is stored
+ * A media that lives on a file system, physical or virtual.
+ * @param file the entry where the media is stored
  */
 data class LocalMedia(
-    val file: File,
+    val file: FsEntry,
 ) : Media {
     override fun <T> accept(visitor: MediaVisitor<T>): T = visitor.visit(this)
 }

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/media/ResolvableMedia.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/media/ResolvableMedia.kt
@@ -1,17 +1,16 @@
 package com.quarkdown.core.media
 
-import com.quarkdown.core.util.IOUtils
+import com.quarkdown.core.filesystem.FileSystem
 import com.quarkdown.core.util.toURLOrNull
-import java.io.File
 
 /**
  * A generic media that is yet to be resolved to a [Media] subclass.
  * @param path path to the media, either a file or a URL
- * @param workingDirectory directory to resolve the media from, in case the path is relative
+ * @param fileSystem file system to resolve the media from, in case the path is a local file
  */
 data class ResolvableMedia(
     private val path: String,
-    private val workingDirectory: File? = null,
+    private val fileSystem: FileSystem,
 ) : Media {
     /**
      * The resolved media as a [LocalMedia] or [RemoteMedia].
@@ -26,9 +25,9 @@ data class ResolvableMedia(
         // If the path is a URL, it is remote.
         path.toURLOrNull()?.let { return RemoteMedia(it) }
 
-        val file = IOUtils.resolvePath(path, workingDirectory)
+        val file = fileSystem.resolve(path)
 
-        if (!file.exists()) throw IllegalArgumentException("Media path cannot be resolved: $path")
+        if (!file.exists) throw IllegalArgumentException("Media path cannot be resolved: $path")
         if (file.isDirectory) throw IllegalArgumentException("Media is a directory: $path")
 
         return LocalMedia(file)

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/media/export/MediaOutputResourceConverter.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/media/export/MediaOutputResourceConverter.kt
@@ -16,12 +16,25 @@ import com.quarkdown.core.pipeline.output.OutputResource
 class MediaOutputResourceConverter(
     private val name: String,
 ) : MediaVisitor<OutputResource> {
+    // Disk-backed media is copied efficiently by reference.
     override fun visit(media: LocalMedia) =
-        FileReferenceOutputArtifact(
-            name,
-            media.file,
-            useChecksumInvalidation = true,
-        )
+        when (val file = media.file.toFileOrNull()) {
+            null -> {
+                BinaryOutputArtifact(
+                    name,
+                    media.file.readBytes().toList(),
+                    ArtifactType.AUTO,
+                )
+            }
+
+            else -> {
+                FileReferenceOutputArtifact(
+                    name,
+                    file,
+                    useChecksumInvalidation = true,
+                )
+            }
+        }
 
     override fun visit(media: RemoteMedia) =
         BinaryOutputArtifact(

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/media/storage/MutableMediaStorage.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/media/storage/MutableMediaStorage.kt
@@ -1,5 +1,6 @@
 package com.quarkdown.core.media.storage
 
+import com.quarkdown.core.filesystem.FileSystem
 import com.quarkdown.core.media.Media
 import com.quarkdown.core.media.ResolvableMedia
 import com.quarkdown.core.media.export.MediaOutputResourceConverter
@@ -11,7 +12,6 @@ import com.quarkdown.core.media.storage.permissions.MediaAccessPermissionChecker
 import com.quarkdown.core.permissions.PermissionHolder
 import com.quarkdown.core.pipeline.output.OutputResource
 import com.quarkdown.core.pipeline.output.OutputResourceGroup
-import java.io.File
 
 /**
  * The name of the media subdirectory in the output resources.
@@ -103,13 +103,13 @@ class MutableMediaStorage(
     /**
      * Registers a media by its path. The corresponding media is resolved lazily from the path.
      * @param path path to the media, either a file or a URL
-     * @param workingDirectory directory to resolve the media from, in case the path is relative
-     * @return the [StoredMedia] associated with the path. If a media was already bound to the path, it is returned. Otherwise, the new [media] is returned.
-     * It may also return `null` if the media is not accepted into the storage.
+     * @param fileSystem file system to resolve the media from, in case the path is a local file
+     * @return the [StoredMedia] associated with the path: the existing binding if the path was already registered,
+     * or the newly resolved media otherwise. It may also return `null` if the media is not accepted into the storage.
      * @see ResolvableMedia
      */
     fun register(
         path: String,
-        workingDirectory: File?,
-    ): StoredMedia? = register(path, ResolvableMedia(path, workingDirectory))
+        fileSystem: FileSystem,
+    ): StoredMedia? = register(path, ResolvableMedia(path, fileSystem))
 }

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/misc/font/resolver/FontFamilyResolver.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/misc/font/resolver/FontFamilyResolver.kt
@@ -1,7 +1,7 @@
 package com.quarkdown.core.misc.font.resolver
 
+import com.quarkdown.core.filesystem.FileSystem
 import com.quarkdown.core.misc.font.FontFamily
-import java.io.File
 
 /**
  * Resolver of a [FontFamily] by its name or path, from system fonts or media.
@@ -10,12 +10,12 @@ interface FontFamilyResolver {
     /**
      * Resolves a [FontFamily] by its name or path.
      * @param nameOrPath the name of the system font or the path/URL to the font file
-     * @param workingDirectory the working directory to resolve relative paths
+     * @param fileSystem the file system to resolve relative font file paths from
      * @return a new [FontFamily] if found
      */
     fun resolve(
         nameOrPath: String,
-        workingDirectory: File?,
+        fileSystem: FileSystem,
     ): FontFamily?
 
     companion object {

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/misc/font/resolver/JVMFontFamilyResolver.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/misc/font/resolver/JVMFontFamilyResolver.kt
@@ -1,9 +1,9 @@
 package com.quarkdown.core.misc.font.resolver
 
+import com.quarkdown.core.filesystem.FileSystem
 import com.quarkdown.core.media.ResolvableMedia
 import com.quarkdown.core.misc.font.FontFamily
 import java.awt.GraphicsEnvironment
-import java.io.File
 
 private const val GOOGLE_FONTS_PREFIX = "GoogleFonts:"
 
@@ -15,7 +15,7 @@ internal object JVMFontFamilyResolver : FontFamilyResolver {
 
     override fun resolve(
         nameOrPath: String,
-        workingDirectory: File?,
+        fileSystem: FileSystem,
     ): FontFamily? =
         when {
             nameOrPath.startsWith(GOOGLE_FONTS_PREFIX) -> {
@@ -26,7 +26,7 @@ internal object JVMFontFamilyResolver : FontFamilyResolver {
             isSystemFont(nameOrPath) -> FontFamily.System(nameOrPath)
 
             else -> {
-                val media = ResolvableMedia(nameOrPath, workingDirectory)
+                val media = ResolvableMedia(nameOrPath, fileSystem)
                 FontFamily.Media(media, nameOrPath)
             }
         }

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/permissions/PermissionHolder.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/permissions/PermissionHolder.kt
@@ -1,8 +1,7 @@
 package com.quarkdown.core.permissions
 
-import com.quarkdown.core.context.file.FileSystem
-import com.quarkdown.core.util.IOUtils
-import java.io.File
+import com.quarkdown.core.filesystem.FileSystem
+import com.quarkdown.core.filesystem.FsEntry
 
 /**
  * An entity that holds a set of granted [Permission]s and provides convenience methods
@@ -42,9 +41,9 @@ fun PermissionHolder.requirePermission(
  * @param file the file to check
  * @return the required [Permission] to read the file
  */
-private fun PermissionHolder.getReadPermission(file: File): Permission {
+private fun PermissionHolder.getReadPermission(file: FsEntry): Permission {
     val workingDirectory = rootFileSystem?.workingDirectory ?: return Permission.GlobalRead
-    return if (IOUtils.isSubPath(workingDirectory, file)) {
+    return if (file.isSubPathOf(workingDirectory)) {
         Permission.ProjectRead
     } else {
         Permission.GlobalRead
@@ -61,8 +60,8 @@ private fun PermissionHolder.getReadPermission(file: File): Permission {
  * @see getReadPermission
  */
 fun PermissionHolder.requireReadPermission(
-    file: File,
-    message: String = "Cannot access file ${file.absolutePath}",
+    file: FsEntry,
+    message: String = "Cannot access file ${file.fullPath}",
 ) {
     requirePermission(required = getReadPermission(file), message)
 }

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/pipeline/PipelineOptions.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/pipeline/PipelineOptions.kt
@@ -1,12 +1,13 @@
 package com.quarkdown.core.pipeline
 
 import com.quarkdown.core.document.sub.SubdocumentOutputNaming
+import com.quarkdown.core.filesystem.DiskFileSystem
+import com.quarkdown.core.filesystem.FileSystem
 import com.quarkdown.core.media.storage.options.MediaStorageOptions
 import com.quarkdown.core.media.storage.options.ReadOnlyMediaStorageOptions
 import com.quarkdown.core.permissions.Permission
 import com.quarkdown.core.pipeline.error.BasePipelineErrorHandler
 import com.quarkdown.core.pipeline.error.PipelineErrorHandler
-import java.io.File
 
 /**
  * Read-only settings that affect different behaviors of a [Pipeline].
@@ -15,8 +16,11 @@ import java.io.File
  * @param wrapOutput whether the rendered code should be wrapped in a template code.
  * For example, an HTML wrapper may add `<html><head>...</head><body>...</body></html>`,
  * with the actual content injected in `body`
- * @param workingDirectory the starting directory to use when resolving relative paths from function calls.
- * Note: subdocuments may have different working directories. For consistent results rely on [com.quarkdown.core.context.file.FileSystem.workingDirectory]
+ * @param fileSystem the file system used to resolve and read input files, such as data files,
+ * included sources, subdocuments, and media. Its working directory is the starting directory
+ * for resolving relative paths from function calls.
+ * Note: subdocuments may have different working directories. For consistent results rely on
+ * [com.quarkdown.core.filesystem.FileSystem.workingDirectory] of the current context.
  * @param enableMediaStorage whether media storage should be enabled.
  * If enabled, media objects referenced in the document are copied to the output directory
  * and those elements that use them (e.g. images) automatically reference the new local path.
@@ -36,7 +40,7 @@ data class PipelineOptions(
     val resourceName: String? = null,
     val prettyOutput: Boolean = false,
     val wrapOutput: Boolean = true,
-    val workingDirectory: File? = null,
+    val fileSystem: FileSystem = DiskFileSystem(),
     val enableMediaStorage: Boolean = true,
     val forbidFunctionOverwriting: Boolean = false,
     val subdocumentNaming: SubdocumentOutputNaming = SubdocumentOutputNaming.FILE_NAME,

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/util/IOUtils.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/util/IOUtils.kt
@@ -1,14 +1,15 @@
 package com.quarkdown.core.util
 
 import com.quarkdown.core.log.Log
+import okio.HashingSink
+import okio.blackholeSink
+import okio.buffer
 import java.io.File
 import java.io.IOException
 import java.nio.file.FileAlreadyExistsException
 import java.nio.file.Files
 import java.nio.file.Path
-import java.security.MessageDigest
 import kotlin.io.path.ExperimentalPathApi
-import kotlin.io.path.Path
 import kotlin.io.path.createSymbolicLinkPointingTo
 import kotlin.io.path.deleteRecursively
 
@@ -17,62 +18,30 @@ import kotlin.io.path.deleteRecursively
  */
 object IOUtils {
     /**
-     * Resolves a [File] located in [path], either relative or absolute.
-     * If the path is relative, the location is determined from the [workingDirectory].
-     * @param path path of the file, either relative or absolute
-     * @param workingDirectory directory from which the file is resolved, in case the path is relative
-     * @return a [File] instance of the file
-     */
-    fun resolvePath(
-        path: String,
-        workingDirectory: File?,
-    ): File =
-        if (workingDirectory != null && !Path(path).isAbsolute) {
-            File(workingDirectory, path)
-        } else {
-            File(path)
-        }
-
-    /**
-     * Checks whether a [child] file is located in [parent] or any of its subdirectories.
-     * Symlinks are resolved to their real paths when possible, so that a symlink inside [parent]
-     * pointing outside it is correctly detected as not being a sub-path.
-     * @param parent the parent directory
-     * @param child the child file
-     * @return `true` if the child is located in the parent, `false` otherwise
-     */
-    fun isSubPath(
-        parent: File,
-        child: File,
-    ): Boolean {
-        val parentPath = parent.toPath().resolveReal()
-        val childPath = child.toPath().resolveReal()
-        return childPath.startsWith(parentPath)
-    }
-
-    /**
      * Computes an SHA-256 digest that represents the current state of [file].
      * - For a regular file, the digest covers its content.
      * - For a directory, the digest covers the sorted list of relative paths and file sizes,
      *   which is fast (metadata only) and catches additions, deletions, and size changes.
      */
     fun computeChecksum(file: File): String {
-        val digest = MessageDigest.getInstance("SHA-256")
-        if (file.isFile) {
-            digest.update(file.readBytes())
-        } else {
-            file
-                .walkTopDown()
-                .filter { it.isFile }
-                .sortedBy { it.relativeTo(file).path }
-                .forEach {
-                    digest.update(it.relativeTo(file).path.toByteArray())
-                    digest.update(0)
-                    digest.update(it.length().toString().toByteArray())
-                    digest.update(0)
-                }
+        val hashingSink = HashingSink.sha256(blackholeSink())
+        hashingSink.buffer().use { sink ->
+            if (file.isFile) {
+                sink.write(file.readBytes())
+            } else {
+                file
+                    .walkTopDown()
+                    .filter { it.isFile }
+                    .sortedBy { it.relativeTo(file).path }
+                    .forEach {
+                        sink.writeUtf8(it.relativeTo(file).path)
+                        sink.writeByte(0)
+                        sink.writeUtf8(it.length().toString())
+                        sink.writeByte(0)
+                    }
+            }
         }
-        return digest.digest().joinToString("") { "%02x".format(it) }
+        return hashingSink.hash.hex()
     }
 
     /**
@@ -126,15 +95,4 @@ object IOUtils {
             target.createSymbolicLinkPointingTo(source)
         }
     }
-
-    /**
-     * Resolves a path to its real (symlink-resolved) form if the file exists,
-     * falling back to absolute + normalized form for non-existent paths.
-     */
-    private fun Path.resolveReal(): Path =
-        try {
-            toRealPath()
-        } catch (_: IOException) {
-            toAbsolutePath().normalize()
-        }
 }

--- a/quarkdown-core/src/test/kotlin/com/quarkdown/core/AstDslTest.kt
+++ b/quarkdown-core/src/test/kotlin/com/quarkdown/core/AstDslTest.kt
@@ -18,7 +18,7 @@ import com.quarkdown.core.ast.base.inline.Link
 import com.quarkdown.core.ast.base.inline.Strong
 import com.quarkdown.core.ast.base.inline.Text
 import com.quarkdown.core.ast.dsl.buildBlock
-import com.quarkdown.core.context.file.SimpleFileSystem
+import com.quarkdown.core.filesystem.DiskFileSystem
 import kotlin.test.Test
 
 /**
@@ -103,7 +103,7 @@ class AstDslTest {
                                                             listOf(Strong(listOf(Text("alt")))),
                                                             url = "url",
                                                             title = listOf(Text("title")),
-                                                            fileSystem = SimpleFileSystem(),
+                                                            fileSystem = DiskFileSystem(),
                                                         ),
                                                     width = null,
                                                     height = null,

--- a/quarkdown-core/src/test/kotlin/com/quarkdown/core/FontTest.kt
+++ b/quarkdown-core/src/test/kotlin/com/quarkdown/core/FontTest.kt
@@ -1,5 +1,7 @@
 package com.quarkdown.core
 
+import com.quarkdown.core.filesystem.DiskFileSystem
+import com.quarkdown.core.filesystem.VirtualFileSystem
 import com.quarkdown.core.misc.font.FontFamily
 import com.quarkdown.core.misc.font.resolver.FontFamilyResolver
 import org.junit.Assume.assumeTrue
@@ -18,14 +20,14 @@ class FontTest {
         val name = "Impact"
         assumeTrue(name in GraphicsEnvironment.getLocalGraphicsEnvironment().availableFontFamilyNames)
         assertIs<FontFamily.System>(
-            FontFamilyResolver.SYSTEM.resolve(name, workingDirectory = File(".")),
+            FontFamilyResolver.SYSTEM.resolve(name, DiskFileSystem(File("."))),
         )
     }
 
     @Test
     fun `local media font`() {
         assertIs<FontFamily.Media>(
-            FontFamilyResolver.SYSTEM.resolve("path/to/font.ttf", workingDirectory = File(".")),
+            FontFamilyResolver.SYSTEM.resolve("path/to/font.ttf", DiskFileSystem(File("."))),
         )
     }
 
@@ -33,14 +35,22 @@ class FontTest {
     fun `remote media font`() {
         val url = "https://example.com/fonts/font.ttf"
         assertIs<FontFamily.Media>(
-            FontFamilyResolver.SYSTEM.resolve(url, workingDirectory = null),
+            FontFamilyResolver.SYSTEM.resolve(url, DiskFileSystem()),
         )
     }
 
     @Test
     fun `google font`() {
-        val font = FontFamilyResolver.SYSTEM.resolve("GoogleFonts:Noto Sans", workingDirectory = null)
+        val font = FontFamilyResolver.SYSTEM.resolve("GoogleFonts:Noto Sans", DiskFileSystem())
         assertIs<FontFamily.GoogleFont>(font)
         assertEquals("Noto Sans", font.name)
+    }
+
+    @Test
+    fun `resolves font file from virtual file system`() {
+        val fs = VirtualFileSystem("/project")
+        fs.writeBytes("fonts/custom.ttf", byteArrayOf(0))
+        val family = FontFamilyResolver.SYSTEM.resolve("fonts/custom.ttf", fs)
+        assertIs<FontFamily.Media>(family)
     }
 }

--- a/quarkdown-core/src/test/kotlin/com/quarkdown/core/IOUtilsTest.kt
+++ b/quarkdown-core/src/test/kotlin/com/quarkdown/core/IOUtilsTest.kt
@@ -3,12 +3,9 @@ package com.quarkdown.core
 import com.quarkdown.core.util.IOUtils
 import java.io.File
 import java.nio.file.Files
-import kotlin.io.path.createDirectories
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFalse
 import kotlin.test.assertNotEquals
-import kotlin.test.assertTrue
 
 /**
  * Tests for [IOUtils] file resolution and path utilities.
@@ -17,54 +14,6 @@ class IOUtilsTest {
     private val root = File.listRoots().first().absolutePath
 
     private fun abs(vararg segments: String) = File(root + segments.joinToString(File.separator))
-
-    @Test
-    fun `isSubPath returns true for child`() {
-        assertTrue(IOUtils.isSubPath(parent = abs("a", "b"), child = abs("a", "b", "c", "d")))
-    }
-
-    @Test
-    fun `isSubPath returns false for sibling`() {
-        assertFalse(IOUtils.isSubPath(parent = abs("a", "b"), child = abs("a", "c")))
-    }
-
-    @Test
-    fun `isSubPath normalizes paths`() {
-        assertTrue(IOUtils.isSubPath(parent = abs("a", "b"), child = File(abs("a", "b", "..", "b", "c").path)))
-    }
-
-    @Test
-    fun `isSubPath resolves symlinks`() {
-        val tempDir = Files.createTempDirectory("isSubPathTest")
-        try {
-            val projectDir = tempDir.resolve("project").createDirectories()
-            val outsideFile = Files.createFile(tempDir.resolve("secret.txt"))
-            val symlink = Files.createSymbolicLink(projectDir.resolve("link.txt"), outsideFile)
-
-            assertFalse(IOUtils.isSubPath(parent = projectDir.toFile(), child = symlink.toFile()))
-        } finally {
-            tempDir.toFile().deleteRecursively()
-        }
-    }
-
-    @Test
-    fun `resolvePath resolves relative path from working directory`() {
-        val result = IOUtils.resolvePath("sub/file.txt", workingDirectory = abs("project"))
-        assertEquals(File(abs("project"), "sub/file.txt"), result)
-    }
-
-    @Test
-    fun `resolvePath resolves absolute path ignoring working directory`() {
-        val absolutePath = abs("absolute", "file.txt").path
-        val result = IOUtils.resolvePath(absolutePath, workingDirectory = abs("project"))
-        assertEquals(File(absolutePath), result)
-    }
-
-    @Test
-    fun `resolvePath resolves relative path as-is when working directory is null`() {
-        val result = IOUtils.resolvePath("relative/file.txt", workingDirectory = null)
-        assertEquals(File("relative/file.txt"), result)
-    }
 
     // Checksum
 

--- a/quarkdown-core/src/test/kotlin/com/quarkdown/core/LinkUrlResolverTest.kt
+++ b/quarkdown-core/src/test/kotlin/com/quarkdown/core/LinkUrlResolverTest.kt
@@ -10,9 +10,10 @@ import com.quarkdown.core.ast.dsl.buildBlock
 import com.quarkdown.core.ast.dsl.buildInline
 import com.quarkdown.core.ast.iterator.ObservableAstIterator
 import com.quarkdown.core.context.MutableContext
-import com.quarkdown.core.context.file.FileSystem
-import com.quarkdown.core.context.file.SimpleFileSystem
 import com.quarkdown.core.context.hooks.LinkUrlResolverHook
+import com.quarkdown.core.filesystem.DiskFileSystem
+import com.quarkdown.core.filesystem.FileSystem
+import com.quarkdown.core.filesystem.FsEntry
 import com.quarkdown.core.permissions.Permission
 import com.quarkdown.core.pipeline.PipelineOptions
 import java.io.File
@@ -25,13 +26,16 @@ private val ROOT_DIR = File("src/test/resources").absoluteFile
  * Tests for relative link path resolution via [LinkUrlResolverHook].
  */
 class LinkUrlResolverTest {
+    /** Converts a [File] to a disk-backed [FsEntry]. */
+    private fun File.toEntry(): FsEntry = DiskFileSystem().resolve(absolutePath)
+
     private fun createContext(workingDirectory: File = ROOT_DIR): MutableContext {
         val context =
             object : MutableContext() {
                 override val permissions = setOf(Permission.GlobalRead)
             }
         context.attachMockPipeline(
-            options = PipelineOptions(workingDirectory = workingDirectory),
+            options = PipelineOptions(fileSystem = DiskFileSystem(workingDirectory)),
         )
         return context
     }
@@ -89,7 +93,7 @@ class LinkUrlResolverTest {
     @Test
     fun `no resolution when file system is root`() {
         val context = createContext()
-        val rootFs = SimpleFileSystem(ROOT_DIR)
+        val rootFs = DiskFileSystem(ROOT_DIR)
 
         val img = image("img/icon.png", fileSystem = rootFs)
         val root = buildBlock { root { +img } }
@@ -106,7 +110,7 @@ class LinkUrlResolverTest {
 
         // Simulate a subdocument in a child directory.
         val childDir = File(ROOT_DIR, "subdoc")
-        val childFs = SimpleFileSystem(ROOT_DIR).branch(childDir)
+        val childFs = DiskFileSystem(ROOT_DIR).branch(childDir.toEntry())
 
         val img = image("../img/icon.png", fileSystem = childFs)
         val root = buildBlock { root { +img } }
@@ -123,7 +127,7 @@ class LinkUrlResolverTest {
         val context = createContext()
 
         val childDir = File(ROOT_DIR, "subdoc")
-        val childFs = SimpleFileSystem(ROOT_DIR).branch(childDir)
+        val childFs = DiskFileSystem(ROOT_DIR).branch(childDir.toEntry())
 
         val img = image("picture.png", fileSystem = childFs)
         val root = buildBlock { root { +img } }
@@ -138,7 +142,7 @@ class LinkUrlResolverTest {
     fun `skips absolute URLs`() {
         val context = createContext()
 
-        val childFs = SimpleFileSystem(ROOT_DIR).branch(File(ROOT_DIR, "subdoc"))
+        val childFs = DiskFileSystem(ROOT_DIR).branch(File(ROOT_DIR, "subdoc").toEntry())
         val img = image("https://example.com/image.png", fileSystem = childFs)
         val root = buildBlock { root { +img } }
 
@@ -151,7 +155,7 @@ class LinkUrlResolverTest {
     fun `skips absolute file paths`() {
         val context = createContext()
 
-        val childFs = SimpleFileSystem(ROOT_DIR).branch(File(ROOT_DIR, "subdoc"))
+        val childFs = DiskFileSystem(ROOT_DIR).branch(File(ROOT_DIR, "subdoc").toEntry())
         val img = image("/absolute/path/image.png", fileSystem = childFs)
         val root = buildBlock { root { +img } }
 
@@ -164,7 +168,7 @@ class LinkUrlResolverTest {
     fun `skips passthrough paths`() {
         val context = createContext()
 
-        val childFs = SimpleFileSystem(ROOT_DIR).branch(File(ROOT_DIR, "subdoc"))
+        val childFs = DiskFileSystem(ROOT_DIR).branch(File(ROOT_DIR, "subdoc").toEntry())
         val img = image("@/img/icon.png", fileSystem = childFs)
         val root = buildBlock { root { +img } }
 
@@ -179,7 +183,7 @@ class LinkUrlResolverTest {
         val context = createContext()
 
         val childDir = File(ROOT_DIR, "subdoc")
-        val childFs = SimpleFileSystem(ROOT_DIR).branch(childDir)
+        val childFs = DiskFileSystem(ROOT_DIR).branch(childDir.toEntry())
 
         val def = linkDefinition("../img/icon.png", fileSystem = childFs)
         val root = buildBlock { root { +def } }

--- a/quarkdown-core/src/test/kotlin/com/quarkdown/core/MediaTest.kt
+++ b/quarkdown-core/src/test/kotlin/com/quarkdown/core/MediaTest.kt
@@ -6,22 +6,27 @@ import com.quarkdown.core.ast.base.inline.Link
 import com.quarkdown.core.ast.media.StoredMediaProperty
 import com.quarkdown.core.ast.media.getStoredMedia
 import com.quarkdown.core.context.MutableContext
-import com.quarkdown.core.context.file.FileSystem
-import com.quarkdown.core.context.file.SimpleFileSystem
+import com.quarkdown.core.filesystem.DiskFileSystem
+import com.quarkdown.core.filesystem.FileSystem
+import com.quarkdown.core.filesystem.VirtualFileSystem
 import com.quarkdown.core.media.LocalMedia
 import com.quarkdown.core.media.Media
 import com.quarkdown.core.media.MediaVisitor
 import com.quarkdown.core.media.RemoteMedia
 import com.quarkdown.core.media.ResolvableMedia
+import com.quarkdown.core.media.export.MediaOutputResourceConverter
 import com.quarkdown.core.media.storage.MEDIA_SUBDIRECTORY_NAME
 import com.quarkdown.core.media.storage.MutableMediaStorage
 import com.quarkdown.core.media.storage.StoredMedia
 import com.quarkdown.core.media.storage.options.ReadOnlyMediaStorageOptions
 import com.quarkdown.core.permissions.MissingPermissionException
 import com.quarkdown.core.permissions.Permission
+import com.quarkdown.core.pipeline.output.BinaryOutputArtifact
+import com.quarkdown.core.pipeline.output.FileReferenceOutputArtifact
 import java.io.File
 import kotlin.test.BeforeTest
 import kotlin.test.Test
+import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertFails
 import kotlin.test.assertFailsWith
@@ -88,30 +93,30 @@ class MediaTest {
 
     @Test
     fun `resolve valid local media`() {
-        val media = ResolvableMedia(File(WORKING_DIR_PATH, LOCAL_ICON).path).accept(selfVisitor)
+        val media = ResolvableMedia(File(WORKING_DIR_PATH, LOCAL_ICON).path, DiskFileSystem()).accept(selfVisitor)
         assertIs<LocalMedia>(media)
     }
 
     @Test
     fun `resolve valid remote media`() {
-        val media = ResolvableMedia(REMOTE_IMAGE).accept(selfVisitor)
+        val media = ResolvableMedia(REMOTE_IMAGE, DiskFileSystem()).accept(selfVisitor)
         assertIs<RemoteMedia>(media)
     }
 
     @Test
     fun `throw on invalid path`() {
-        assertFails { ResolvableMedia(INVALID_PATH).accept(selfVisitor) }
+        assertFails { ResolvableMedia(INVALID_PATH, DiskFileSystem()).accept(selfVisitor) }
     }
 
     @Test
     fun `throw on directory path`() {
-        assertFails { ResolvableMedia(WORKING_DIR_PATH).accept(selfVisitor) }
+        assertFails { ResolvableMedia(WORKING_DIR_PATH, DiskFileSystem()).accept(selfVisitor) }
     }
 
     @Test
     fun `register and resolve local media`() {
         val storage = createLocalOnlyStorage()
-        storage.register(LOCAL_ICON, workingDirectory = workingDir)
+        storage.register(LOCAL_ICON, fileSystem = DiskFileSystem(workingDir))
 
         val stored = storage.resolve(LOCAL_ICON)
         assertEquals(1, storage.all.size)
@@ -122,8 +127,8 @@ class MediaTest {
     @Test
     fun `resolve multiple local media entries`() {
         val storage = createLocalOnlyStorage()
-        storage.register(LOCAL_ICON, workingDirectory = workingDir)
-        storage.register(LOCAL_BANNER, workingDirectory = workingDir)
+        storage.register(LOCAL_ICON, fileSystem = DiskFileSystem(workingDir))
+        storage.register(LOCAL_BANNER, fileSystem = DiskFileSystem(workingDir))
 
         assertEquals(2, storage.all.size)
 
@@ -135,16 +140,16 @@ class MediaTest {
     @Test
     fun `unresolved remote media in local-only storage`() {
         val storage = createLocalOnlyStorage()
-        storage.register(REMOTE_LOGO, workingDirectory = null)
+        storage.register(REMOTE_LOGO, fileSystem = DiskFileSystem())
         assertEquals(0, storage.resolve(REMOTE_LOGO)?.let { 1 } ?: 0)
     }
 
     @Test
     fun `register and resolve both local and remote media`() {
         val storage = createLocalAndRemoteStorage()
-        storage.register(LOCAL_ICON, workingDir)
-        storage.register(LOCAL_BANNER, workingDir)
-        storage.register(REMOTE_LOGO, null)
+        storage.register(LOCAL_ICON, DiskFileSystem(workingDir))
+        storage.register(LOCAL_BANNER, DiskFileSystem(workingDir))
+        storage.register(REMOTE_LOGO, DiskFileSystem())
 
         assertEquals(3, storage.all.size)
         assertEquals(REMOTE_LOGO_OUT_NAME, storage.resolve(REMOTE_LOGO)?.name)
@@ -153,8 +158,8 @@ class MediaTest {
     @Test
     fun `media with same filename but different paths do not collide`() {
         val storage = createLocalAndRemoteStorage()
-        storage.register(OUT_PATH_1, workingDir)
-        storage.register(OUT_PATH_2, workingDir)
+        storage.register(OUT_PATH_1, DiskFileSystem(workingDir))
+        storage.register(OUT_PATH_2, DiskFileSystem(workingDir))
 
         val name1 = storage.resolve(OUT_PATH_1)!!.name
         val name2 = storage.resolve(OUT_PATH_2)!!.name
@@ -191,7 +196,7 @@ class MediaTest {
     @Test
     fun `remote media path retrieval`() {
         val storage = createLocalAndRemoteStorage()
-        val media = storage.register(REMOTE_LOGO, workingDirectory = null)!!
+        val media = storage.register(REMOTE_LOGO, fileSystem = DiskFileSystem())!!
         val image = remoteImage(media)
         assertEquals("$OUT_DIR/$REMOTE_LOGO_OUT_NAME", image.link.getStoredMedia(context.attributes)?.path)
     }
@@ -199,7 +204,7 @@ class MediaTest {
     @Test
     fun `local media path retrieval`() {
         val storage = createLocalAndRemoteStorage()
-        val media = storage.register(LOCAL_ICON, workingDirectory = workingDir)!!
+        val media = storage.register(LOCAL_ICON, fileSystem = DiskFileSystem(workingDir))!!
         val image = localImage(media)
         image.link.getStoredMedia(context.attributes)?.path?.let {
             assertTrue(it.startsWith("$OUT_DIR/icon@"))
@@ -210,7 +215,7 @@ class MediaTest {
     @Test
     fun `denied remote media path retrieval`() {
         val storage = createLocalOnlyStorage()
-        val media = storage.register(REMOTE_LOGO, workingDirectory = null)
+        val media = storage.register(REMOTE_LOGO, fileSystem = DiskFileSystem())
         val image = remoteImage(media)
         assertNull(media)
         assertNull(image.link.getStoredMedia(context.attributes))
@@ -236,7 +241,7 @@ class MediaTest {
     fun `denied local media registration without read permission`() {
         val storage = createStorageWithPermissions()
         assertFailsWith<MissingPermissionException> {
-            storage.register(LOCAL_ICON, workingDirectory = workingDir)
+            storage.register(LOCAL_ICON, fileSystem = DiskFileSystem(workingDir))
         }
     }
 
@@ -244,7 +249,7 @@ class MediaTest {
     fun `denied local media registration with only ProjectRead and no root file system`() {
         val storage = createStorageWithPermissions(permissions = setOf(Permission.ProjectRead))
         assertFailsWith<MissingPermissionException> {
-            storage.register(LOCAL_ICON, workingDirectory = workingDir)
+            storage.register(LOCAL_ICON, fileSystem = DiskFileSystem(workingDir))
         }
     }
 
@@ -256,7 +261,7 @@ class MediaTest {
                 permissions = setOf(Permission.GlobalRead),
             )
         assertFailsWith<MissingPermissionException> {
-            storage.register(REMOTE_LOGO, workingDirectory = null)
+            storage.register(REMOTE_LOGO, fileSystem = DiskFileSystem())
         }
     }
 
@@ -265,9 +270,9 @@ class MediaTest {
         val storage =
             createStorageWithPermissions(
                 permissions = setOf(Permission.ProjectRead),
-                rootFileSystem = SimpleFileSystem(workingDir),
+                rootFileSystem = DiskFileSystem(workingDir),
             )
-        val stored = storage.register(LOCAL_ICON, workingDirectory = workingDir)
+        val stored = storage.register(LOCAL_ICON, fileSystem = DiskFileSystem(workingDir))
         assertTrue(stored!!.name.startsWith("icon@"))
     }
 
@@ -277,10 +282,37 @@ class MediaTest {
         val storage =
             createStorageWithPermissions(
                 permissions = setOf(Permission.ProjectRead),
-                rootFileSystem = SimpleFileSystem(narrowRoot),
+                rootFileSystem = DiskFileSystem(narrowRoot),
             )
         assertFailsWith<MissingPermissionException> {
-            storage.register(LOCAL_ICON, workingDirectory = workingDir)
+            storage.register(LOCAL_ICON, fileSystem = DiskFileSystem(workingDir))
         }
+    }
+
+    @Test
+    fun `local media from virtual file system`() {
+        val fs = VirtualFileSystem("/project")
+        fs.writeBytes("media/icon.png", byteArrayOf(1, 2, 3))
+        val media = ResolvableMedia("media/icon.png", fs).accept(selfVisitor)
+        assertIs<LocalMedia>(media)
+        assertContentEquals(byteArrayOf(1, 2, 3), media.file.readBytes())
+        assertNull(media.file.toFileOrNull())
+    }
+
+    @Test
+    fun `virtual local media exports as binary artifact`() {
+        val fs = VirtualFileSystem("/project")
+        fs.writeBytes("icon.png", byteArrayOf(4, 5))
+        val media = LocalMedia(fs.resolve("icon.png"))
+        val resource = media.accept(MediaOutputResourceConverter("icon.png"))
+        assertIs<BinaryOutputArtifact>(resource)
+        assertEquals(listOf<Byte>(4, 5), resource.content)
+    }
+
+    @Test
+    fun `disk local media exports as file reference artifact`() {
+        val media = LocalMedia(DiskFileSystem(workingDir).resolve(LOCAL_ICON))
+        val resource = media.accept(MediaOutputResourceConverter("icon"))
+        assertIs<FileReferenceOutputArtifact>(resource)
     }
 }

--- a/quarkdown-core/src/test/kotlin/com/quarkdown/core/PermissionTest.kt
+++ b/quarkdown-core/src/test/kotlin/com/quarkdown/core/PermissionTest.kt
@@ -1,6 +1,7 @@
 package com.quarkdown.core
 
-import com.quarkdown.core.context.file.SimpleFileSystem
+import com.quarkdown.core.filesystem.DiskFileSystem
+import com.quarkdown.core.filesystem.FsEntry
 import com.quarkdown.core.permissions.MissingPermissionException
 import com.quarkdown.core.permissions.Permission.GlobalRead
 import com.quarkdown.core.permissions.Permission.NativeContent
@@ -17,6 +18,9 @@ import kotlin.test.assertFailsWith
  * Tests for the permission system primitives: [requirePermission] and [requireReadPermission].
  */
 class PermissionTest {
+    /** Creates a disk-backed [FsEntry] for the given absolute [path]. */
+    private fun entry(path: String): FsEntry = DiskFileSystem().resolve(path)
+
     @Test
     fun `requirePermission succeeds when permission is granted`() {
         requirePermission(ProjectRead, granted = setOf(ProjectRead, NativeContent), message = "test")
@@ -35,9 +39,9 @@ class PermissionTest {
         val holder =
             MockPermissionHolder(
                 permissions = setOf(ProjectRead),
-                rootFileSystem = SimpleFileSystem(workingDir),
+                rootFileSystem = DiskFileSystem(workingDir),
             )
-        holder.requireReadPermission(File("/project/src/file.txt"))
+        holder.requireReadPermission(entry("/project/src/file.txt"))
     }
 
     @Test
@@ -46,10 +50,10 @@ class PermissionTest {
         val holder =
             MockPermissionHolder(
                 permissions = setOf(ProjectRead),
-                rootFileSystem = SimpleFileSystem(workingDir),
+                rootFileSystem = DiskFileSystem(workingDir),
             )
         assertFailsWith<MissingPermissionException> {
-            holder.requireReadPermission(File("/other/file.txt"))
+            holder.requireReadPermission(entry("/other/file.txt"))
         }
     }
 
@@ -59,9 +63,9 @@ class PermissionTest {
         val holder =
             MockPermissionHolder(
                 permissions = setOf(ProjectRead, GlobalRead),
-                rootFileSystem = SimpleFileSystem(workingDir),
+                rootFileSystem = DiskFileSystem(workingDir),
             )
-        holder.requireReadPermission(File("/other/file.txt"))
+        holder.requireReadPermission(entry("/other/file.txt"))
     }
 
     @Test
@@ -75,10 +79,10 @@ class PermissionTest {
             val holder =
                 MockPermissionHolder(
                     permissions = setOf(ProjectRead),
-                    rootFileSystem = SimpleFileSystem(projectDir.toFile()),
+                    rootFileSystem = DiskFileSystem(projectDir.toFile()),
                 )
             assertFailsWith<MissingPermissionException> {
-                holder.requireReadPermission(symlink.toFile())
+                holder.requireReadPermission(entry(symlink.toString()))
             }
         } finally {
             tempDir.toFile().deleteRecursively()
@@ -88,11 +92,11 @@ class PermissionTest {
     @Test
     fun `requireReadPermission treats all files as global when rootFileSystem is null`() {
         val holderWithGlobal = MockPermissionHolder(permissions = setOf(GlobalRead), rootFileSystem = null)
-        holderWithGlobal.requireReadPermission(File("/any/file.txt"))
+        holderWithGlobal.requireReadPermission(entry("/any/file.txt"))
 
         val holderWithoutGlobal = MockPermissionHolder(permissions = setOf(ProjectRead), rootFileSystem = null)
         assertFailsWith<MissingPermissionException> {
-            holderWithoutGlobal.requireReadPermission(File("/any/file.txt"))
+            holderWithoutGlobal.requireReadPermission(entry("/any/file.txt"))
         }
     }
 }

--- a/quarkdown-core/src/test/kotlin/com/quarkdown/core/filesystem/FileSystemContractTest.kt
+++ b/quarkdown-core/src/test/kotlin/com/quarkdown/core/filesystem/FileSystemContractTest.kt
@@ -1,0 +1,115 @@
+package com.quarkdown.core.filesystem
+
+import java.io.File
+import java.nio.file.Files
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Behavioral contract for [FileSystem] implementations.
+ */
+sealed class FileSystemContractTest {
+    /** A file system whose working directory points at the seeded tree root. */
+    protected abstract val fs: FileSystem
+
+    @Test
+    fun `resolves relative paths against the working directory`() {
+        assertEquals("content", fs.resolve("file.txt").readText())
+        assertEquals("content", fs.resolve("sub/../file.txt").normalized.readText())
+    }
+
+    @Test
+    fun `resolves absolute paths as-is`() {
+        val absolute = fs.resolve("file.txt")
+        assertTrue(absolute.isAbsolute)
+        assertEquals(absolute, fs.resolve(absolute.fullPath))
+    }
+
+    @Test
+    fun `is root until branched`() {
+        assertTrue(fs.isRoot)
+        assertNull(fs.root)
+        val branched = fs.branch(fs.resolve("sub"))
+        assertFalse(branched.isRoot)
+        assertEquals(fs, branched.root)
+        // Branching from a branch keeps the original root.
+        val branchedTwice = branched.branch(fs.workingDirectory)
+        assertEquals(fs, branchedTwice.root)
+    }
+
+    @Test
+    fun `branched file system resolves from its own working directory`() {
+        val branched = fs.branch(fs.resolve("sub"))
+        assertTrue(branched.resolve("inner.txt").exists)
+    }
+
+    @Test
+    fun `reroot creates an independent root on the same backend`() {
+        val rerooted = fs.reroot(fs.resolve("sub"))
+        assertTrue(rerooted.isRoot)
+        assertTrue(rerooted.resolve("inner.txt").exists)
+    }
+
+    @Test
+    fun `computes relative paths between file systems`() {
+        val branched = fs.branch(fs.resolve("sub"))
+        assertEquals("sub", fs.relativePathTo(branched)?.invariantSeparatorsPath)
+        assertEquals("..", branched.relativePathTo(fs)?.invariantSeparatorsPath)
+        assertEquals(".", fs.relativePathTo(fs)?.invariantSeparatorsPath)
+    }
+
+    @Test
+    fun `relative path is null without a working directory`() {
+        assertNull(fs.reroot(null).relativePathTo(fs))
+        assertNull(fs.relativePathTo(fs.reroot(null)))
+    }
+}
+
+class DiskFileSystemTest : FileSystemContractTest() {
+    private val tempDir: File by lazy { Files.createTempDirectory("filesystem-test").toFile() }
+
+    @AfterTest
+    fun cleanup() {
+        tempDir.deleteRecursively()
+    }
+
+    override val fs: FileSystem by lazy {
+        File(tempDir, "sub").mkdirs()
+        File(tempDir, "file.txt").writeText("content")
+        File(tempDir, "sub/inner.txt").writeText("inner")
+        DiskFileSystem(tempDir)
+    }
+
+    @Test
+    fun `entries are disk-backed`() {
+        assertEquals(
+            File(tempDir, "file.txt").canonicalFile,
+            fs.resolve("file.txt").canonical.toFileOrNull(),
+        )
+    }
+}
+
+class VirtualFileSystemTest : FileSystemContractTest() {
+    override val fs: VirtualFileSystem by lazy {
+        VirtualFileSystem("/project").apply {
+            mkdirs("sub")
+            write("file.txt", "content")
+            write("sub/inner.txt", "inner")
+        }
+    }
+
+    @Test
+    fun `entries are not disk-backed`() {
+        assertNull(fs.resolve("file.txt").toFileOrNull())
+    }
+
+    @Test
+    fun `write creates missing parent directories`() {
+        fs.write("deep/tree/leaf.txt", "leaf")
+        assertEquals("leaf", fs.resolve("deep/tree/leaf.txt").readText())
+    }
+}

--- a/quarkdown-core/src/test/kotlin/com/quarkdown/core/filesystem/FsEntryContractTest.kt
+++ b/quarkdown-core/src/test/kotlin/com/quarkdown/core/filesystem/FsEntryContractTest.kt
@@ -1,0 +1,136 @@
+package com.quarkdown.core.filesystem
+
+import okio.Path.Companion.toOkioPath
+import okio.Path.Companion.toPath
+import okio.fakefilesystem.FakeFileSystem
+import java.io.File
+import java.nio.file.Files
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import okio.FileSystem as OkioBackend
+
+/**
+ * Behavioral contract for [FsEntry], run against both the disk and the in-memory backend.
+ */
+abstract class FsEntryContractTest {
+    /** The backend under test. */
+    protected abstract val backend: OkioBackend
+
+    /** An absolute [FsEntry] pointing at the seeded root directory. */
+    protected abstract val root: FsEntry
+
+    /** Seeds the tree under [at]; called by subclasses while initializing [root]. */
+    protected fun seed(at: FsEntry) {
+        backend.createDirectories(at.path / "sub")
+        backend.write(at.path / "file.txt") { writeUtf8("hello\nworld") }
+        backend.write(at.path / "sub" / "nested.txt") { writeUtf8("nested") }
+    }
+
+    @Test
+    fun `resolves child entries`() {
+        val file = root.resolve("file.txt")
+        assertEquals("file.txt", file.name)
+        assertEquals("file", file.nameWithoutExtension)
+        assertEquals(root, file.parent)
+        assertTrue(file.isAbsolute)
+    }
+
+    @Test
+    fun `queries existence and kind`() {
+        assertTrue(root.resolve("file.txt").exists)
+        assertTrue(root.resolve("file.txt").isFile)
+        assertFalse(root.resolve("file.txt").isDirectory)
+        assertTrue(root.resolve("sub").isDirectory)
+        assertFalse(root.resolve("missing.txt").exists)
+    }
+
+    @Test
+    fun `reads content`() {
+        assertEquals("hello\nworld", root.resolve("file.txt").readText())
+        assertEquals(listOf("hello", "world"), root.resolve("file.txt").readLines())
+        assertEquals("nested", root.resolve("sub/nested.txt").readText())
+        assertTrue(root.resolve("file.txt").readBytes().isNotEmpty())
+    }
+
+    @Test
+    fun `lists children and descendants`() {
+        assertEquals(
+            setOf("file.txt", "sub"),
+            root.children().map { it.name }.toSet(),
+        )
+        assertEquals(
+            setOf("file.txt", "sub", "nested.txt"),
+            root.descendants().map { it.name }.toSet(),
+        )
+    }
+
+    @Test
+    fun `computes relative paths`() {
+        val nested = root.resolve("sub/nested.txt").normalized
+        assertEquals("sub/nested.txt", nested.relativeTo(root)?.invariantSeparatorsPath)
+    }
+
+    @Test
+    fun `detects sub-paths`() {
+        assertTrue(root.resolve("sub/nested.txt").isSubPathOf(root))
+        assertTrue(root.resolve("sub").isSubPathOf(root))
+        assertFalse(root.parent!!.isSubPathOf(root))
+        // Non-normalized escape.
+        assertFalse(root.resolve("../outside.txt").isSubPathOf(root))
+    }
+
+    @Test
+    fun `normalizes mixed separators`() {
+        assertEquals("hello\nworld", root.resolve("./file.txt").normalized.readText())
+    }
+}
+
+class DiskFsEntryTest : FsEntryContractTest() {
+    private val tempDir: File by lazy { Files.createTempDirectory("fsentry-test").toFile() }
+
+    @AfterTest
+    fun cleanup() {
+        tempDir.deleteRecursively()
+    }
+
+    override val backend: OkioBackend = OkioBackend.SYSTEM
+    override val root: FsEntry by lazy {
+        val entry = FsEntry(tempDir.toOkioPath(), backend)
+        seed(entry)
+        entry.canonical
+    }
+
+    @Test
+    fun `converts to java io File`() {
+        assertEquals(tempDir.canonicalFile, root.toFileOrNull())
+    }
+
+    @Test
+    fun `sub-path detection resolves symlinks`() {
+        val outside = root.resolve("secret.txt")
+        Files.createFile(outside.toFileOrNull()!!.toPath())
+        val symlink = root.resolve("sub/link.txt")
+        Files.createSymbolicLink(symlink.toFileOrNull()!!.toPath(), outside.toFileOrNull()!!.toPath())
+
+        // The symlink lives inside sub/, but points outside of it.
+        assertFalse(symlink.isSubPathOf(root.resolve("sub")))
+    }
+}
+
+class VirtualFsEntryTest : FsEntryContractTest() {
+    override val backend: OkioBackend = FakeFileSystem()
+    override val root: FsEntry by lazy {
+        val entry = FsEntry("/project".toPath(), backend)
+        seed(entry)
+        entry
+    }
+
+    @Test
+    fun `does not convert to java io File`() {
+        assertNull(root.toFileOrNull())
+    }
+}

--- a/quarkdown-core/src/test/kotlin/com/quarkdown/core/filesystem/FsPathsTest.kt
+++ b/quarkdown-core/src/test/kotlin/com/quarkdown/core/filesystem/FsPathsTest.kt
@@ -1,0 +1,25 @@
+package com.quarkdown.core.filesystem
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Tests for [FsPaths] raw path string checks.
+ */
+class FsPathsTest {
+    @Test
+    fun `unix paths`() {
+        assertTrue(FsPaths.isAbsolute("/absolute/path"))
+        assertFalse(FsPaths.isAbsolute("relative/path"))
+        assertFalse(FsPaths.isAbsolute("./relative"))
+        assertFalse(FsPaths.isAbsolute("../relative"))
+    }
+
+    @Test
+    fun `windows drive-letter paths`() {
+        assertTrue(FsPaths.isAbsolute("C:\\absolute\\path"))
+        assertTrue(FsPaths.isAbsolute("C:/absolute/path"))
+        assertFalse(FsPaths.isAbsolute("relative\\path"))
+    }
+}

--- a/quarkdown-core/src/testFixtures/kotlin/com/quarkdown/core/TestUtils.kt
+++ b/quarkdown-core/src/testFixtures/kotlin/com/quarkdown/core/TestUtils.kt
@@ -4,7 +4,7 @@ import com.quarkdown.core.ast.AstRoot
 import com.quarkdown.core.ast.InlineContent
 import com.quarkdown.core.ast.Node
 import com.quarkdown.core.context.MutableContext
-import com.quarkdown.core.context.file.FileSystem
+import com.quarkdown.core.filesystem.FileSystem
 import com.quarkdown.core.lexer.Lexer
 import com.quarkdown.core.lexer.tokens.LineBreakToken
 import com.quarkdown.core.lexer.tokens.NewlineToken
@@ -28,6 +28,7 @@ fun assertNodeEquals(
     actual: Node,
 ) = assertThat(actual)
     .usingRecursiveComparison()
+    .withEqualsForType({ a, b -> a == b }, FileSystem::class.java)
     .isEqualTo(expected)!!
 
 /**

--- a/quarkdown-html/src/main/kotlin/com/quarkdown/rendering/html/post/document/CssFontFacesImporter.kt
+++ b/quarkdown-html/src/main/kotlin/com/quarkdown/rendering/html/post/document/CssFontFacesImporter.kt
@@ -52,7 +52,7 @@ private class CssFontFaceImporterMediaVisitor(
     override fun visit(media: LocalMedia) =
         fontFaceSnippet(
             family.id,
-            "url('${storedMedia?.path ?: media.file.absolutePath}')",
+            "url('${storedMedia?.path ?: media.file.fullPath}')",
         )
 
     override fun visit(media: RemoteMedia) =

--- a/quarkdown-html/src/main/kotlin/com/quarkdown/rendering/html/post/resources/StaticAssetsPostRendererResource.kt
+++ b/quarkdown-html/src/main/kotlin/com/quarkdown/rendering/html/post/resources/StaticAssetsPostRendererResource.kt
@@ -1,8 +1,11 @@
 package com.quarkdown.rendering.html.post.resources
 
+import com.quarkdown.core.filesystem.FsEntry
+import com.quarkdown.core.pipeline.output.ArtifactType
+import com.quarkdown.core.pipeline.output.BinaryOutputArtifact
 import com.quarkdown.core.pipeline.output.FileReferenceOutputArtifact
 import com.quarkdown.core.pipeline.output.OutputResource
-import java.io.File
+import com.quarkdown.core.pipeline.output.OutputResourceGroup
 
 private const val STATIC_ASSETS_DIRECTORY_NAME = "public"
 
@@ -13,20 +16,48 @@ private const val STATIC_ASSETS_DIRECTORY_NAME = "public"
  * This allows users to ship static files (e.g. `robots.txt`, `CNAME`, `favicon.ico`) alongside
  * the rendered document without any processing. The files land at the top level of the output resources.
  *
+ * Disk-backed directories are copied efficiently by reference, while virtual directories
+ * are walked and materialized into in-memory artifacts.
+ *
  * If the `public/` directory does not exist, no resources are emitted.
  *
  * @param parentDirectory the project's working directory in which to look for a `public/` subdirectory
  */
 class StaticAssetsPostRendererResource(
-    private val parentDirectory: File,
+    private val parentDirectory: FsEntry,
 ) : PostRendererResource {
     override fun includeTo(
         resources: MutableSet<OutputResource>,
         rendered: CharSequence,
     ) {
         val staticAssetsDirectory = parentDirectory.resolve(STATIC_ASSETS_DIRECTORY_NAME)
-        if (staticAssetsDirectory.isDirectory) {
-            resources += FileReferenceOutputArtifact(".", staticAssetsDirectory)
-        }
+        if (!staticAssetsDirectory.isDirectory) return
+
+        resources +=
+            staticAssetsDirectory
+                .toFileOrNull()
+                ?.let { FileReferenceOutputArtifact(".", it) }
+                ?: staticAssetsDirectory.toResourceGroup(".")
     }
+
+    /**
+     * Recursively materializes a virtual directory entry into an [OutputResourceGroup]
+     * of in-memory artifacts.
+     */
+    private fun FsEntry.toResourceGroup(name: String): OutputResourceGroup =
+        OutputResourceGroup(
+            name,
+            children()
+                .map { child ->
+                    when {
+                        child.isDirectory -> child.toResourceGroup(child.name)
+                        else ->
+                            BinaryOutputArtifact(
+                                child.name,
+                                child.readBytes().toList(),
+                                ArtifactType.AUTO,
+                            )
+                    }
+                }.toSet(),
+        )
 }

--- a/quarkdown-html/src/test/kotlin/com/quarkdown/rendering/html/HtmlPostRendererTest.kt
+++ b/quarkdown-html/src/test/kotlin/com/quarkdown/rendering/html/HtmlPostRendererTest.kt
@@ -14,6 +14,7 @@ import com.quarkdown.core.document.layout.page.PageFormatInfo
 import com.quarkdown.core.document.layout.paragraph.ParagraphStyleInfo
 import com.quarkdown.core.document.size.inch
 import com.quarkdown.core.document.tex.TexInfo
+import com.quarkdown.core.filesystem.DiskFileSystem
 import com.quarkdown.core.flavor.quarkdown.QuarkdownFlavor
 import com.quarkdown.core.localization.LocaleLoader
 import com.quarkdown.core.media.ResolvableMedia
@@ -275,7 +276,7 @@ class HtmlPostRendererTest {
     fun `local font, no media storage`() {
         val workingDirectory = File("src/test/resources")
         val path = "media/NotoSans-Regular.ttf"
-        val media = ResolvableMedia(path, workingDirectory)
+        val media = ResolvableMedia(path, DiskFileSystem(workingDirectory))
 
         setFontInfo(FontInfo(mainFamily = FontFamily.Media(media, path)))
         val result = postRenderer().wrap("")
@@ -289,8 +290,9 @@ class HtmlPostRendererTest {
     fun `local font, with media storage`() {
         val workingDirectory = File("src/test/resources")
         val path = "media/NotoSans-Regular.ttf"
-        val file = File(workingDirectory, path)
-        val media = ResolvableMedia(path, workingDirectory)
+        val fileSystem = DiskFileSystem(workingDirectory)
+        val file = fileSystem.resolve(path)
+        val media = ResolvableMedia(path, fileSystem)
 
         setFontInfo(FontInfo(mainFamily = FontFamily.Media(media, path)))
 
@@ -306,7 +308,7 @@ class HtmlPostRendererTest {
     fun `remote font, no media storage`() {
         val url =
             "https://fonts.gstatic.com/s/notosans/v39/o-0mIpQlx3QUlC5A4PNB6Ryti20_6n1iPHjcz6L1SoM-jCpoiyD9A-9U6VTYyWtZ3rKW9w.woff"
-        val media = ResolvableMedia(url)
+        val media = ResolvableMedia(url, DiskFileSystem())
 
         setFontInfo(FontInfo(mainFamily = FontFamily.Media(media, url)))
         val result = postRenderer().wrap("")
@@ -319,7 +321,7 @@ class HtmlPostRendererTest {
     fun `remote font, with media storage`() {
         val url =
             "https://fonts.gstatic.com/s/notosans/v39/o-0mIpQlx3QUlC5A4PNB6Ryti20_6n1iPHjcz6L1SoM-jCpoiyD9A-9U6VTYyWtZ3rKW9w.woff"
-        val media = ResolvableMedia(url)
+        val media = ResolvableMedia(url, DiskFileSystem())
 
         setFontInfo(FontInfo(mainFamily = FontFamily.Media(media, url)))
 

--- a/quarkdown-html/src/test/kotlin/com/quarkdown/rendering/html/HtmlResourceGenerationTest.kt
+++ b/quarkdown-html/src/test/kotlin/com/quarkdown/rendering/html/HtmlResourceGenerationTest.kt
@@ -11,6 +11,7 @@ import com.quarkdown.core.document.DocumentInfo
 import com.quarkdown.core.document.DocumentTheme
 import com.quarkdown.core.document.DocumentType
 import com.quarkdown.core.document.sub.Subdocument
+import com.quarkdown.core.filesystem.DiskFileSystem
 import com.quarkdown.core.flavor.quarkdown.QuarkdownFlavor
 import com.quarkdown.core.localization.LocaleLoader
 import com.quarkdown.core.media.storage.MEDIA_SUBDIRECTORY_NAME
@@ -134,7 +135,7 @@ class HtmlResourceGenerationTest {
     @Test
     fun `with media`() {
         context.options.enableLocalMediaStorage = true
-        context.mediaStorage.register("src/test/resources/media/file.txt", workingDirectory = null)
+        context.mediaStorage.register("src/test/resources/media/file.txt", fileSystem = DiskFileSystem())
         `generate resources` { resources ->
             // theme + script + lib + media + HTML
             assertEquals(5, resources.size)

--- a/quarkdown-html/src/test/kotlin/com/quarkdown/rendering/html/MediaTest.kt
+++ b/quarkdown-html/src/test/kotlin/com/quarkdown/rendering/html/MediaTest.kt
@@ -6,6 +6,7 @@ import com.quarkdown.core.ast.base.inline.Link
 import com.quarkdown.core.ast.media.StoredMediaProperty
 import com.quarkdown.core.attachMockPipeline
 import com.quarkdown.core.context.MutableContext
+import com.quarkdown.core.filesystem.DiskFileSystem
 import com.quarkdown.core.flavor.quarkdown.QuarkdownFlavor
 import com.quarkdown.core.media.storage.MEDIA_SUBDIRECTORY_NAME
 import com.quarkdown.core.media.storage.StoredMedia
@@ -79,7 +80,7 @@ class MediaTest {
     @Test
     fun `remote media path update`() {
         val media =
-            context.mediaStorage.register(REMOTE_URL, workingDirectory = null)!!
+            context.mediaStorage.register(REMOTE_URL, fileSystem = DiskFileSystem())!!
 
         val image = remoteImage(media)
 
@@ -91,7 +92,7 @@ class MediaTest {
 
     @Test
     fun `local media path update`() {
-        val media = context.mediaStorage.register(LOCAL_PATH, workingDirectory = File(WORKING_DIR_PATH))!!
+        val media = context.mediaStorage.register(LOCAL_PATH, fileSystem = DiskFileSystem(File(WORKING_DIR_PATH)))!!
         val image = localImage(media)
 
         assertTrue(image.accept(renderer).startsWith("<img src=\"$OUT_DIR/icon@"))

--- a/quarkdown-html/src/test/kotlin/com/quarkdown/rendering/html/StaticAssetsPostRendererResourceTest.kt
+++ b/quarkdown-html/src/test/kotlin/com/quarkdown/rendering/html/StaticAssetsPostRendererResourceTest.kt
@@ -1,0 +1,43 @@
+package com.quarkdown.rendering.html
+
+import com.quarkdown.core.filesystem.VirtualFileSystem
+import com.quarkdown.core.pipeline.output.BinaryOutputArtifact
+import com.quarkdown.core.pipeline.output.OutputResource
+import com.quarkdown.core.pipeline.output.OutputResourceGroup
+import com.quarkdown.rendering.html.post.resources.StaticAssetsPostRendererResource
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+/**
+ * Tests for [StaticAssetsPostRendererResource] on a virtual file system.
+ */
+class StaticAssetsPostRendererResourceTest {
+    @Test
+    fun `virtual public directory is emitted as a resource group`() {
+        val fs = VirtualFileSystem("/project")
+        fs.write("public/robots.txt", "User-agent: *")
+        fs.write("public/nested/CNAME", "example.com")
+
+        val resources = mutableSetOf<OutputResource>()
+        StaticAssetsPostRendererResource(fs.workingDirectory!!).includeTo(resources, rendered = "")
+
+        val group = resources.single()
+        assertIs<OutputResourceGroup>(group)
+        assertEquals(".", group.name)
+        val robots = group.resources.filterIsInstance<BinaryOutputArtifact>().single()
+        assertEquals("robots.txt", robots.name)
+        val nested = group.resources.filterIsInstance<OutputResourceGroup>().single()
+        assertEquals("nested", nested.name)
+        assertTrue(nested.resources.filterIsInstance<BinaryOutputArtifact>().any { it.name == "CNAME" })
+    }
+
+    @Test
+    fun `missing public directory emits nothing`() {
+        val fs = VirtualFileSystem("/project")
+        val resources = mutableSetOf<OutputResource>()
+        StaticAssetsPostRendererResource(fs.workingDirectory!!).includeTo(resources, rendered = "")
+        assertTrue(resources.isEmpty())
+    }
+}

--- a/quarkdown-markdown/src/test/kotlin/com/quarkdown/rendering/markdown/GfmPostRendererTest.kt
+++ b/quarkdown-markdown/src/test/kotlin/com/quarkdown/rendering/markdown/GfmPostRendererTest.kt
@@ -2,6 +2,7 @@ package com.quarkdown.rendering.markdown
 
 import com.quarkdown.core.attachMockPipeline
 import com.quarkdown.core.context.MutableContext
+import com.quarkdown.core.filesystem.DiskFileSystem
 import com.quarkdown.core.flavor.quarkdown.QuarkdownFlavor
 import com.quarkdown.core.media.storage.MEDIA_SUBDIRECTORY_NAME
 import com.quarkdown.core.media.storage.options.ReadOnlyMediaStorageOptions
@@ -96,10 +97,17 @@ class GfmPostRendererTest {
     fun `media resource is emitted when storage is populated`() {
         val context = newContext()
         context.attachMockPipeline(
-            PipelineOptions(permissions = setOf(Permission.ProjectRead, Permission.GlobalRead, Permission.NetworkAccess)),
+            PipelineOptions(
+                permissions =
+                    setOf(
+                        Permission.ProjectRead,
+                        Permission.GlobalRead,
+                        Permission.NetworkAccess,
+                    ),
+            ),
         )
         context.options.enableLocalMediaStorage = true
-        context.mediaStorage.register("src/test/resources/media/file.txt", workingDirectory = null)
+        context.mediaStorage.register("src/test/resources/media/file.txt", fileSystem = DiskFileSystem())
 
         val postRenderer = GfmPostRenderer(context)
         val resources = postRenderer.generateResources("# Hello\n\n")

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Bibliography.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Bibliography.kt
@@ -73,7 +73,7 @@ fun bibliography(
     @Name("indexheading") indexHeading: Boolean = false,
 ): NodeValue {
     val file = file(context, path)
-    val resolvedStyle = CslBibliographyStyle.from(style, file.inputStream(), file.name, context.documentInfo.locale)
+    val resolvedStyle = CslBibliographyStyle.from(style, file.readBytes().inputStream(), file.name, context.documentInfo.locale)
 
     val heading =
         Heading.createSectionHeading(

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Data.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Data.kt
@@ -8,9 +8,10 @@ import com.quarkdown.core.ast.InlineMarkdownContent
 import com.quarkdown.core.ast.base.block.Table
 import com.quarkdown.core.ast.dsl.buildInline
 import com.quarkdown.core.context.Context
-import com.quarkdown.core.context.file.FileSystem
-import com.quarkdown.core.context.file.RootGranularity
-import com.quarkdown.core.context.file.getRootFileSystem
+import com.quarkdown.core.filesystem.FileSystem
+import com.quarkdown.core.filesystem.FsEntry
+import com.quarkdown.core.filesystem.RootGranularity
+import com.quarkdown.core.filesystem.getRootFileSystem
 import com.quarkdown.core.function.reflect.annotation.Injected
 import com.quarkdown.core.function.reflect.annotation.LikelyNamed
 import com.quarkdown.core.function.value.IterableValue
@@ -35,12 +36,11 @@ import com.quarkdown.stdlib.internal.Ordering
 import com.quarkdown.stdlib.internal.Sorting
 import com.quarkdown.stdlib.internal.sortedBy
 import kotlinx.serialization.json.Json
-import java.io.File
 
 /**
  * @param path path of the file, relative or absolute (with extension)
  * @param requireExistence whether the corresponding file must exist
- * @return a [File] instance of the file located in [path].
+ * @return an [FsEntry] of the file located in [path].
  *         If the path is relative, the location is determined by the working directory of the pipeline.
  * @throws IllegalArgumentException if the file does not exist and [requireExistence] is `true`
  */
@@ -48,12 +48,12 @@ internal fun file(
     context: Context,
     path: String,
     requireExistence: Boolean = true,
-): File {
+): FsEntry {
     val file = context.fileSystem.resolve(path)
     context.requireReadPermission(file)
 
-    if (requireExistence && !file.exists()) {
-        throw IllegalArgumentException("File $file does not exist.")
+    if (requireExistence && !file.exists) {
+        throw IllegalArgumentException("File ${file.fullPath} does not exist.")
     }
 
     return file
@@ -147,7 +147,7 @@ fun pathToRoot(
 ): StringValue {
     val root: FileSystem = context.getRootFileSystem(granularity) ?: return ".".wrappedAsValue()
     val path: String =
-        context.fileSystem.relativePathTo(root)?.toString()
+        context.fileSystem.relativePathTo(root)?.fullPath
             ?: throw IllegalStateException(
                 """
                 Unable to determine relative path to file system root.
@@ -168,8 +168,8 @@ fun pathToRoot(
  * @see listFiles
  */
 enum class FileSorting(
-    override val sort: (Sequence<File>, Ordering) -> Sequence<File>,
-) : Sorting<File> {
+    override val sort: (Sequence<FsEntry>, Ordering) -> Sequence<FsEntry>,
+) : Sorting<FsEntry> {
     /** No sorting is applied. */
     NONE({ files, _ -> files }),
 
@@ -180,7 +180,7 @@ enum class FileSorting(
 
     /** Files are sorted by last modified date. */
     LAST_MODIFIED({ files, ordering ->
-        files.sortedBy(ordering) { it.lastModified() }
+        files.sortedBy(ordering) { it.lastModifiedAtMillis ?: 0L }
     }),
 }
 
@@ -217,11 +217,11 @@ fun listFiles(
 ): IterableValue<StringValue> {
     val rootDirectory = file(context, path)
 
-    if (!rootDirectory.exists()) {
-        throw IllegalArgumentException("Directory $rootDirectory does not exist.")
+    if (!rootDirectory.exists) {
+        throw IllegalArgumentException("Directory ${rootDirectory.fullPath} does not exist.")
     }
     if (!rootDirectory.isDirectory) {
-        throw IllegalArgumentException("Path $rootDirectory is not a directory.")
+        throw IllegalArgumentException("Path ${rootDirectory.fullPath} is not a directory.")
     }
 
     val nameRegex = pattern?.toRegex()
@@ -231,7 +231,7 @@ fun listFiles(
             .filter { listDirectories || it.isFile }
             .filter { currentFile -> nameRegex == null || nameRegex.matches(currentFile.name) }
             .let { sortBy.sort(it, order) }
-            .map { if (fullPath) it.absolutePath else it.name }
+            .map { if (fullPath) it.fullPath else it.name }
             .map(::StringValue)
 
     return when {
@@ -241,13 +241,13 @@ fun listFiles(
 }
 
 private fun listFiles(
-    directory: File,
+    directory: FsEntry,
     recursive: Boolean,
-): Sequence<File> =
+): Sequence<FsEntry> =
     if (recursive) {
-        directory.walkTopDown().drop(1)
+        directory.descendants()
     } else {
-        directory.listFiles()?.asSequence() ?: emptySequence()
+        directory.children().asSequence()
     }
 
 /**
@@ -350,7 +350,7 @@ fun csv(
     val columns = mutableListOf<Table.MutableColumn>()
 
     // CSV is read row-by-row, while the Table is built by columns.
-    csvReader().open(file) {
+    csvReader().open(file.readBytes().inputStream()) {
         readAllWithHeaderAsSequence()
             .forEach { row ->
                 row.entries.forEachIndexed { index, (header, content) ->

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Ecosystem.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Ecosystem.kt
@@ -10,7 +10,7 @@ import com.quarkdown.core.context.MutableContext
 import com.quarkdown.core.context.ScopeContext
 import com.quarkdown.core.context.SharedContext
 import com.quarkdown.core.context.SubdocumentContext
-import com.quarkdown.core.context.file.FileSystem
+import com.quarkdown.core.filesystem.FileSystem
 import com.quarkdown.core.function.reflect.annotation.Injected
 import com.quarkdown.core.function.reflect.annotation.LikelyBody
 import com.quarkdown.core.function.reflect.annotation.LikelyNamed
@@ -103,7 +103,7 @@ fun include(
     val file = file(context, path)
 
     // Context initialization with updated working directory.
-    val newFileSystem: FileSystem = context.fileSystem.branch(workingDirectory = file.parentFile)
+    val newFileSystem: FileSystem = context.fileSystem.branch(workingDirectory = file.parent)
     val newContext: Context =
         when (sandbox) {
             ContextSandbox.SHARE -> SharedContext(context, newFileSystem)
@@ -111,7 +111,7 @@ fun include(
             ContextSandbox.SUBDOCUMENT -> SubdocumentContext(context, context.subdocument, newFileSystem)
         }
 
-    return includeResource(newContext, file.bufferedReader())
+    return includeResource(newContext, file.readText().reader())
 }
 
 /**

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/internal/Font.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/internal/Font.kt
@@ -13,7 +13,7 @@ internal fun loadFontFamily(
     nameOrPath: String,
     context: MutableContext,
 ): FontFamily? {
-    val fontFamily = FontFamilyResolver.SYSTEM.resolve(nameOrPath, context.fileSystem.workingDirectory)
+    val fontFamily = FontFamilyResolver.SYSTEM.resolve(nameOrPath, context.fileSystem)
     if (fontFamily is FontFamily.Media) {
         context.mediaStorage.register(nameOrPath, fontFamily.media)
     }

--- a/quarkdown-stdlib/src/test/kotlin/com/quarkdown/stdlib/DataTest.kt
+++ b/quarkdown-stdlib/src/test/kotlin/com/quarkdown/stdlib/DataTest.kt
@@ -7,6 +7,7 @@ import com.quarkdown.core.ast.dsl.buildInline
 import com.quarkdown.core.attachMockPipeline
 import com.quarkdown.core.context.MutableContext
 import com.quarkdown.core.context.SharedContext
+import com.quarkdown.core.filesystem.DiskFileSystem
 import com.quarkdown.core.flavor.quarkdown.QuarkdownFlavor
 import com.quarkdown.core.function.value.BooleanValue
 import com.quarkdown.core.function.value.DictionaryValue
@@ -39,7 +40,7 @@ class DataTest {
     @BeforeTest
     fun setup() {
         // Attach a mock pipeline to the context, in order to set a working directory for the function calls to use.
-        val options = PipelineOptions(workingDirectory = File(DATA_FOLDER))
+        val options = PipelineOptions(fileSystem = DiskFileSystem(File(DATA_FOLDER)))
         context.attachMockPipeline(options)
     }
 
@@ -82,11 +83,7 @@ class DataTest {
 
     @Test
     fun `path to root, nested`() {
-        val nested =
-            File(DATA_FOLDER, "nested")
-                .resolve("a")
-                .resolve("b")
-        val branchedOutFileSystem = context.fileSystem.branch(workingDirectory = nested)
+        val branchedOutFileSystem = context.fileSystem.branch(workingDirectory = context.fileSystem.resolve("nested/a/b"))
         val branchedOutContext = SharedContext(context, branchedOutFileSystem)
         val relativePath = pathToRoot(branchedOutContext).unwrappedValue
         assertEquals("..${File.separator}..${File.separator}..", relativePath)

--- a/quarkdown-test/src/test/kotlin/com/quarkdown/test/SubdocumentTest.kt
+++ b/quarkdown-test/src/test/kotlin/com/quarkdown/test/SubdocumentTest.kt
@@ -627,7 +627,11 @@ class SubdocumentTest {
             loadableLibraries = setOf("hello", "content"),
             useDummyLibraryDirectory = true,
             outputResourceHook = {
-                val files = File(fileSystem.workingDirectory, "subdoc").listFiles()!!.filter { it.isFile }
+                val files =
+                    fileSystem.workingDirectory!!
+                        .resolve("subdoc")
+                        .children()
+                        .filter { it.isFile }
                 assertEquals(files.size + 1, subdocumentGraph.vertices.size) // +1 for root
 
                 files.forEach { file ->

--- a/quarkdown-test/src/test/kotlin/com/quarkdown/test/VirtualFileSystemTest.kt
+++ b/quarkdown-test/src/test/kotlin/com/quarkdown/test/VirtualFileSystemTest.kt
@@ -1,0 +1,91 @@
+package com.quarkdown.test
+
+import com.quarkdown.core.filesystem.VirtualFileSystem
+import com.quarkdown.core.permissions.MissingPermissionException
+import com.quarkdown.core.permissions.Permission
+import com.quarkdown.test.util.execute
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertFailsWith
+
+/**
+ * Tests for compiling documents whose inputs live entirely on a [VirtualFileSystem],
+ * with no disk access.
+ */
+class VirtualFileSystemTest {
+    private fun virtualFs(): VirtualFileSystem =
+        VirtualFileSystem("/project").apply {
+            write("data.txt", "Hello from memory")
+            write("table.csv", "name,age\nAlice,30\nBob,40")
+            write("lib/included.qd", ".var {fromlib} {included!}")
+            write("sub/child.qd", "# Child")
+        }
+
+    @Test
+    fun `reads a text file`() {
+        execute(".read {data.txt}", fileSystem = virtualFs()) {
+            assertContains(it, "Hello from memory")
+        }
+    }
+
+    @Test
+    fun `reads a csv table`() {
+        execute(".csv {table.csv}", fileSystem = virtualFs()) {
+            assertContains(it, "Alice")
+            assertContains(it, "<table")
+        }
+    }
+
+    @Test
+    fun `includes a source file, branching the working directory`() {
+        execute(
+            ".include {lib/included.qd}\n\n.fromlib",
+            fileSystem = virtualFs(),
+        ) {
+            assertContains(it, "included!")
+        }
+    }
+
+    @Test
+    fun `registers a subdocument`() {
+        execute(
+            "[Child](sub/child.qd)",
+            fileSystem = virtualFs(),
+        ) {
+            // The hook runs for the root document (which links the child) and for the
+            // child subdocument itself, whose content is compiled from the virtual tree.
+            assertContains(it, "Child")
+        }
+    }
+
+    @Test
+    fun `lists files from the virtual tree`() {
+        execute(".listfiles {lib} fullpath:{no}", fileSystem = virtualFs()) {
+            assertContains(it, "included.qd")
+        }
+    }
+
+    @Test
+    fun `denies reads outside the virtual project without global permission`() {
+        val fs = virtualFs().apply { write("/outside/secret.txt", "secret") }
+        assertFailsWith<MissingPermissionException> {
+            execute(
+                ".read {/outside/secret.txt}",
+                fileSystem = fs,
+                permissions = setOf(Permission.ProjectRead),
+            ) {}
+        }
+    }
+
+    @Test
+    fun `stores a virtual image in the media storage`() {
+        val fs = virtualFs().apply { writeBytes("img/pixel.png", byteArrayOf(-119, 80, 78, 71)) }
+        execute(
+            "![Pixel](img/pixel.png)",
+            fileSystem = fs,
+            enableMediaStorage = true,
+        ) {
+            assertContains(it, "media/")
+        }
+    }
+}

--- a/quarkdown-test/src/test/kotlin/com/quarkdown/test/util/Launcher.kt
+++ b/quarkdown-test/src/test/kotlin/com/quarkdown/test/util/Launcher.kt
@@ -6,6 +6,8 @@ import com.quarkdown.core.context.options.MutableContextOptions
 import com.quarkdown.core.context.subdocument.subdocumentGraph
 import com.quarkdown.core.document.sub.Subdocument
 import com.quarkdown.core.document.sub.SubdocumentOutputNaming
+import com.quarkdown.core.filesystem.DiskFileSystem
+import com.quarkdown.core.filesystem.FileSystem
 import com.quarkdown.core.flavor.RendererFactory
 import com.quarkdown.core.flavor.quarkdown.QuarkdownFlavor
 import com.quarkdown.core.graph.VisitableOnceGraph
@@ -43,6 +45,7 @@ val DEFAULT_OPTIONS =
  * @param options execution options
  * @param renderer function that provides the rendering components to use (defaults to HTML)
  * @param workingDirectory working directory to use for the execution, used for resolving relative paths and as the root for the file system
+ * @param fileSystem file system to run the pipeline on; defaults to a disk file system rooted at [workingDirectory]
  * @param subdocumentGraph modifier of the subdocument graph before rendering
  * @param loadableLibraries file names to export as libraries from the `data/libraries` folder, and loadable by the user via `.include`
  * @param useDummyLibraryDirectory whether to use the dummy library directory for loading libraries instead of the one from the `libs` module
@@ -62,6 +65,7 @@ fun execute(
     options: MutableContextOptions = DEFAULT_OPTIONS.copy(),
     renderer: (RendererFactory, Context) -> RenderingComponents = { rendererFactory, ctx -> rendererFactory.html(ctx) },
     workingDirectory: File = File(DATA_FOLDER),
+    fileSystem: FileSystem? = null,
     subdocumentGraph: (VisitableOnceGraph<Subdocument>) -> VisitableOnceGraph<Subdocument> = { it },
     loadableLibraries: Set<String> = emptySet(),
     useDummyLibraryDirectory: Boolean = false,
@@ -108,7 +112,7 @@ fun execute(
             context,
             PipelineOptions(
                 errorHandler = errorHandler,
-                workingDirectory = workingDirectory,
+                fileSystem = fileSystem ?: DiskFileSystem(workingDirectory),
                 enableMediaStorage = enableMediaStorage,
                 permissions = permissions,
                 subdocumentNaming = subdocumentNaming,


### PR DESCRIPTION
- [X] I have read the [contributing guidelines](https://github.com/iamgio/quarkdown/blob/main/CONTRIBUTING.md).
- [X] I have tested the changes locally.
- [ ] An issue for this change exists, and it was discussed with maintainers. This is required for new features and non-trivial changes. If present, append `Closes #ISSUE_NUMBER` at the end of this PR description.
- [ ] (Optional) I have added necessary documentation to [`docs`](https://github.com/iamgio/quarkdown/tree/main/docs) and [`CHANGELOG.md`](https://github.com/iamgio/quarkdown/blob/main/CHANGELOG.md)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for disk-backed and in-memory file systems.
  * Virtual files and directories can now be processed and exported as generated resources.
  * Improved handling of links, media, fonts, included files, and subdocuments across file-system types.
  * File paths are resolved more consistently across platforms.

* **Bug Fixes**
  * Improved cleaning safety, permission checks, and resource path handling.
  * Fixed media export behavior for virtual and disk-backed files.
  * Improved bibliography and file-reading reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->