### PR TITLE
refactor: load csl from install layout

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -78,7 +78,7 @@ fun usesQuarkdoc(project: Project): Boolean {
         .any { it.dependencyProject == quarkdoc }
 }
 
-val quarkdocGenerate =
+val quarkdocGenerate: TaskProvider<Task> =
     tasks.register("quarkdocGenerate") {
         group = "documentation"
         description = "Generates the Quarkdoc documentation for modules that include the Quarkdoc plugin."
@@ -156,6 +156,10 @@ val installLibLayout: CopySpec.() -> Unit = {
     into("skills") {
         from(rootProject.file("skills"))
     }
+    // CSL citation style definitions for bibliographies, extracted by :quarkdown-core:extractCslStyles.
+    into("csl") {
+        from(project(":quarkdown-core").layout.buildDirectory.dir("generated/csl-styles"))
+    }
 }
 
 // Bundled JVM runtime
@@ -177,7 +181,7 @@ data class JlinkTarget(
     val jdkHomeRelative: String,
 )
 
-val jdkVersion = providers.gradleProperty("bundledJdkVersion").get()
+val jdkVersion = providers.gradleProperty("bundledJdkVersion").get()!!
 val jdkVersionEncoded = jdkVersion.replace("+", "%2B") // URL-encoded for the GitHub release path
 val jdkBaseUrl = "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-$jdkVersionEncoded/"
 val jdkFileVersion = jdkVersion.replace("+", "_") // Adoptium uses underscores in archive filenames
@@ -417,21 +421,22 @@ distributions.main {
 // directory at runtime.
 val assembleDevLib by tasks.registering(Sync::class) {
     dependsOn(":quarkdown-html:bundleThirdParty")
+    dependsOn(":quarkdown-core:extractCslStyles")
     into(layout.buildDirectory.dir("dev-lib"))
     installLibLayout()
 }
 
 tasks.installDist {
-    dependsOn(quarkdocGenerate, bundleRuntime)
+    dependsOn(quarkdocGenerate, bundleRuntime, ":quarkdown-core:extractCslStyles")
 }
 
 tasks.distZip {
-    dependsOn(quarkdocGenerate, bundleRuntime)
+    dependsOn(quarkdocGenerate, bundleRuntime, ":quarkdown-core:extractCslStyles")
     archiveVersion.set("")
 }
 
 tasks.distTar {
-    dependsOn(quarkdocGenerate, bundleRuntime)
+    dependsOn(quarkdocGenerate, bundleRuntime, ":quarkdown-core:extractCslStyles")
     archiveVersion.set("")
 }
 

--- a/quarkdown-core/build.gradle.kts
+++ b/quarkdown-core/build.gradle.kts
@@ -65,6 +65,15 @@ val extractCslStyles by tasks.registering {
     }
 }
 
-sourceSets.main {
-    resources.srcDir(extractCslStyles)
+tasks.test {
+    // Lets tests read CSL styles from the extraction output.
+    dependsOn(extractCslStyles)
+    systemProperty(
+        "quarkdown.test.csl.styles.path",
+        layout.buildDirectory
+            .dir("generated/csl-styles")
+            .get()
+            .asFile
+            .absolutePath,
+    )
 }

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/bibliography/style/csl/CslBibliographyStyle.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/bibliography/style/csl/CslBibliographyStyle.kt
@@ -25,7 +25,8 @@ import java.io.InputStream
  * which processes the CSL XML style definition and produces structured output
  * converted to Quarkdown AST nodes via [QuarkdownCslFormat] and [CslTokenConverter].
  *
- * @param cslStyleName the CSL style identifier (e.g. `"apa"`, `"ieee"`, `"chicago-author-date"`)
+ * @param cslStyleName the CSL style name (e.g. `"apa"`, `"ieee"`, `"chicago-author-date"`)
+ * @param cslStyleSource the XML content of the CSL style definition
  * @param provider the item data provider supplying bibliography data to citeproc-java
  * @param locale optional [RFC 4646](https://www.rfc-editor.org/rfc/rfc4646) locale tag
  *               (e.g. `"en-US"`, `"de-DE"`). Controls localized terms such as "and"/"und",
@@ -36,13 +37,14 @@ import java.io.InputStream
  */
 class CslBibliographyStyle(
     private val cslStyleName: String,
+    cslStyleSource: String,
     private val provider: ItemDataProvider,
     locale: String? = null,
 ) : BibliographyStyle {
     private val format = QuarkdownCslFormat()
 
     private val csl =
-        CSL(provider, cslStyleName, locale).apply {
+        CSL(provider, cslStyleSource, locale).apply {
             setOutputFormat(format)
             registerCitationItems(provider.ids)
         }
@@ -92,7 +94,8 @@ class CslBibliographyStyle(
         /**
          * Reads a bibliography file and creates a [CslBibliographyStyle].
          * Supports BibTeX (`.bib`), CSL JSON, YAML, EndNote, and RIS formats.
-         * @param cslStyleName the CSL style identifier
+         * @param cslStyleName the CSL style name, used for error reporting
+         * @param cslStyleSource the serialized XML content of the CSL style definition
          * @param input the input stream for the bibliography source
          * @param filename the filename hint for format detection
          * @param locale optional [Locale] for localized terms (e.g. "and"/"und", month names).
@@ -101,16 +104,17 @@ class CslBibliographyStyle(
          */
         fun from(
             cslStyleName: String,
+            cslStyleSource: String,
             input: InputStream,
             filename: String,
             locale: Locale? = null,
         ): CslBibliographyStyle {
             val provider = BibliographyFileReader().readBibliographyFile(input, filename)
             return try {
-                CslBibliographyStyle(cslStyleName, provider, locale?.tag)
+                CslBibliographyStyle(cslStyleName, cslStyleSource, provider, locale?.tag)
             } catch (e: IOException) {
                 throw IllegalArgumentException(
-                    "Bibliography style '$cslStyleName' does not exist or failed to load. " +
+                    "Bibliography style '$cslStyleName' failed to load. " +
                         "See https://quarkdown.com/wiki/bibliography for a list of available styles.",
                     e,
                 )

--- a/quarkdown-core/src/test/kotlin/com/quarkdown/core/CslBibliographyStyleTest.kt
+++ b/quarkdown-core/src/test/kotlin/com/quarkdown/core/CslBibliographyStyleTest.kt
@@ -4,6 +4,7 @@ import com.quarkdown.core.ast.base.inline.Emphasis
 import com.quarkdown.core.ast.base.inline.Link
 import com.quarkdown.core.bibliography.style.csl.CslBibliographyStyle
 import com.quarkdown.core.util.node.toPlainText
+import java.io.File
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -14,8 +15,14 @@ import kotlin.test.assertTrue
 class CslBibliographyStyleTest {
     private fun bibResource(name: String) = javaClass.getResourceAsStream("/bib/$name")!!
 
+    /**
+     * Reads a CSL style definition from the `extractCslStyles` Gradle task output.
+     */
+    private fun styleSource(styleName: String): String =
+        File(System.getProperty("quarkdown.test.csl.styles.path"), "$styleName.csl").readText()
+
     private fun cslStyle(styleName: String): CslBibliographyStyle =
-        CslBibliographyStyle.from(styleName, bibResource("bibliography.bib"), "bibliography.bib")
+        CslBibliographyStyle.from(styleName, styleSource(styleName), bibResource("bibliography.bib"), "bibliography.bib")
 
     @Test
     fun `csl apa, article citation label`() {

--- a/quarkdown-install-layout-navigator/src/main/kotlin/com/quarkdown/installlayout/InstallLayout.kt
+++ b/quarkdown-install-layout-navigator/src/main/kotlin/com/quarkdown/installlayout/InstallLayout.kt
@@ -18,6 +18,9 @@ class InstallLayout(
     /** The bundled agent skill directory, containing the `SKILL.md` entrypoint and any supporting files. */
     val agentSkill get() = resolveDirectory("skills").resolveDirectory("quarkdown")
 
+    /** The directory containing CSL citation style definitions for bibliographies. */
+    val cslStyles get() = resolveDirectory("csl")
+
     companion object {
         /** Lazily resolved singleton pointing to the current process's install layout. Throws if resolution fails. */
         val get by lazy(InstallDirectoryResolver::resolve)

--- a/quarkdown-stdlib/build.gradle.kts
+++ b/quarkdown-stdlib/build.gradle.kts
@@ -11,6 +11,7 @@ dependencies {
     testImplementation("org.assertj:assertj-core:3.27.7")
     testImplementation(testFixtures(project(":quarkdown-core")))
     implementation(project(":quarkdown-core"))
+    implementation(project(":quarkdown-install-layout-navigator"))
     implementation("se.sawano.java:alphanumeric-comparator:2.0.0")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.11.0")
     implementation("com.jsoizo:kotlin-csv-jvm:2.0.0")

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Bibliography.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Bibliography.kt
@@ -16,6 +16,7 @@ import com.quarkdown.core.function.value.NodeValue
 import com.quarkdown.core.function.value.wrappedAsValue
 import com.quarkdown.core.permissions.Permission
 import com.quarkdown.core.util.trimEntries
+import com.quarkdown.installlayout.InstallLayout
 import com.quarkdown.processor.annotation.Name
 import com.quarkdown.processor.annotation.QFunction
 import com.quarkdown.processor.annotation.QModule
@@ -24,6 +25,30 @@ import com.quarkdown.processor.annotation.QModule
  * The default [CSL](https://citationstyles.org) style used when no explicit style is specified.
  */
 internal const val DEFAULT_CSL_STYLE = "ieee"
+
+/**
+ * Pattern of a valid CSL style name: a plain file name with no path separators.
+ */
+private val CSL_STYLE_NAME_REGEX = Regex("""[\w.-]+""")
+
+/**
+ * Reads the content of the CSL style definition named [style] from the install layout's `csl/` directory.
+ * @param style the CSL style name (e.g. `apa`, `ieee`)
+ * @return the serialized XML content of the style definition
+ * @throws IllegalArgumentException if no style with such name is bundled
+ */
+private fun cslStyleSource(style: String): String {
+    fun notFound(): String =
+        "Bibliography style '$style' not found. " +
+            "See https://quarkdown.com/wiki/bibliography for a list of available styles."
+
+    require(CSL_STYLE_NAME_REGEX.matches(style)) { notFound() }
+
+    val styleFile = InstallLayout.get.cslStyles.resolveFile("$style.csl")
+    require(styleFile.exists()) { notFound() }
+
+    return styleFile.file.readText()
+}
 
 /**
  * Generates a bibliography from a bibliography file.
@@ -42,7 +67,7 @@ internal const val DEFAULT_CSL_STYLE = "ieee"
  * ```
  *
  * @param path path to the bibliography file, with extension
- * @param style [CSL](https://citationstyles.org) style identifier (e.g. `apa`, `ieee`, `chicago-author-date`)
+ * @param style CSL (https://citationstyles.org) style identifier (e.g. `apa`, `ieee`, `chicago-author-date`)
  *              from Quarkdown's selection. See the wiki page for a list of supported styles.
  * @param title title of the bibliography. If unset, the default localized title is used
  * @param breakPage whether the heading preceding the bibliography triggers an automatic page break.
@@ -73,7 +98,14 @@ fun bibliography(
     @Name("indexheading") indexHeading: Boolean = false,
 ): NodeValue {
     val file = file(context, path)
-    val resolvedStyle = CslBibliographyStyle.from(style, file.readBytes().inputStream(), file.name, context.documentInfo.locale)
+    val resolvedStyle =
+        CslBibliographyStyle.from(
+            cslStyleName = style,
+            cslStyleSource = cslStyleSource(style),
+            input = file.readBytes().inputStream(),
+            filename = file.name,
+            locale = context.documentInfo.locale,
+        )
 
     val heading =
         Heading.createSectionHeading(

--- a/quarkdown-test/src/test/kotlin/com/quarkdown/test/BibliographyTest.kt
+++ b/quarkdown-test/src/test/kotlin/com/quarkdown/test/BibliographyTest.kt
@@ -1,11 +1,13 @@
 package com.quarkdown.test
 
+import com.quarkdown.core.function.error.InvalidFunctionCallException
 import com.quarkdown.rendering.markdown.extension.gfm
 import com.quarkdown.rendering.plaintext.extension.plainText
 import com.quarkdown.test.util.DEFAULT_OPTIONS
 import com.quarkdown.test.util.execute
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
 private const val BIBLIOGRAPHY_CALL = ".bibliography {bib/bibliography.bib} breakpage:{no}"
@@ -52,6 +54,16 @@ class BibliographyTest {
                 ieeeBibliographyOutput(),
                 it,
             )
+        }
+    }
+
+    @Test
+    fun `style name cannot escape the styles directory`() {
+        // Traversal and separator attempts must be rejected before any file resolution.
+        listOf("../apa", "..\\apa", "styles/apa", "/etc/apa", "../../qd/main").forEach { style ->
+            assertFailsWith<InvalidFunctionCallException> {
+                execute(".bibliography {bib/bibliography.bib} style:{$style}") {}
+            }
         }
     }
 


### PR DESCRIPTION
- [X] I have read the [contributing guidelines](https://github.com/iamgio/quarkdown/blob/main/CONTRIBUTING.md).
- [X] I have tested the changes locally.
- [ ] An issue for this change exists, and it was discussed with maintainers. This is required for new features and non-trivial changes. If present, append `Closes #ISSUE_NUMBER` at the end of this PR description.
- [ ] (Optional) I have added necessary documentation to [`docs`](https://github.com/iamgio/quarkdown/tree/main/docs) and [`CHANGELOG.md`](https://github.com/iamgio/quarkdown/blob/main/CHANGELOG.md)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Installed distributions now include bundled CSL citation styles.
  * Bibliographies load citation styles from the installation’s styles directory.

* **Bug Fixes**
  * Improved citation style loading and error handling for unavailable styles.
  * Prevented bibliography style names from accessing files outside the styles directory.

* **Tests**
  * Updated bibliography tests to use extracted CSL style files.
  * Added coverage for invalid and unsafe citation style names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->