### PR TITLE
fix(lsp): fix parameter completions inside body arg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,10 @@ Additionally, the two themes now ship smaller font artifacts that reduce the siz
 
 Function extensions declared in a nested scope now compose with inherited extensions only within that scope, without leaking into parent or sibling scopes.
 
+#### [LSP] Fixed incorrect parameter completions inside body arguments
+
+When inside a body argument, the language server doesn't suggest other sibling parameters anymore.
+
 ## [2.5.1] - 2026-08-12
 
 ### Changed

--- a/quarkdown-lsp/src/main/kotlin/com/quarkdown/lsp/tokenizer/FunctionCallTokenizer.kt
+++ b/quarkdown-lsp/src/main/kotlin/com/quarkdown/lsp/tokenizer/FunctionCallTokenizer.kt
@@ -180,6 +180,13 @@ class FunctionCallTokenizer {
                 FunctionCallToken.Type.LINE_CONTINUATION
             }
 
+            // .function
+            //     body
+            //     ^^^^
+            FUNCTION_CALL_BODY_ARGUMENT_CONTENT_TOKEN_NAME -> {
+                FunctionCallToken.Type.BODY_ARGUMENT
+            }
+
             else -> {
                 null
             }

--- a/quarkdown-lsp/src/test/kotlin/com/quarkdown/lsp/FunctionCallTokenizerTest.kt
+++ b/quarkdown-lsp/src/test/kotlin/com/quarkdown/lsp/FunctionCallTokenizerTest.kt
@@ -179,6 +179,19 @@ class FunctionCallTokenizerTest {
     }
 
     @Test
+    fun `body argument tokenization`() {
+        val text = ".function\n    body content"
+        val calls = tokenizer.getFunctionCalls(text)
+
+        assertEquals(1, calls.size)
+
+        val bodyToken = calls.first().tokens.find { it.type == FunctionCallToken.Type.BODY_ARGUMENT }
+        assertNotNull(bodyToken, "body argument was not tokenized")
+        assertEquals("\n    body content", bodyToken.lexeme)
+        assertTrue(text.lastIndex in bodyToken.range)
+    }
+
+    @Test
     fun `multiple function calls in text`() {
         val text = "Text .function1 {arg1} more text .function2 param:{value}"
         val calls = tokenizer.getFunctionCalls(text)

--- a/quarkdown-lsp/src/test/kotlin/com/quarkdown/lsp/FunctionCallTokensSupplierTest.kt
+++ b/quarkdown-lsp/src/test/kotlin/com/quarkdown/lsp/FunctionCallTokensSupplierTest.kt
@@ -285,6 +285,47 @@ class FunctionCallTokensSupplierTest {
         }
     }
 
+    @Test
+    fun `nested function call inside body argument`() {
+        tokenize(
+            """
+            .outer
+              Text .inner param:{yes}
+            """.trimIndent().normalizeLineSeparators().toString(),
+        ) {
+            assertNext(TYPE_BEGIN, 0..1)
+            assertNext(TYPE_NAME, 1..6)
+            assertNext(TYPE_BEGIN, 14..15)
+            assertNext(TYPE_NAME, 15..20)
+            assertNext(TYPE_NAMED_PARAMETER, 21..26)
+            assertNext(TYPE_NAMED_PARAMETER_SEPARATOR, 26..27)
+            assertNext(TYPE_INLINE_ARGUMENT_DELIMITER, 27..28)
+            assertNext(TokenType.BOOLEAN, 28..31)
+            assertNext(TYPE_INLINE_ARGUMENT_DELIMITER, 31..32)
+        }
+    }
+
+    @Test
+    fun `nested function calls in body arguments at multiple depths`() {
+        tokenize(
+            """
+            .outer
+              .middle
+                .leaf {1}
+            """.trimIndent().normalizeLineSeparators().toString(),
+        ) {
+            assertNext(TYPE_BEGIN, 0..1)
+            assertNext(TYPE_NAME, 1..6)
+            assertNext(TYPE_BEGIN, 9..10)
+            assertNext(TYPE_NAME, 10..16)
+            assertNext(TYPE_BEGIN, 21..22)
+            assertNext(TYPE_NAME, 22..26)
+            assertNext(TYPE_INLINE_ARGUMENT_DELIMITER, 27..28)
+            assertNext(TokenType.NUMBER, 28..29)
+            assertNext(TYPE_INLINE_ARGUMENT_DELIMITER, 29..30)
+        }
+    }
+
     // Value types
 
     @Test

--- a/quarkdown-lsp/src/test/kotlin/com/quarkdown/lsp/FunctionCompletionSupplierTest.kt
+++ b/quarkdown-lsp/src/test/kotlin/com/quarkdown/lsp/FunctionCompletionSupplierTest.kt
@@ -352,6 +352,39 @@ class FunctionCompletionSupplierTest {
         assertTrue(completions.isEmpty())
     }
 
+    // Body arguments
+
+    @Test
+    fun `no parameter completions inside body argument`() {
+        val text = ".$COLUMN_FUNCTION\n    cr"
+        val completions = getCompletions(text, Position(1, 6))
+        assertTrue(completions.isEmpty())
+    }
+
+    @Test
+    fun `no parameter completions inside multiline body argument`() {
+        val text = ".$COLUMN_FUNCTION\n    content\n    cr"
+        val completions = getCompletions(text, Position(2, 6))
+        assertTrue(completions.isEmpty())
+    }
+
+    @Test
+    fun `name completions for nested call inside body argument`() {
+        val text = ".$COLUMN_FUNCTION\n    .cl"
+        val completions = getCompletions(text, Position(1, 7))
+
+        assertEquals(1, completions.size)
+        assertEquals(CLIP_FUNCTION, completions.first().label)
+    }
+
+    @Test
+    fun `parameter completions for nested call inside body argument`() {
+        val text = ".$COLUMN_FUNCTION\n    .$ALIGN_FUNCTION align"
+        val completions = getCompletions(text, Position(1, text.lines()[1].length)).map { it.label }
+
+        assertEquals(ALIGNMENT_PARAMETER, completions.single())
+    }
+
     // Wrapped (tight) function calls
 
     @Test


### PR DESCRIPTION
- [x] I have read the [contributing guidelines](https://github.com/iamgio/quarkdown/blob/main/CONTRIBUTING.md).
- [x] I have tested the changes locally.
- [ ] An issue for this change exists, and it was discussed with maintainers. This is required for new features and non-trivial changes. If present, append `Closes #ISSUE_NUMBER` at the end of this PR description.
- [x] (Optional) I have added necessary documentation to [`docs`](https://github.com/iamgio/quarkdown/tree/main/docs) and [`CHANGELOG.md`](https://github.com/iamgio/quarkdown/blob/main/CHANGELOG.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed language server completion suggestions inside function body arguments.
  - Sibling parameter suggestions are no longer shown while editing body text.
  - Nested function names and parameters continue to receive appropriate completion suggestions.
  - Improved recognition and tokenization of indented body arguments, including nested function calls.

- **Tests**
  - Added coverage for body argument tokenization, nested calls, and completion behavior at multiple nesting levels.

- **Documentation**
  - Added the fix to the unreleased changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->