### PR TITLE
docs: inline table headers list in .tablebyrows

### DIFF
--- a/docs/table-generation.qd
+++ b/docs/table-generation.qd
@@ -23,12 +23,11 @@ In the following example, `.repeat` is used, which, like other supported [loops]
 The **`.tablebyrows`** .docslink {quarkdown-stdlib/com.quarkdown.stdlib.module.TableComputation/tablebyrows.html} function takes two arguments: an optional iterable of headers and an iterable of rows.
 
 .examplemirror
-    .var {headers}
-       - Name
-       - Age
-       - City
-
-    .tablebyrows {.headers}
+    .tablebyrows headers:{
+        - Name
+        - Age
+        - City
+    }
         - - John
           - 25
           - NY

--- a/quarkdown-test/src/test/kotlin/com/quarkdown/test/TableComputationTest.kt
+++ b/quarkdown-test/src/test/kotlin/com/quarkdown/test/TableComputationTest.kt
@@ -258,6 +258,56 @@ class TableComputationTest {
     }
 
     @Test
+    fun `generation by rows, dynamic rows`() {
+        execute(
+            """
+            .tablebyrows
+                .repeat {3}
+                    y:
+                    .repeat {3}
+                        x:
+                        Cell .x:.y
+            """.trimIndent(),
+        ) {
+            assertEquals(
+                "<table><thead><tr><th></th><th></th><th></th></tr></thead><tbody>" +
+                    (1..3).joinToString("") { y ->
+                        "<tr>" + (1..3).joinToString("") { x -> "<td>Cell $x:$y</td>" } + "</tr>"
+                    } +
+                    "</tbody></table>",
+                it,
+            )
+        }
+    }
+
+    @Test
+    fun `generation by rows, with inlined headers`() {
+        execute(
+            """
+            .tablebyrows headers:{
+                - Name
+                - Age
+                - City
+            }
+                - - John
+                  - 25
+                  - NY
+                - - Lisa
+                  - 32
+                  - LA
+                - - Mike
+                  - 19
+                  - CHI
+            """.trimIndent(),
+        ) {
+            assertEquals(
+                htmlTable(john + lisa + mike),
+                it,
+            )
+        }
+    }
+
+    @Test
     fun `generation by rows, with headers`() {
         execute(
             """


### PR DESCRIPTION
- [X] I have read the [contributing guidelines](https://github.com/iamgio/quarkdown/blob/main/CONTRIBUTING.md).
- [X] I have tested the changes locally.
- [ ] An issue for this change exists, and it was discussed with maintainers. This is required for new features and non-trivial changes. If present, append `Closes #ISSUE_NUMBER` at the end of this PR description.
- [ ] (Optional) I have added necessary documentation to [`docs`](https://github.com/iamgio/quarkdown/tree/main/docs) and [`CHANGELOG.md`](https://github.com/iamgio/quarkdown/blob/main/CHANGELOG.md)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the `.tablebyrows` example to pass table headers inline.

* **Tests**
  * Added coverage for dynamically generated table rows using nested repeats.
  * Added coverage for inline header lists in table generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->