### PR TITLE
fix(lexer): use widespread IsX

### DIFF
--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/lexer/patterns/BaseMarkdownInlineTokenRegexPatterns.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/lexer/patterns/BaseMarkdownInlineTokenRegexPatterns.kt
@@ -321,7 +321,7 @@ open class BaseMarkdownInlineTokenRegexPatterns {
     }
 }
 
-private const val PUNCTUATION_HELPER = "\\p{P}\\p{S}"
+private const val PUNCTUATION_HELPER = "\\p{IsP}\\p{IsS}"
 
 // [this is a label]
 private const val LABEL_HELPER = "(?:\\[(?:\\\\.|[^\\[\\]\\\\])*\\]|\\\\.|`[^`]*`|[^\\[\\]\\\\`])*?"

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/util/StringUtils.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/util/StringUtils.kt
@@ -108,7 +108,7 @@ fun StringBuilder.replace(
  *         `.` is sanitized only at the beginning and the end of the string.
  * @param replacement character to replace invalid characters with
  */
-fun String.sanitizeFileName(replacement: String) = this.replace("^\\.|\\.$|[^\\p{L}\\p{N}\\p{M}\\-_.@]+".toRegex(), replacement)
+fun String.sanitizeFileName(replacement: String) = this.replace("^\\.|\\.$|[^\\p{IsL}\\p{IsN}\\p{IsM}\\-_.@]+".toRegex(), replacement)
 
 /**
  * Converts [this] string to a URI-like identifier:
@@ -123,7 +123,7 @@ fun String.toUriIdentifier(): String =
     this
         .lowercase()
         .replace("\\s+".toRegex(), "-")
-        .replace("[^\\p{L}\\p{N}-]".toRegex(), "")
+        .replace("[^\\p{IsL}\\p{IsN}-]".toRegex(), "")
 
 /**
  * Sanitizes [this] string for use as a stable, anchor-like identifier:


### PR DESCRIPTION
- [X] I have read the [contributing guidelines](https://github.com/iamgio/quarkdown/blob/main/CONTRIBUTING.md).
- [X] I have tested the changes locally.
- [ ] An issue for this change exists, and it was discussed with maintainers. This is required for new features and non-trivial changes. If present, append `Closes #ISSUE_NUMBER` at the end of this PR description.
- [ ] (Optional) I have added necessary documentation to [`docs`](https://github.com/iamgio/quarkdown/tree/main/docs) and [`CHANGELOG.md`](https://github.com/iamgio/quarkdown/blob/main/CHANGELOG.md)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Unicode punctuation, symbols, letters, numbers, and marks.
  * Enhanced filename sanitization and URI identifier generation for international characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->