### PR TITLE
build: save up binary size with ktor netty->cio

### DIFF
--- a/quarkdown-server/build.gradle.kts
+++ b/quarkdown-server/build.gradle.kts
@@ -10,10 +10,7 @@ dependencies {
 
     val ktorVersion = "3.5.0"
 
-    implementation("io.ktor:ktor-server-netty:$ktorVersion") {
-        exclude(group = "io.netty", module = "netty-codec-marshalling")
-        exclude(group = "io.netty", module = "netty-codec-protobuf")
-    }
+    implementation("io.ktor:ktor-server-cio:$ktorVersion")
     implementation("io.ktor:ktor-server-sse:$ktorVersion")
     implementation("io.ktor:ktor-client-core:$ktorVersion")
     implementation("io.ktor:ktor-client-cio:$ktorVersion")

--- a/quarkdown-server/src/main/kotlin/com/quarkdown/server/LocalFileWebServer.kt
+++ b/quarkdown-server/src/main/kotlin/com/quarkdown/server/LocalFileWebServer.kt
@@ -7,9 +7,9 @@ import com.quarkdown.server.stop.KtorStoppableAdapter
 import com.quarkdown.server.stop.Stoppable
 import io.ktor.server.application.ServerReady
 import io.ktor.server.application.install
+import io.ktor.server.cio.CIO
 import io.ktor.server.engine.embeddedServer
 import io.ktor.server.http.content.staticFiles
-import io.ktor.server.netty.Netty
 import io.ktor.server.routing.get
 import io.ktor.server.routing.post
 import io.ktor.server.routing.routing
@@ -57,7 +57,7 @@ class LocalFileWebServer(
         }
 
         val server =
-            embeddedServer(Netty, port) {
+            embeddedServer(CIO, port) {
                 install(SSE)
 
                 routing {


### PR DESCRIPTION
- [X] I have read the [contributing guidelines](https://github.com/iamgio/quarkdown/blob/main/CONTRIBUTING.md).
- [X] I have tested the changes locally.
- [ ] An issue for this change exists, and it was discussed with maintainers. This is required for new features and non-trivial changes. If present, append `Closes #ISSUE_NUMBER` at the end of this PR description.
- [ ] (Optional) I have added necessary documentation to [`docs`](https://github.com/iamgio/quarkdown/tree/main/docs) and [`CHANGELOG.md`](https://github.com/iamgio/quarkdown/blob/main/CHANGELOG.md)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the local web server to use the CIO engine instead of Netty.
  * Preserved existing server behavior while changing the underlying runtime engine.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->