### PR TITLE
refactor(media): allow custom fetcher strategy for remote media

### DIFF
--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/context/options/MutableContextOptions.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/context/options/MutableContextOptions.kt
@@ -1,5 +1,7 @@
 package com.quarkdown.core.context.options
 
+import com.quarkdown.core.media.fetch.RemoteMediaFetcher
+import com.quarkdown.core.media.fetch.UrlRemoteMediaFetcher
 import com.quarkdown.core.media.storage.options.MediaStorageOptions
 import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
@@ -18,6 +20,7 @@ data class MutableContextOptions(
     override var uuidSupplier: () -> String = { Uuid.random().toString() },
     override var enableRemoteMediaStorage: Boolean = false,
     override var enableLocalMediaStorage: Boolean = false,
+    override var remoteMediaFetcher: RemoteMediaFetcher = UrlRemoteMediaFetcher,
     override var html: HtmlOptions = HtmlOptions(),
 ) : ContextOptions {
     /**
@@ -28,5 +31,6 @@ data class MutableContextOptions(
     fun mergeMediaStorageOptions(options: MediaStorageOptions) {
         options.enableRemoteMediaStorage?.let { enableRemoteMediaStorage = it }
         options.enableLocalMediaStorage?.let { enableLocalMediaStorage = it }
+        options.remoteMediaFetcher?.let { remoteMediaFetcher = it }
     }
 }

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/media/export/MediaOutputResourceConverter.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/media/export/MediaOutputResourceConverter.kt
@@ -4,6 +4,7 @@ import com.quarkdown.core.media.LocalMedia
 import com.quarkdown.core.media.Media
 import com.quarkdown.core.media.MediaVisitor
 import com.quarkdown.core.media.RemoteMedia
+import com.quarkdown.core.media.fetch.RemoteMediaFetcher
 import com.quarkdown.core.pipeline.output.ArtifactType
 import com.quarkdown.core.pipeline.output.BinaryOutputArtifact
 import com.quarkdown.core.pipeline.output.OutputResource
@@ -12,9 +13,11 @@ import com.quarkdown.core.pipeline.output.toOutputResource
 /**
  * A converter of a [Media] to an [OutputResource].
  * @param name generated media name
+ * @param remoteFetcher strategy used to download the content of remote media
  */
 class MediaOutputResourceConverter(
     private val name: String,
+    private val remoteFetcher: RemoteMediaFetcher,
 ) : MediaVisitor<OutputResource> {
     // Disk-backed media is copied efficiently by reference; virtual media is materialized in memory.
     override fun visit(media: LocalMedia) = media.file.toOutputResource(name, useChecksumInvalidation = true)
@@ -22,10 +25,7 @@ class MediaOutputResourceConverter(
     override fun visit(media: RemoteMedia) =
         BinaryOutputArtifact(
             name,
-            media.url
-                .openStream()
-                .readBytes()
-                .toList(),
+            remoteFetcher.fetch(media).toList(),
             ArtifactType.AUTO,
         )
 }

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/media/fetch/RemoteMediaFetcher.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/media/fetch/RemoteMediaFetcher.kt
@@ -1,0 +1,18 @@
+package com.quarkdown.core.media.fetch
+
+import com.quarkdown.core.media.RemoteMedia
+
+/**
+ * Strategy for downloading the content of a [RemoteMedia], used when the media storage
+ * materializes remote media into the output resources.
+ * @see UrlRemoteMediaFetcher for a default implementation that downloads content synchronously
+ */
+fun interface RemoteMediaFetcher {
+    /**
+     * Downloads the content of [media]. Blocking call.
+     * @param media the remote media to fetch
+     * @return the raw bytes of the downloaded content
+     * @throws java.io.IOException if the content cannot be retrieved
+     */
+    fun fetch(media: RemoteMedia): ByteArray
+}

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/media/fetch/UrlRemoteMediaFetcher.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/media/fetch/UrlRemoteMediaFetcher.kt
@@ -1,0 +1,11 @@
+package com.quarkdown.core.media.fetch
+
+import com.quarkdown.core.media.RemoteMedia
+
+/**
+ * Default [RemoteMediaFetcher] that downloads content synchronously
+ * by opening a stream on the media's URL.
+ */
+object UrlRemoteMediaFetcher : RemoteMediaFetcher {
+    override fun fetch(media: RemoteMedia): ByteArray = media.url.openStream().use { it.readBytes() }
+}

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/media/storage/MutableMediaStorage.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/media/storage/MutableMediaStorage.kt
@@ -4,6 +4,8 @@ import com.quarkdown.core.filesystem.FileSystem
 import com.quarkdown.core.media.Media
 import com.quarkdown.core.media.ResolvableMedia
 import com.quarkdown.core.media.export.MediaOutputResourceConverter
+import com.quarkdown.core.media.fetch.RemoteMediaFetcher
+import com.quarkdown.core.media.fetch.UrlRemoteMediaFetcher
 import com.quarkdown.core.media.storage.name.MediaNameProviderStrategy
 import com.quarkdown.core.media.storage.name.SanitizedMediaNameProvider
 import com.quarkdown.core.media.storage.options.MediaStorageOptions
@@ -19,6 +21,12 @@ import com.quarkdown.core.pipeline.output.OutputResourceGroup
 const val MEDIA_SUBDIRECTORY_NAME = "media"
 
 /**
+ * The platform's default [RemoteMediaFetcher], used when
+ * [MediaStorageOptions.remoteMediaFetcher] is undetermined.
+ */
+private val DEFAULT_REMOTE_MEDIA_FETCHER: RemoteMediaFetcher = UrlRemoteMediaFetcher
+
+/**
  * A media storage that can be modified with new entries.
  * @param options storage rules
  * @param permissionHolder holder to check media access permissions against
@@ -31,6 +39,11 @@ class MutableMediaStorage(
     permissionHolder: PermissionHolder,
     private val nameProvider: MediaNameProviderStrategy = SanitizedMediaNameProvider(),
 ) : ReadOnlyMediaStorage {
+    /**
+     * Strategy used to download the content of remote media in [toResource].
+     */
+    private val remoteFetcher: RemoteMediaFetcher = options.remoteMediaFetcher ?: DEFAULT_REMOTE_MEDIA_FETCHER
+
     /**
      * All the stored entries.
      */
@@ -58,7 +71,7 @@ class MutableMediaStorage(
         val subResources =
             this.all
                 .map {
-                    val converter = MediaOutputResourceConverter(it.name)
+                    val converter = MediaOutputResourceConverter(it.name, remoteFetcher)
                     it.media.accept(converter)
                 }.toSet()
 

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/media/storage/options/MediaStorageOptions.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/media/storage/options/MediaStorageOptions.kt
@@ -1,5 +1,7 @@
 package com.quarkdown.core.media.storage.options
 
+import com.quarkdown.core.media.fetch.RemoteMediaFetcher
+
 /**
  * Read-only options that affect the rules of a context's media storage.
  * @see com.quarkdown.core.context.options.MutableContextOptions for an implementation
@@ -12,6 +14,13 @@ interface MediaStorageOptions {
      * If null, the preference is determined by the active renderer.
      */
     val enableRemoteMediaStorage: Boolean?
+
+    /**
+     * Strategy used to download the content of remote media
+     * when the storage materializes it into the output resources.
+     * If null, the default URL-based fetcher is used.
+     */
+    val remoteMediaFetcher: RemoteMediaFetcher?
 
     /**
      * Whether local media should be stored locally in the output directory.

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/media/storage/options/ReadOnlyMediaStorageOptions.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/media/storage/options/ReadOnlyMediaStorageOptions.kt
@@ -1,5 +1,7 @@
 package com.quarkdown.core.media.storage.options
 
+import com.quarkdown.core.media.fetch.RemoteMediaFetcher
+
 /**
  * Read-only options that affect the rules of a media storage.
  * Used in [com.quarkdown.core.rendering.PostRenderer] to determine the preferred rules of a rendering strategy.
@@ -7,4 +9,5 @@ package com.quarkdown.core.media.storage.options
 data class ReadOnlyMediaStorageOptions(
     override val enableRemoteMediaStorage: Boolean? = null,
     override val enableLocalMediaStorage: Boolean? = null,
+    override val remoteMediaFetcher: RemoteMediaFetcher? = null,
 ) : MediaStorageOptions

--- a/quarkdown-core/src/test/kotlin/com/quarkdown/core/MediaTest.kt
+++ b/quarkdown-core/src/test/kotlin/com/quarkdown/core/MediaTest.kt
@@ -15,6 +15,8 @@ import com.quarkdown.core.media.MediaVisitor
 import com.quarkdown.core.media.RemoteMedia
 import com.quarkdown.core.media.ResolvableMedia
 import com.quarkdown.core.media.export.MediaOutputResourceConverter
+import com.quarkdown.core.media.fetch.RemoteMediaFetcher
+import com.quarkdown.core.media.fetch.UrlRemoteMediaFetcher
 import com.quarkdown.core.media.storage.MEDIA_SUBDIRECTORY_NAME
 import com.quarkdown.core.media.storage.MutableMediaStorage
 import com.quarkdown.core.media.storage.StoredMedia
@@ -23,6 +25,7 @@ import com.quarkdown.core.permissions.MissingPermissionException
 import com.quarkdown.core.permissions.Permission
 import com.quarkdown.core.pipeline.output.BinaryOutputArtifact
 import com.quarkdown.core.pipeline.output.FileReferenceOutputArtifact
+import com.quarkdown.core.pipeline.output.OutputResourceGroup
 import java.io.File
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -304,7 +307,7 @@ class MediaTest {
         val fs = VirtualFileSystem("/project")
         fs.writeBytes("icon.png", byteArrayOf(4, 5))
         val media = LocalMedia(fs.resolve("icon.png"))
-        val resource = media.accept(MediaOutputResourceConverter("icon.png"))
+        val resource = media.accept(MediaOutputResourceConverter("icon.png", UrlRemoteMediaFetcher))
         assertIs<BinaryOutputArtifact>(resource)
         assertEquals(listOf<Byte>(4, 5), resource.content)
     }
@@ -312,7 +315,33 @@ class MediaTest {
     @Test
     fun `disk local media exports as file reference artifact`() {
         val media = LocalMedia(DiskFileSystem(workingDir).resolve(LOCAL_ICON))
-        val resource = media.accept(MediaOutputResourceConverter("icon"))
+        val resource = media.accept(MediaOutputResourceConverter("icon", UrlRemoteMediaFetcher))
         assertIs<FileReferenceOutputArtifact>(resource)
+    }
+
+    @Test
+    fun `remote media exports through the injected fetcher`() {
+        val media = RemoteMedia(java.net.URL(REMOTE_IMAGE))
+        val fetcher = RemoteMediaFetcher { byteArrayOf(6, 7, 8) }
+        val resource = media.accept(MediaOutputResourceConverter("image.jpg", fetcher))
+        assertIs<BinaryOutputArtifact>(resource)
+        assertEquals(listOf<Byte>(6, 7, 8), resource.content)
+    }
+
+    @Test
+    fun `storage resource materializes remote media through the injected fetcher`() {
+        val storage =
+            MutableMediaStorage(
+                ReadOnlyMediaStorageOptions(
+                    enableLocalMediaStorage = true,
+                    enableRemoteMediaStorage = true,
+                    remoteMediaFetcher = { media -> media.url.toExternalForm().toByteArray() },
+                ),
+                permissionHolder = localAndRemotePermissionHolder,
+            )
+        storage.register(REMOTE_IMAGE, fileSystem = DiskFileSystem())
+        val resource = assertIs<OutputResourceGroup>(storage.toResource())
+        val artifact = assertIs<BinaryOutputArtifact>(resource.resources.single())
+        assertEquals(REMOTE_IMAGE, artifact.content.toByteArray().decodeToString())
     }
 }

--- a/quarkdown-test/src/test/kotlin/com/quarkdown/test/MediaStorageTest.kt
+++ b/quarkdown-test/src/test/kotlin/com/quarkdown/test/MediaStorageTest.kt
@@ -3,6 +3,7 @@ package com.quarkdown.test
 import com.quarkdown.core.document.sub.Subdocument
 import com.quarkdown.core.media.storage.MEDIA_SUBDIRECTORY_NAME
 import com.quarkdown.core.permissions.Permission
+import com.quarkdown.core.pipeline.output.BinaryOutputArtifact
 import com.quarkdown.core.pipeline.output.FileReferenceOutputArtifact
 import com.quarkdown.core.pipeline.output.OutputResourceGroup
 import com.quarkdown.test.util.DATA_FOLDER
@@ -85,13 +86,24 @@ class MediaStorageTest {
 
                 ![Banner](https://raw.githubusercontent.com/iamgio/quarkdown/project-files/images/tbanner-light.svg)
             """.trimIndent(),
-            options = DEFAULT_OPTIONS.copy(enableRemoteMediaStorage = true),
+            options =
+                DEFAULT_OPTIONS.copy(
+                    enableRemoteMediaStorage = true,
+                    // Fake networkless fetcher.
+                    remoteMediaFetcher = { media -> "<svg><!-- ${media.url} --></svg>".toByteArray() },
+                ),
             enableMediaStorage = true,
             permissions = Permission.DEFAULT_SET + Permission.NetworkAccess,
             outputResourceHook = { group ->
+                val icon = getMediaResources(group).single { "ticon" in it.name }
                 assertEquals(
                     "https-raw.githubusercontent.com-iamgio-quarkdown-project-files-images-ticon-light.svg",
-                    getMediaResources(group).single { "ticon" in it.name }.name,
+                    icon.name,
+                )
+                assertIs<BinaryOutputArtifact>(icon)
+                assertEquals(
+                    "<svg><!-- https://raw.githubusercontent.com/iamgio/quarkdown/project-files/images/ticon-light.svg --></svg>",
+                    icon.content.toByteArray().decodeToString(),
                 )
             },
         ) {


### PR DESCRIPTION
- [X] I have read the [contributing guidelines](https://github.com/iamgio/quarkdown/blob/main/CONTRIBUTING.md).
- [X] I have tested the changes locally.
- [ ] An issue for this change exists, and it was discussed with maintainers. This is required for new features and non-trivial changes. If present, append `Closes #ISSUE_NUMBER` at the end of this PR description.
- [ ] (Optional) I have added necessary documentation to [`docs`](https://github.com/iamgio/quarkdown/tree/main/docs) and [`CHANGELOG.md`](https://github.com/iamgio/quarkdown/blob/main/CHANGELOG.md)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for fetching and exporting remote media through configurable fetchers.
  - Remote media continues to use URL-based downloading by default.
  - Added support for custom, network-independent media retrieval.

- **Bug Fixes**
  - Improved remote media storage and export handling, including correct binary artifacts, filenames, and content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->