### PR TITLE
refactor: support virtual filesystems in install-layout-navigator

### DIFF
--- a/quarkdown-cli/src/main/kotlin/com/quarkdown/cli/doctor/get/AbstractDoctorGetPathCommand.kt
+++ b/quarkdown-cli/src/main/kotlin/com/quarkdown/cli/doctor/get/AbstractDoctorGetPathCommand.kt
@@ -2,14 +2,14 @@ package com.quarkdown.cli.doctor.get
 
 import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.core.CliktError
+import com.quarkdown.core.filesystem.FsEntry
 import com.quarkdown.installlayout.InstallLayout
-import java.io.File
 
 /**
  * Base class for `doctor get <name>` subcommands that print the absolute filesystem path of a
  * single entry in the Quarkdown install layout to standard output.
  *
- * Subclasses select the entry to print by overriding [getFile], and provide a human-readable
+ * Subclasses select the entry to print by overriding [getEntry], and provide a human-readable
  * [description] used in error messages. The command exits with a non-zero status if the install
  * layout cannot be resolved or if the entry does not exist on disk.
  *
@@ -25,18 +25,18 @@ abstract class AbstractDoctorGetPathCommand(
      * @param installLayout the Quarkdown install layout
      * @return the file or directory whose absolute path should be printed, or `null` if it cannot be resolved.
      */
-    protected abstract fun getFile(installLayout: InstallLayout): File?
+    protected abstract fun getEntry(installLayout: InstallLayout): FsEntry?
 
     final override fun run() {
-        val file =
+        val entry =
             InstallLayout.getOrNull
-                ?.let(::getFile)
-                ?.takeIf { it.exists() }
+                ?.let(::getEntry)
+                ?.takeIf { it.exists }
                 ?: throw CliktError(
                     "Cannot resolve the $description. " +
                         "This usually means Quarkdown is being run outside its standard distribution layout.",
                 )
 
-        echo(file.absolutePath)
+        echo(entry.fullPath)
     }
 }

--- a/quarkdown-cli/src/main/kotlin/com/quarkdown/cli/doctor/get/DoctorGetCommand.kt
+++ b/quarkdown-cli/src/main/kotlin/com/quarkdown/cli/doctor/get/DoctorGetCommand.kt
@@ -2,8 +2,8 @@ package com.quarkdown.cli.doctor.get
 
 import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.core.subcommands
+import com.quarkdown.core.filesystem.FsEntry
 import com.quarkdown.installlayout.InstallLayout
-import java.io.File
 
 /**
  * Command group that retrieves individual pieces of information about the Quarkdown installation.
@@ -36,7 +36,7 @@ class DoctorGetCommand : CliktCommand("get") {
             name = "install-dir",
             description = "Quarkdown install directory",
         ) {
-        override fun getFile(installLayout: InstallLayout): File? = installLayout.file.parentFile
+        override fun getEntry(installLayout: InstallLayout): FsEntry? = installLayout.file.parent
     }
 
     /**
@@ -55,6 +55,6 @@ class DoctorGetCommand : CliktCommand("get") {
             name = "agent-skill",
             description = "bundled agent skill directory",
         ) {
-        override fun getFile(installLayout: InstallLayout): File = installLayout.agentSkill.file
+        override fun getEntry(installLayout: InstallLayout): FsEntry = installLayout.agentSkill.file
     }
 }

--- a/quarkdown-cli/src/main/kotlin/com/quarkdown/cli/exec/ExecuteCommand.kt
+++ b/quarkdown-cli/src/main/kotlin/com/quarkdown/cli/exec/ExecuteCommand.kt
@@ -215,7 +215,12 @@ abstract class ExecuteCommand(
             // Might be overridden by a subclass via `finalizeCliOptions`, e.g. `CompileCommand` which requires a source file.
             source = null,
             outputDirectory,
-            libraryDirectory = libraryDirectory ?: InstallLayout.get.quarkdownLibraries.file,
+            libraryDirectory =
+                libraryDirectory
+                    ?: InstallLayout.get
+                        .quarkdownLibraries
+                        .file
+                        .toFileOrNull(),
             renderer,
             clean,
             pipe = false,

--- a/quarkdown-cli/src/main/kotlin/com/quarkdown/cli/lsp/LanguageServerCommand.kt
+++ b/quarkdown-cli/src/main/kotlin/com/quarkdown/cli/lsp/LanguageServerCommand.kt
@@ -10,7 +10,11 @@ import com.quarkdown.lsp.QuarkdownLanguageServerLauncher
 class LanguageServerCommand : CliktCommand("language-server") {
     override fun run() {
         // The distribution directory which contains lib/, docs/, etc.
-        val quarkdownDirectory = InstallLayout.getOrNull?.file?.parentFile
+        val quarkdownDirectory =
+            InstallLayout.getOrNull
+                ?.file
+                ?.parent
+                ?.toFileOrNull()
         QuarkdownLanguageServerLauncher(quarkdownDirectory).startListening()
     }
 }

--- a/quarkdown-cli/src/test/kotlin/com/quarkdown/cli/doctor/DoctorGetAgentSkillCommandTest.kt
+++ b/quarkdown-cli/src/test/kotlin/com/quarkdown/cli/doctor/DoctorGetAgentSkillCommandTest.kt
@@ -22,7 +22,7 @@ class DoctorGetAgentSkillCommandTest {
 
     @Test
     fun `prints the resolved agent skill directory`() {
-        val expected = InstallLayout.get.agentSkill.file.absolutePath
+        val expected = InstallLayout.get.agentSkill.file.fullPath
         assertEquals(expected, runCommand())
     }
 

--- a/quarkdown-cli/src/test/kotlin/com/quarkdown/cli/doctor/DoctorGetInstallDirCommandTest.kt
+++ b/quarkdown-cli/src/test/kotlin/com/quarkdown/cli/doctor/DoctorGetInstallDirCommandTest.kt
@@ -22,7 +22,9 @@ class DoctorGetInstallDirCommandTest {
 
     @Test
     fun `prints the resolved install directory`() {
-        val expected = InstallLayout.get.file.parentFile.absolutePath
+        val expected =
+            InstallLayout.get.file.parent
+                ?.fullPath
         assertEquals(expected, runCommand())
     }
 

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/media/export/MediaOutputResourceConverter.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/media/export/MediaOutputResourceConverter.kt
@@ -6,8 +6,8 @@ import com.quarkdown.core.media.MediaVisitor
 import com.quarkdown.core.media.RemoteMedia
 import com.quarkdown.core.pipeline.output.ArtifactType
 import com.quarkdown.core.pipeline.output.BinaryOutputArtifact
-import com.quarkdown.core.pipeline.output.FileReferenceOutputArtifact
 import com.quarkdown.core.pipeline.output.OutputResource
+import com.quarkdown.core.pipeline.output.toOutputResource
 
 /**
  * A converter of a [Media] to an [OutputResource].
@@ -16,25 +16,8 @@ import com.quarkdown.core.pipeline.output.OutputResource
 class MediaOutputResourceConverter(
     private val name: String,
 ) : MediaVisitor<OutputResource> {
-    // Disk-backed media is copied efficiently by reference.
-    override fun visit(media: LocalMedia) =
-        when (val file = media.file.toFileOrNull()) {
-            null -> {
-                BinaryOutputArtifact(
-                    name,
-                    media.file.readBytes().toList(),
-                    ArtifactType.AUTO,
-                )
-            }
-
-            else -> {
-                FileReferenceOutputArtifact(
-                    name,
-                    file,
-                    useChecksumInvalidation = true,
-                )
-            }
-        }
+    // Disk-backed media is copied efficiently by reference; virtual media is materialized in memory.
+    override fun visit(media: LocalMedia) = media.file.toOutputResource(name, useChecksumInvalidation = true)
 
     override fun visit(media: RemoteMedia) =
         BinaryOutputArtifact(

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/pipeline/output/FsEntryOutputResource.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/pipeline/output/FsEntryOutputResource.kt
@@ -1,0 +1,37 @@
+package com.quarkdown.core.pipeline.output
+
+import com.quarkdown.core.filesystem.FsEntry
+
+/**
+ * Converts this entry to an [OutputResource] for the pipeline to output.
+ *
+ * Disk-backed entries are wrapped as a [FileReferenceOutputArtifact], so they are efficiently
+ * copied (or symlinked) by reference. Virtual entries are materialized into in-memory artifacts,
+ * walking directories recursively.
+ *
+ * @param name the output resource name. Defaults to this entry's [FsEntry.name]
+ * @param useChecksumInvalidation whether disk-backed entries should also carry a checksum file,
+ *                                used by incremental builds to detect unchanged artifacts
+ * @param symlink whether disk-backed entries should be symlinked instead of copied
+ * @return the resource wrapping this entry
+ */
+fun FsEntry.toOutputResource(
+    name: String = this.name,
+    useChecksumInvalidation: Boolean = false,
+    symlink: Boolean = false,
+): OutputResource =
+    when (val file = toFileOrNull()) {
+        null -> toInMemoryResource(name)
+        else -> FileReferenceOutputArtifact(name, file, useChecksumInvalidation, symlink)
+    }
+
+/**
+ * Materializes a virtual entry into an in-memory [OutputResource]:
+ * a [BinaryOutputArtifact] for a file, or an [OutputResourceGroup]
+ * of recursively materialized children for a directory.
+ */
+private fun FsEntry.toInMemoryResource(name: String): OutputResource =
+    when {
+        isDirectory -> OutputResourceGroup(name, children().map { it.toInMemoryResource(it.name) }.toSet())
+        else -> BinaryOutputArtifact(name, readBytes().toList(), ArtifactType.AUTO)
+    }

--- a/quarkdown-html/src/main/kotlin/com/quarkdown/rendering/html/post/resources/ScriptPostRendererResource.kt
+++ b/quarkdown-html/src/main/kotlin/com/quarkdown/rendering/html/post/resources/ScriptPostRendererResource.kt
@@ -41,7 +41,7 @@ class ScriptPostRendererResource(
         if (scriptsLayout == null) return
 
         check(scriptsLayout.exists()) {
-            "Required Quarkdown runtime script file is missing: ${scriptsLayout.file.absolutePath}. " +
+            "Required Quarkdown runtime script file is missing: ${scriptsLayout.file.fullPath}. " +
                 "This likely indicates a broken Quarkdown installation."
         }
 

--- a/quarkdown-html/src/main/kotlin/com/quarkdown/rendering/html/post/resources/StaticAssetsPostRendererResource.kt
+++ b/quarkdown-html/src/main/kotlin/com/quarkdown/rendering/html/post/resources/StaticAssetsPostRendererResource.kt
@@ -1,11 +1,8 @@
 package com.quarkdown.rendering.html.post.resources
 
 import com.quarkdown.core.filesystem.FsEntry
-import com.quarkdown.core.pipeline.output.ArtifactType
-import com.quarkdown.core.pipeline.output.BinaryOutputArtifact
-import com.quarkdown.core.pipeline.output.FileReferenceOutputArtifact
 import com.quarkdown.core.pipeline.output.OutputResource
-import com.quarkdown.core.pipeline.output.OutputResourceGroup
+import com.quarkdown.core.pipeline.output.toOutputResource
 
 private const val STATIC_ASSETS_DIRECTORY_NAME = "public"
 
@@ -33,31 +30,6 @@ class StaticAssetsPostRendererResource(
         val staticAssetsDirectory = parentDirectory.resolve(STATIC_ASSETS_DIRECTORY_NAME)
         if (!staticAssetsDirectory.isDirectory) return
 
-        resources +=
-            staticAssetsDirectory
-                .toFileOrNull()
-                ?.let { FileReferenceOutputArtifact(".", it) }
-                ?: staticAssetsDirectory.toResourceGroup(".")
+        resources += staticAssetsDirectory.toOutputResource(name = ".")
     }
-
-    /**
-     * Recursively materializes a virtual directory entry into an [OutputResourceGroup]
-     * of in-memory artifacts.
-     */
-    private fun FsEntry.toResourceGroup(name: String): OutputResourceGroup =
-        OutputResourceGroup(
-            name,
-            children()
-                .map { child ->
-                    when {
-                        child.isDirectory -> child.toResourceGroup(child.name)
-                        else ->
-                            BinaryOutputArtifact(
-                                child.name,
-                                child.readBytes().toList(),
-                                ArtifactType.AUTO,
-                            )
-                    }
-                }.toSet(),
-        )
 }

--- a/quarkdown-html/src/main/kotlin/com/quarkdown/rendering/html/post/resources/ThemePostRendererResource.kt
+++ b/quarkdown-html/src/main/kotlin/com/quarkdown/rendering/html/post/resources/ThemePostRendererResource.kt
@@ -1,13 +1,14 @@
 package com.quarkdown.rendering.html.post.resources
 
 import com.quarkdown.core.document.DocumentTheme
+import com.quarkdown.core.filesystem.FsEntry
 import com.quarkdown.core.localization.Locale
 import com.quarkdown.core.log.Log
 import com.quarkdown.core.pipeline.output.ArtifactType
-import com.quarkdown.core.pipeline.output.FileReferenceOutputArtifact
 import com.quarkdown.core.pipeline.output.OutputResource
 import com.quarkdown.core.pipeline.output.OutputResourceGroup
 import com.quarkdown.core.pipeline.output.TextOutputArtifact
+import com.quarkdown.core.pipeline.output.toOutputResource
 import com.quarkdown.installlayout.InstallLayout
 import com.quarkdown.installlayout.InstallLayoutDirectory
 
@@ -72,7 +73,7 @@ class ThemePostRendererResource(
      */
     private data class Component(
         val name: String,
-        val source: java.io.File,
+        val source: FsEntry,
     ) {
         val importPath: String get() = importPathFor(name)
     }
@@ -90,15 +91,14 @@ class ThemePostRendererResource(
     }
 
     /**
-     * Builds the artifact set for a theme group: one [FileReferenceOutputArtifact] per
-     * [Component] plus a single-entry `theme.css` manifest that `@import`s them all.
+     * Builds the artifact set for a theme group: one artifact per [Component]
+     * plus a single-entry `theme.css` manifest that `@import`s them all.
      */
     private fun buildArtifacts(components: List<Component>): Set<OutputResource> =
         buildSet {
             components.mapTo(this) {
-                FileReferenceOutputArtifact(
+                it.source.toOutputResource(
                     name = it.name,
-                    file = it.source,
                     useChecksumInvalidation = true,
                 )
             }
@@ -113,7 +113,7 @@ class ThemePostRendererResource(
 
     /**
      * Resolves the set of active theme [Component]s from [themeLayout].
-     * Returns `null` if [themeLayout] is absent or does not exist on disk.
+     * Returns `null` if [themeLayout] is absent or does not exist.
      * Missing layout or color themes are logged and skipped rather than raising,
      * so a broken theme reference degrades gracefully; missing locales are silently
      * skipped, since most locales have no stylesheet.
@@ -149,7 +149,7 @@ class ThemePostRendererResource(
         if (!directory.exists()) {
             if (warnIfMissing) {
                 Log.error(
-                    "'${kindDirectory.name}' theme not found: $name (looked in ${directory.file.absolutePath}).\n" +
+                    "'${kindDirectory.name}' theme not found: $name (looked in ${directory.file.fullPath}).\n" +
                         "For a list of available themes, check https://quarkdown.com/wiki/themes or your local theme directory.",
                 )
             }

--- a/quarkdown-html/src/main/kotlin/com/quarkdown/rendering/html/post/resources/ThirdPartyPostRendererResource.kt
+++ b/quarkdown-html/src/main/kotlin/com/quarkdown/rendering/html/post/resources/ThirdPartyPostRendererResource.kt
@@ -52,7 +52,7 @@ class ThirdPartyPostRendererResource(
                         .map { libraryName ->
                             librariesLayout
                                 .resolveDirectory(libraryName)
-                                .also { if (!it.exists()) error("HTML library directory not found: ${it.file.path}") }
+                                .also { if (!it.exists()) error("HTML library directory not found: ${it.file.fullPath}") }
                                 .asOutputResource(symlink = symlink)
                         }.toSet(),
             )

--- a/quarkdown-html/src/test/kotlin/com/quarkdown/rendering/html/HtmlResourceGenerationTest.kt
+++ b/quarkdown-html/src/test/kotlin/com/quarkdown/rendering/html/HtmlResourceGenerationTest.kt
@@ -29,7 +29,6 @@ import com.quarkdown.rendering.html.post.resources.HTML_LIBRARY_OUTPUT_PATH
 import com.quarkdown.rendering.html.post.resources.ThemePostRendererResource
 import com.quarkdown.rendering.html.post.resources.ThirdPartyPostRendererResource
 import com.quarkdown.rendering.html.post.thirdparty.ThirdPartyLibrary
-import java.io.File
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -238,7 +237,7 @@ class HtmlResourceGenerationTest {
 
     @Test
     fun `no lib group when library directory does not exist`() {
-        val bogusLibDir = InstallLayoutDirectory(File("nonexistent"))
+        val bogusLibDir = InstallLayoutDirectory(DiskFileSystem().resolve("nonexistent"))
         val resources =
             buildSet {
                 ThirdPartyPostRendererResource(context, librariesLayout = bogusLibDir, symlink = false)

--- a/quarkdown-install-layout-navigator/src/main/kotlin/com/quarkdown/installlayout/InstallDirectoryResolver.kt
+++ b/quarkdown-install-layout-navigator/src/main/kotlin/com/quarkdown/installlayout/InstallDirectoryResolver.kt
@@ -1,5 +1,6 @@
 package com.quarkdown.installlayout
 
+import com.quarkdown.core.filesystem.DiskFileSystem
 import com.quarkdown.core.log.Log
 import java.io.File
 
@@ -33,7 +34,7 @@ internal object InstallDirectoryResolver {
         val directory = resolveFrom(executable)
 
         Log.debug { "Resolved install directory: $directory" }
-        return InstallLayout(InstallLayoutDirectory(directory))
+        return InstallLayout(InstallLayoutDirectory(DiskFileSystem().resolve(directory.absolutePath)))
     }
 
     private fun resolveFrom(executable: File): File {

--- a/quarkdown-install-layout-navigator/src/main/kotlin/com/quarkdown/installlayout/InstallLayoutEntry.kt
+++ b/quarkdown-install-layout-navigator/src/main/kotlin/com/quarkdown/installlayout/InstallLayoutEntry.kt
@@ -1,21 +1,21 @@
 package com.quarkdown.installlayout
 
-import com.quarkdown.core.pipeline.output.FileReferenceOutputArtifact
+import com.quarkdown.core.filesystem.FsEntry
 import com.quarkdown.core.pipeline.output.OutputResource
-import java.io.File
+import com.quarkdown.core.pipeline.output.toOutputResource
 
 /**
  * A navigable entry (file or directory) within the Quarkdown install layout.
  */
 interface InstallLayoutEntry {
-    /** The filesystem location this entry points to. */
-    val file: File
+    /** The file system location this entry points to. */
+    val file: FsEntry
 
     /** Short name of this entry (file name) */
     val name: String
         get() = file.name
 
-    /** Whether this entry exists on disk with the expected type (file vs. directory). */
+    /** Whether this entry exists with the expected type (file vs. directory). */
     fun exists(): Boolean
 
     /** Resolves a child file relative to this entry's [file]. */
@@ -26,12 +26,12 @@ interface InstallLayoutEntry {
 
     /**
      * Wraps this entry as an [OutputResource] for the pipeline to output.
-     * @param symlink whether to create a symbolic link to the source file instead of copying it
+     * Disk-backed entries are copied by reference, while virtual entries are materialized in memory.
+     * @param symlink whether disk-backed entries should be symlinked instead of copied
      */
     fun asOutputResource(symlink: Boolean = false): OutputResource =
-        FileReferenceOutputArtifact(
+        file.toOutputResource(
             name,
-            file,
             useChecksumInvalidation = true,
             symlink = symlink,
         )
@@ -42,7 +42,7 @@ interface InstallLayoutEntry {
  * [exists] returns `true` only if the path is an existing regular file.
  */
 data class InstallLayoutFile(
-    override val file: File,
+    override val file: FsEntry,
 ) : InstallLayoutEntry {
     override fun exists(): Boolean = file.isFile
 }
@@ -52,7 +52,7 @@ data class InstallLayoutFile(
  * [exists] returns `true` only if the path is an existing directory.
  */
 data class InstallLayoutDirectory(
-    override val file: File,
+    override val file: FsEntry,
 ) : InstallLayoutEntry {
     override fun exists(): Boolean = file.isDirectory
 }

--- a/quarkdown-install-layout-navigator/src/test/kotlin/com/quarkdown/installlayout/InstallLayoutTest.kt
+++ b/quarkdown-install-layout-navigator/src/test/kotlin/com/quarkdown/installlayout/InstallLayoutTest.kt
@@ -1,0 +1,81 @@
+package com.quarkdown.installlayout
+
+import com.quarkdown.core.filesystem.DiskFileSystem
+import com.quarkdown.core.filesystem.VirtualFileSystem
+import com.quarkdown.core.pipeline.output.BinaryOutputArtifact
+import com.quarkdown.core.pipeline.output.FileReferenceOutputArtifact
+import com.quarkdown.core.pipeline.output.OutputResourceGroup
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+/**
+ * Tests for [InstallLayout] navigation over both virtual and disk-backed file systems.
+ */
+class InstallLayoutTest {
+    /**
+     * @return an [InstallLayout] over an in-memory file system seeded with a minimal install layout
+     */
+    private fun virtualLayout(): InstallLayout {
+        val fs = VirtualFileSystem("/install/lib")
+        fs.write("html/theme/global.css", "body {}")
+        fs.write("html/theme/layout/latex/latex.css", ".latex {}")
+        fs.write("html/script/quarkdown.min.js", "// runtime")
+        fs.write("qd/stdlib.qd", "")
+        fs.write("skills/quarkdown/SKILL.md", "# Skill")
+        return InstallLayout(InstallLayoutDirectory(fs.resolve("/install/lib")))
+    }
+
+    @Test
+    fun `navigates a virtual layout`() {
+        val layout = virtualLayout()
+        assertTrue(layout.quarkdownLibraries.exists())
+        assertTrue(layout.agentSkill.exists())
+        assertTrue(layout.htmlResources.scripts.exists())
+        assertTrue(
+            layout.htmlResources.themes.global
+                .exists(),
+        )
+        assertTrue(
+            layout.htmlResources.themes.layout
+                .resolveDirectory("latex")
+                .exists(),
+        )
+    }
+
+    @Test
+    fun `existence is type-checked`() {
+        val layout = virtualLayout()
+        // A file entry pointing at a directory does not exist as a file, and vice versa.
+        assertFalse(layout.resolveFile("qd").exists())
+        assertFalse(layout.resolveDirectory("html/theme/global.css").exists())
+        assertFalse(layout.resolveDirectory("nonexistent").exists())
+    }
+
+    @Test
+    fun `virtual entry materializes into in-memory resources`() {
+        val scripts = virtualLayout().htmlResources.scripts
+        val resource = assertIs<OutputResourceGroup>(scripts.asOutputResource())
+        assertEquals("script", resource.name)
+        val artifact = assertIs<BinaryOutputArtifact>(resource.resources.single())
+        assertEquals("quarkdown.min.js", artifact.name)
+        assertEquals("// runtime", artifact.content.toByteArray().decodeToString())
+    }
+
+    @Test
+    fun `disk entry is referenced by file`() {
+        val directory = Files.createTempDirectory("quarkdown-install-layout").toFile()
+        try {
+            directory.resolve("qd").mkdirs()
+            val layout = InstallLayout(InstallLayoutDirectory(DiskFileSystem().resolve(directory.absolutePath)))
+            assertTrue(layout.quarkdownLibraries.exists())
+            val resource = assertIs<FileReferenceOutputArtifact>(layout.quarkdownLibraries.asOutputResource())
+            assertEquals(directory.resolve("qd"), resource.file)
+        } finally {
+            directory.deleteRecursively()
+        }
+    }
+}


### PR DESCRIPTION
- [X] I have read the [contributing guidelines](https://github.com/iamgio/quarkdown/blob/main/CONTRIBUTING.md).
- [X] I have tested the changes locally.
- [ ] An issue for this change exists, and it was discussed with maintainers. This is required for new features and non-trivial changes. If present, append `Closes #ISSUE_NUMBER` at the end of this PR description.
- [ ] (Optional) I have added necessary documentation to [`docs`](https://github.com/iamgio/quarkdown/tree/main/docs) and [`CHANGELOG.md`](https://github.com/iamgio/quarkdown/blob/main/CHANGELOG.md)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved support for virtual and disk-based files when exporting media, themes, scripts, and static assets.
  - Virtual directories and files can now be materialized correctly as output resources.

- **Bug Fixes**
  - Improved install-directory and bundled resource path resolution.
  - Error messages now display complete resource paths for easier troubleshooting.
  - Preserved checksum invalidation and symlink handling during resource export.

- **Tests**
  - Added coverage for virtual and disk-backed install layouts, navigation, existence checks, and resource generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->