### PR TITLE
refactor(quarkdoc-reader): drop jsoup for ksoup

### DIFF
--- a/quarkdown-lsp/build.gradle.kts
+++ b/quarkdown-lsp/build.gradle.kts
@@ -7,6 +7,7 @@ dependencies {
     testImplementation("io.mockk:mockk:1.14.11")
     implementation("org.eclipse.lsp4j:org.eclipse.lsp4j:1.0.0")
     implementation("com.github.h0tk3y.betterParse:better-parse:0.4.4")
+    implementation("com.fleeksoft.ksoup:ksoup:0.2.6")
     implementation("com.vladsch.flexmark:flexmark-html2md-converter:0.64.8")
     implementation(project(":quarkdown-core"))
     implementation(project(":quarkdown-quarkdoc-reader"))

--- a/quarkdown-lsp/src/main/kotlin/com/quarkdown/lsp/documentation/HtmlToMarkdown.kt
+++ b/quarkdown-lsp/src/main/kotlin/com/quarkdown/lsp/documentation/HtmlToMarkdown.kt
@@ -1,50 +1,69 @@
 package com.quarkdown.lsp.documentation
 
+import com.fleeksoft.ksoup.Ksoup
 import com.quarkdown.quarkdoc.reader.DocsContentExtractor
 import com.vladsch.flexmark.html2md.converter.FlexmarkHtmlConverter
 import org.eclipse.lsp4j.MarkupContent
 import org.eclipse.lsp4j.MarkupKind
-import org.jsoup.Jsoup
 
 /**
  * Helper to convert HTML to Markdown, suitable for use in LSP documentation.
+ *
+ * The HTML is preprocessed with ksoup into a simplified, structurally valid form,
+ * then serialized and handed to the Markdown converter.
  */
 object HtmlToMarkdown {
+    private val converter = FlexmarkHtmlConverter.builder().build()
+
     /**
      * Converts HTML to Markdown, suitable for use in LSP documentation.
      * @param html the HTML string to convert
      * @return the converted Markdown string
      */
     fun convert(html: String): String {
-        val processedHtml =
-            Jsoup
+        val document =
+            Ksoup
                 .parse(html)
                 .apply {
-                    // Cleans up links in code blocks.
+                    // Flattens links and spans in code blocks to plain text: a fence must not carry Markdown links.
+                    // Dokka renders signatures as per-token spans split across formatted source lines,
+                    // whose line breaks are formatting artifacts to collapse; plain code samples keep theirs.
                     select("pre code").forEach {
-                        it.text(it.wholeText())
+                        val isTokenized = it.select("span.token").isNotEmpty()
+                        val text = it.wholeText()
+                        it.text(if (isTokenized) text.replace(Regex("\\s+"), " ").trim() else text)
                     }
 
+                    // Parameter names are underlined in the source, but bold reads better in tooltips.
+                    select("u").forEach {
+                        it.tagName("strong")
+                    }
+
+                    // Parameter tables become lists.
                     select(".table").forEach {
                         it.tagName("ul")
                     }
                     select(".main-subrow").forEach {
                         it.tagName("li")
                     }
-
-                    select(".table h4").forEach {
+                    select(".main-subrow h4").forEach {
                         it.tagName("p")
                     }
 
-                    select(".main-subrow > *").forEach {
-                        it.tagName("p")
+                    // Wrappers dissolve so the serialized HTML remains structurally valid:
+                    // block elements inside `p`, or between `ul` and `li`, would be relocated
+                    // when the converter reparses the serialized document.
+                    select(".table-row").forEach {
+                        it.unwrap()
+                    }
+                    select(".main-subrow div, .main-subrow span").forEach {
+                        it.unwrap()
                     }
 
-                    select("u").forEach {
-                        it.tagName("strong")
-                    }
+                    // Compact serialization: pretty-printing would inject whitespace between elements.
+                    outputSettings().prettyPrint(false)
                 }
-        return FlexmarkHtmlConverter.builder().build().convert(processedHtml)
+        return converter.convert(document.body().html())
     }
 }
 

--- a/quarkdown-lsp/src/test/kotlin/com/quarkdown/lsp/HtmlToMarkdownTest.kt
+++ b/quarkdown-lsp/src/test/kotlin/com/quarkdown/lsp/HtmlToMarkdownTest.kt
@@ -10,6 +10,15 @@ import kotlin.test.assertEquals
  */
 class HtmlToMarkdownTest {
     @Test
+    fun `links in code blocks are flattened to plain text`() {
+        val html = """<pre><code class="lang-kotlin">.func {<a href="type.html">Type</a>}</code></pre>"""
+        assertEquals(
+            "```lang-kotlin\n.func {Type}\n```",
+            HtmlToMarkdown.convert(html).trim(),
+        )
+    }
+
+    @Test
     fun `stdlib page`() {
         val html = javaClass.getResourceAsStream("/html-to-markdown/align.html")!!.bufferedReader().use { it.readText() }
         val md = javaClass.getResourceAsStream("/html-to-markdown/align.md")!!.bufferedReader().use { it.readText() }

--- a/quarkdown-lsp/src/test/resources/html-to-markdown/align.md
+++ b/quarkdown-lsp/src/test/resources/html-to-markdown/align.md
@@ -12,24 +12,19 @@ the new aligned Container node
 
 * **alignment**
 
-
   content alignment anchor and text alignment
 
   Values
   * `start`
   * `center`
   * `end`
-
 * **body**
-
 
   content to center
 
 #### See also
 
 * [container](container.html)
-
-  <br />
 
 #### Wiki page
 

--- a/quarkdown-quarkdoc-reader/build.gradle.kts
+++ b/quarkdown-quarkdoc-reader/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 
 dependencies {
     testImplementation(kotlin("test"))
-    implementation("org.jsoup:jsoup:1.22.2")
+    implementation("com.fleeksoft.ksoup:ksoup:0.2.6")
 }
 
 tasks.test {

--- a/quarkdown-quarkdoc-reader/src/main/kotlin/com/quarkdown/quarkdoc/reader/anchors/AnchorsHtml.kt
+++ b/quarkdown-quarkdoc-reader/src/main/kotlin/com/quarkdown/quarkdoc/reader/anchors/AnchorsHtml.kt
@@ -1,7 +1,7 @@
 package com.quarkdown.quarkdoc.reader.anchors
 
+import com.fleeksoft.ksoup.nodes.Element
 import com.quarkdown.quarkdoc.reader.anchors.AnchorsHtml.ANCHOR_TAG
-import org.jsoup.nodes.Element
 
 /**
  * Utilities for handling HTML [Anchors].

--- a/quarkdown-quarkdoc-reader/src/main/kotlin/com/quarkdown/quarkdoc/reader/dokka/DokkaHtmlContentExtractor.kt
+++ b/quarkdown-quarkdoc-reader/src/main/kotlin/com/quarkdown/quarkdoc/reader/dokka/DokkaHtmlContentExtractor.kt
@@ -1,5 +1,7 @@
 package com.quarkdown.quarkdoc.reader.dokka
 
+import com.fleeksoft.ksoup.Ksoup
+import com.fleeksoft.ksoup.nodes.Element
 import com.quarkdown.quarkdoc.reader.DocsContentExtractor
 import com.quarkdown.quarkdoc.reader.DocsFunction
 import com.quarkdown.quarkdoc.reader.DocsParameter
@@ -7,8 +9,6 @@ import com.quarkdown.quarkdoc.reader.anchors.Anchors
 import com.quarkdown.quarkdoc.reader.anchors.getAnchorNextElement
 import com.quarkdown.quarkdoc.reader.anchors.hasAnchor
 import com.quarkdown.quarkdoc.reader.anchors.stripAnchors
-import org.jsoup.Jsoup
-import org.jsoup.nodes.Element
 
 private const val PARAMETERS_HEADER = "Parameters"
 
@@ -19,7 +19,7 @@ class DokkaHtmlContentExtractor(
     private val html: String,
 ) : DocsContentExtractor {
     override fun extractContent(): String? =
-        Jsoup
+        Ksoup
             .parse(html)
             .selectFirst("#main .content")
             ?.apply {
@@ -29,7 +29,7 @@ class DokkaHtmlContentExtractor(
 
     override fun extractFunctionData(): DocsFunction? {
         val main =
-            Jsoup
+            Ksoup
                 .parse(html)
                 .selectFirst("#main > .main-content")
                 ?.takeIf { it.attr("data-page-type") == "member" }

--- a/quarkdown-quarkdoc/build.gradle.kts
+++ b/quarkdown-quarkdoc/build.gradle.kts
@@ -18,5 +18,5 @@ dependencies {
     testImplementation("org.jetbrains.dokka:dokka-test-api:$dokkaVersion")
     testImplementation("org.jetbrains.dokka:dokka-base-test-utils:$dokkaVersion")
     testRuntimeOnly("org.jetbrains.dokka:analysis-kotlin-symbols:$dokkaVersion")
-    testImplementation("org.jsoup:jsoup:1.21.2")
+    testImplementation("com.fleeksoft.ksoup:ksoup:0.2.6")
 }

--- a/quarkdown-quarkdoc/src/test/kotlin/com/quarkdown/quarkdoc/dokka/QuarkdocDokkaTest.kt
+++ b/quarkdown-quarkdoc/src/test/kotlin/com/quarkdown/quarkdoc/dokka/QuarkdocDokkaTest.kt
@@ -1,5 +1,7 @@
 package com.quarkdown.quarkdoc.dokka
 
+import com.fleeksoft.ksoup.Ksoup
+import com.fleeksoft.ksoup.nodes.Element
 import com.quarkdown.core.log.Log
 import com.quarkdown.quarkdoc.dokka.transformers.enumeration.EnumStorage
 import com.quarkdown.quarkdoc.dokka.transformers.module.QuarkdownModulesStorage
@@ -7,8 +9,6 @@ import org.jetbrains.dokka.base.testApi.testRunner.BaseAbstractTest
 import org.jetbrains.dokka.testApi.logger.TestLogger
 import org.jetbrains.dokka.utilities.DokkaConsoleLogger
 import org.jetbrains.dokka.utilities.LoggingLevel
-import org.jsoup.Jsoup
-import org.jsoup.nodes.Element
 import utils.TestOutputWriterPlugin
 import java.io.File
 import kotlin.reflect.KClass
@@ -135,7 +135,7 @@ open class QuarkdocDokkaTest(
     )
 
     protected fun getText(html: String): String =
-        Jsoup
+        Ksoup
             .parse(html)
             .text()
 
@@ -145,7 +145,7 @@ open class QuarkdocDokkaTest(
      * @throws IllegalStateException if the signature is not found
      */
     protected fun getSignature(html: String) =
-        Jsoup
+        Ksoup
             .parse(html)
             .select(".content :is(pre, .monospace)")
             .firstOrNull()
@@ -158,7 +158,7 @@ open class QuarkdocDokkaTest(
      * @throws IllegalStateException if the paragraph is not found
      */
     protected fun getParagraph(html: String) =
-        Jsoup
+        Ksoup
             .parse(html)
             .select(".content > .paragraph")
             .firstOrNull()
@@ -169,7 +169,7 @@ open class QuarkdocDokkaTest(
         html: String,
         name: String,
     ): Element =
-        Jsoup
+        Ksoup
             .parse(html)
             .select("h4:contains($name)")
             .firstOrNull()


### PR DESCRIPTION
- [X] I have read the [contributing guidelines](https://github.com/iamgio/quarkdown/blob/main/CONTRIBUTING.md).
- [X] I have tested the changes locally.
- [ ] An issue for this change exists, and it was discussed with maintainers. This is required for new features and non-trivial changes. If present, append `Closes #ISSUE_NUMBER` at the end of this PR description.
- [ ] (Optional) I have added necessary documentation to [`docs`](https://github.com/iamgio/quarkdown/tree/main/docs) and [`CHANGELOG.md`](https://github.com/iamgio/quarkdown/blob/main/CHANGELOG.md)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved conversion of HTML documentation to Markdown, including cleaner formatting for code samples, parameter descriptions, tables, and links.
  - Links embedded in code blocks are now displayed as plain text, preserving readable code output.
  - Generated documentation maintains more consistent structure and compact formatting.

- **Documentation**
  - Refined documentation formatting by removing unnecessary spacing and trailing markup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->