### PR TITLE
fix(bibliography): fix bare doi not being an absolute url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,10 @@ Additionally, the two themes now ship smaller font artifacts that reduce the siz
 
 Function extensions declared in a nested scope now compose with inherited extensions only within that scope, without leaking into parent or sibling scopes.
 
+#### [Bibliography](https://quarkdown.com/wiki/bibliography): bare DOIs now link to doi.org
+
+A DOI given as a plain identifier now links to its absolute `https://doi.org/` address.
+
 #### [LSP] Fixed incorrect parameter completions inside body arguments
 
 When inside a body argument, the language server doesn't suggest other sibling parameters anymore.

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/bibliography/style/csl/QuarkdownCslFormat.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/bibliography/style/csl/QuarkdownCslFormat.kt
@@ -24,7 +24,7 @@ internal class QuarkdownCslFormat : BaseFormat() {
     private val tokenConverter =
         CslTokenConverter { text, type ->
             when (type) {
-                TextToken.Type.DOI -> formatDOI(text)
+                TextToken.Type.DOI -> addDOIPrefix(text)
                 else -> formatURL(text)
             }
         }

--- a/quarkdown-core/src/test/kotlin/com/quarkdown/core/CslBibliographyStyleTest.kt
+++ b/quarkdown-core/src/test/kotlin/com/quarkdown/core/CslBibliographyStyleTest.kt
@@ -119,6 +119,30 @@ class CslBibliographyStyleTest {
     }
 
     @Test
+    fun `csl apa, bare doi is resolved to an absolute doi url`() {
+        val style = cslStyle("apa")
+        val entry = style.bibliography.entries["baredoi"]!!
+        val content = style.contentOf(entry)
+        val doiLink = content.filterIsInstance<Link>().firstOrNull()
+        assertEquals(
+            "https://doi.org/10.1109/ICRA46639.2022.9812329",
+            doiLink?.url,
+        )
+    }
+
+    @Test
+    fun `csl apa, absolute doi url is kept as-is`() {
+        val style = cslStyle("apa")
+        val entry = style.bibliography.entries["einstein"]!!
+        val content = style.contentOf(entry)
+        val doiLink = content.filterIsInstance<Link>().firstOrNull()
+        assertEquals(
+            "http://dx.doi.org/10.1002/andp.19053221004",
+            doiLink?.url,
+        )
+    }
+
+    @Test
     fun `csl apa, list label is empty`() {
         val style = cslStyle("apa")
         val entry = style.bibliography.entries["einstein"]!!

--- a/quarkdown-core/src/test/resources/bib/bibliography.bib
+++ b/quarkdown-core/src/test/resources/bib/bibliography.bib
@@ -23,3 +23,11 @@
     title     = "Knuth: Computers and Typesetting",
     url       = "http://www-cs-faculty.stanford.edu/\~uno/abcde.html"
 }
+
+@article{baredoi,
+    author  = "Ada Lovelace",
+    title   = "On Bare Digital Object Identifiers",
+    journal = "Journal of Identifiers",
+    year    = "2022",
+    DOI     = "10.1109/ICRA46639.2022.9812329"
+}


### PR DESCRIPTION
- [X] I have read the [contributing guidelines](https://github.com/iamgio/quarkdown/blob/main/CONTRIBUTING.md).
- [X] I have tested the changes locally.
- [x] An issue for this change exists, and it was discussed with maintainers. This is required for new features and non-trivial changes. If present, append `Closes #ISSUE_NUMBER` at the end of this PR description.
- [x] (Optional) I have added necessary documentation to [`docs`](https://github.com/iamgio/quarkdown/tree/main/docs) and [`CHANGELOG.md`](https://github.com/iamgio/quarkdown/blob/main/CHANGELOG.md)

Closes #657

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Bare DOI identifiers in bibliographies now link to their full `https://doi.org/` addresses.
  - Existing absolute DOI URLs remain unchanged.
  - Bibliography links now provide consistent DOI destinations whether the identifier includes a URL prefix or not.

- **Documentation**
  - Updated the unreleased changelog to document the DOI linking fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->