### PR TITLE
fix: make .text and .whitespace block-aware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,11 @@ Breaking change: calling `.doclang` without a parameter now returns the *English
 
 ### Fixed
 
+#### Block-aware [`.text`](https://quarkdown.com/wiki/text) and `.whitespace`
+
+The `.text` and `.whitespace` functions now adapt to where they are called.
+This fixes spacing issues when invoked as block-level functions.
+
 #### Layout themes: bold weight and leaner font artifacts
 
 Fixed an issue that caused bold text in `minimal` and `beamer` themes to be browser-synthesized. It is now correctly and consistently rendered.

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/quarkdown/inline/Whitespace.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/quarkdown/inline/Whitespace.kt
@@ -1,5 +1,6 @@
 package com.quarkdown.core.ast.quarkdown.inline
 
+import com.quarkdown.amber.annotations.Diverge
 import com.quarkdown.core.ast.Node
 import com.quarkdown.core.document.size.Size
 import com.quarkdown.core.visitor.node.NodeVisitor
@@ -9,10 +10,12 @@ import com.quarkdown.core.visitor.node.NodeVisitor
  * If both width and height are `null`, the whitespace consists of a blank space.
  * @param width width of the whitespace
  * @param height height of the whitespace
+ * @param isBlock whether the whitespace is a block element (like a paragraph) or inline (like a text span)
  */
 class Whitespace(
     val width: Size?,
     val height: Size?,
+    @Diverge val isBlock: Boolean = false,
 ) : Node {
     override fun <T> accept(visitor: NodeVisitor<T>): T = visitor.visit(this)
 }

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/function/value/output/node/BlockNodeOutputValueVisitor.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/function/value/output/node/BlockNodeOutputValueVisitor.kt
@@ -3,6 +3,10 @@ package com.quarkdown.core.function.value.output.node
 import com.quarkdown.core.ast.InlineMarkdownContent
 import com.quarkdown.core.ast.Node
 import com.quarkdown.core.ast.base.block.Paragraph
+import com.quarkdown.core.ast.base.inline.Link
+import com.quarkdown.core.ast.quarkdown.inline.TextTransform
+import com.quarkdown.core.ast.quarkdown.inline.Whitespace
+import com.quarkdown.core.ast.quarkdown.inline.diverge
 import com.quarkdown.core.context.Context
 import com.quarkdown.core.function.value.BooleanValue
 import com.quarkdown.core.function.value.NodeValue
@@ -44,6 +48,8 @@ class BlockNodeOutputValueVisitor(
     override fun visit(value: NodeValue) =
         when (val node = value.unwrappedValue) {
             is InlineMarkdownContent -> Paragraph(node.children)
+            is TextTransform, is Link -> node.inParagraph()
+            is Whitespace -> node.diverge(isBlock = true)
             else -> node
         }
 

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/function/value/output/node/NodeOutputValueVisitor.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/function/value/output/node/NodeOutputValueVisitor.kt
@@ -87,7 +87,7 @@ abstract class NodeOutputValueVisitor : OutputValueVisitor<Node> {
         when (value.unwrappedValue) {
             is OutputValue<*> -> value.unwrappedValue.accept(this)
             is Iterable<*> -> GeneralCollectionValue(value.unwrappedValue as Iterable<OutputValue<*>>).accept(this)
-            is Node -> value.unwrappedValue
+            is Node -> this.visit(NodeValue(value.unwrappedValue))
             else -> this.visit(parseRaw(value.unwrappedValue.toString(), value.evaluationContext))
         }
 

--- a/quarkdown-html/src/main/kotlin/com/quarkdown/rendering/html/node/QuarkdownHtmlNodeRenderer.kt
+++ b/quarkdown-html/src/main/kotlin/com/quarkdown/rendering/html/node/QuarkdownHtmlNodeRenderer.kt
@@ -299,20 +299,15 @@ class QuarkdownHtmlNodeRenderer(
         }
 
     override fun visit(node: Whitespace) =
-        // If at least one of the dimensions is set, the square will have a fixed size.
-        // Otherwise, a blank character is rendered.
-        when {
-            node.width == null && node.height == null -> {
-                buildTag("span", "&nbsp;")
+        buildTag(if (node.isBlock) "div" else "span") {
+            className("whitespace")
+            val hasSize = node.width != null || node.height != null
+            if (!hasSize) {
+                +"&nbsp;"
             }
-
-            else -> {
-                buildTag("div") {
-                    style {
-                        "width" value node.width
-                        "height" value node.height
-                    }
-                }
+            style {
+                "width" value node.width
+                "height" value node.height
             }
         }
 

--- a/quarkdown-html/src/main/scss/components/_whitespace.scss
+++ b/quarkdown-html/src/main/scss/components/_whitespace.scss
@@ -1,0 +1,9 @@
+.quarkdown {
+  div.whitespace {
+    margin-top: var(--qd-block-margin);
+  }
+
+  span.whitespace {
+    display: inline-block;
+  }
+}

--- a/quarkdown-html/src/main/scss/global.scss
+++ b/quarkdown-html/src/main/scss/global.scss
@@ -16,6 +16,7 @@
 @use "components/focus";
 @use "components/blockquote";
 @use "components/figure";
+@use "components/whitespace";
 @use "components/mermaid";
 @use "components/filetree";
 @use "components/keybinding";

--- a/quarkdown-html/src/test/e2e/text-formatting/paragraph-wrapping/main.qd
+++ b/quarkdown-html/src/test/e2e/text-formatting/paragraph-wrapping/main.qd
@@ -1,0 +1,5 @@
+First paragraph.
+
+.text {Styled text} size:{large}
+
+Last paragraph.

--- a/quarkdown-html/src/test/e2e/text-formatting/paragraph-wrapping/paragraph-wrapping.spec.ts
+++ b/quarkdown-html/src/test/e2e/text-formatting/paragraph-wrapping/paragraph-wrapping.spec.ts
@@ -1,0 +1,16 @@
+import {evaluateComputedStyle, getComputedSizeProperty} from "../../__util/css";
+import {suite} from "../../quarkdown";
+
+const {test, expect} = suite(__dirname);
+
+test("block text call is wrapped in a paragraph with paragraph spacing", async (page) => {
+    const paragraphs = page.locator("p");
+    await expect(paragraphs).toHaveCount(3);
+
+    const wrapped = paragraphs.nth(1);
+    await expect(wrapped.locator("span")).toHaveText("Styled text");
+
+    const paragraphMargin = await getComputedSizeProperty(page, "var(--qd-paragraph-vertical-margin)");
+    const style = await evaluateComputedStyle(wrapped);
+    expect(parseFloat(style.marginTop)).toBeCloseTo(paragraphMargin, 1);
+});

--- a/quarkdown-html/src/test/e2e/whitespace/block/block.spec.ts
+++ b/quarkdown-html/src/test/e2e/whitespace/block/block.spec.ts
@@ -1,0 +1,15 @@
+import {evaluateComputedStyle, getComputedSizeProperty} from "../../__util/css";
+import {suite} from "../../quarkdown";
+
+const {test, expect} = suite(__dirname);
+
+test("renders block whitespace as a block element with block margin", async (page) => {
+    const whitespace = page.locator("div.whitespace");
+    await expect(whitespace).toHaveCount(1);
+    await expect(whitespace).toHaveCSS("display", "block");
+    await expect(whitespace).toHaveText("\u00a0");
+
+    const blockMargin = await getComputedSizeProperty(page, "var(--qd-block-margin)");
+    const style = await evaluateComputedStyle(whitespace);
+    expect(parseFloat(style.marginTop)).toBeCloseTo(blockMargin, 1);
+});

--- a/quarkdown-html/src/test/e2e/whitespace/block/main.qd
+++ b/quarkdown-html/src/test/e2e/whitespace/block/main.qd
@@ -1,0 +1,5 @@
+Paragraph one.
+
+.whitespace
+
+Paragraph two.

--- a/quarkdown-html/src/test/e2e/whitespace/inline/inline.spec.ts
+++ b/quarkdown-html/src/test/e2e/whitespace/inline/inline.spec.ts
@@ -1,0 +1,13 @@
+import {suite} from "../../quarkdown";
+
+const {test, expect} = suite(__dirname);
+
+test("renders inline whitespace as an inline element inside the paragraph", async (page) => {
+    await expect(page.locator("p")).toHaveCount(1);
+
+    const whitespace = page.locator("p > span.whitespace");
+    await expect(whitespace).toHaveCount(1);
+    await expect(whitespace).toHaveCSS("display", "inline-block");
+    await expect(whitespace).toHaveText("\u00a0");
+    await expect(whitespace).toHaveCSS("margin-top", "0px");
+});

--- a/quarkdown-html/src/test/e2e/whitespace/inline/main.qd
+++ b/quarkdown-html/src/test/e2e/whitespace/inline/main.qd
@@ -1,0 +1,1 @@
+A .whitespace B

--- a/quarkdown-html/src/test/e2e/whitespace/sized/main.qd
+++ b/quarkdown-html/src/test/e2e/whitespace/sized/main.qd
@@ -1,0 +1,5 @@
+Before A .whitespace width:{2cm} B
+
+.whitespace width:{3cm} height:{2cm}
+
+After.

--- a/quarkdown-html/src/test/e2e/whitespace/sized/sized.spec.ts
+++ b/quarkdown-html/src/test/e2e/whitespace/sized/sized.spec.ts
@@ -1,0 +1,22 @@
+import {evaluateComputedStyle, getComputedSizeProperty} from "../../__util/css";
+import {suite} from "../../quarkdown";
+
+const {test, expect} = suite(__dirname);
+
+test("sized block whitespace occupies the given size", async (page) => {
+    const whitespace = page.locator("div.whitespace");
+    await expect(whitespace).toHaveCount(1);
+
+    const style = await evaluateComputedStyle(whitespace);
+    expect(parseFloat(style.width)).toBeCloseTo(await getComputedSizeProperty(page, "3cm"), 1);
+    expect(parseFloat(style.height)).toBeCloseTo(await getComputedSizeProperty(page, "2cm"), 1);
+});
+
+test("sized inline whitespace reserves horizontal space", async (page) => {
+    const whitespace = page.locator("span.whitespace");
+    await expect(whitespace).toHaveCount(1);
+
+    const box = await whitespace.boundingBox();
+    expect(box).not.toBeNull();
+    expect(box!.width).toBeCloseTo(await getComputedSizeProperty(page, "2cm"), 1);
+});

--- a/quarkdown-html/src/test/kotlin/com/quarkdown/rendering/html/HtmlNodeRendererTest.kt
+++ b/quarkdown-html/src/test/kotlin/com/quarkdown/rendering/html/HtmlNodeRendererTest.kt
@@ -57,6 +57,7 @@ import com.quarkdown.core.ast.quarkdown.inline.MathSpan
 import com.quarkdown.core.ast.quarkdown.inline.TextSymbol
 import com.quarkdown.core.ast.quarkdown.inline.TextTransform
 import com.quarkdown.core.ast.quarkdown.inline.TextTransformData
+import com.quarkdown.core.ast.quarkdown.inline.Whitespace
 import com.quarkdown.core.attachMockPipeline
 import com.quarkdown.core.bibliography.Bibliography
 import com.quarkdown.core.bibliography.BibliographyEntry
@@ -68,6 +69,7 @@ import com.quarkdown.core.context.options.MutableContextOptions
 import com.quarkdown.core.document.size.Sizes
 import com.quarkdown.core.document.size.cm
 import com.quarkdown.core.document.size.inch
+import com.quarkdown.core.document.size.mm
 import com.quarkdown.core.document.size.percent
 import com.quarkdown.core.document.size.px
 import com.quarkdown.core.flavor.base.BaseMarkdownFlavor
@@ -1089,6 +1091,19 @@ class HtmlNodeRendererTest {
                 listOf(Keybinding.CtrlModifier, Keybinding.Key("C")),
             ).render(),
         )
+    }
+
+    @Test
+    fun whitespace() {
+        val out = readParts("quarkdown/whitespace.html")
+
+        assertEquals(out.next(), Whitespace(width = null, height = null, isBlock = false).render())
+
+        assertEquals(out.next(), Whitespace(width = null, height = null, isBlock = true).render())
+
+        assertEquals(out.next(), Whitespace(width = 1.0.cm, height = null, isBlock = false).render())
+
+        assertEquals(out.next(), Whitespace(width = 1.0.cm, height = 3.0.mm, isBlock = true).render())
     }
 
     @Test

--- a/quarkdown-html/src/test/resources/rendering/quarkdown/whitespace.html
+++ b/quarkdown-html/src/test/resources/rendering/quarkdown/whitespace.html
@@ -1,0 +1,19 @@
+<span class="whitespace">
+    &nbsp;
+</span>
+
+---
+
+<div class="whitespace">
+    &nbsp;
+</div>
+
+---
+
+<span class="whitespace" style="width: 1.0cm;">
+</span>
+
+---
+
+<div class="whitespace" style="width: 1.0cm; height: 3.0mm;">
+</div>

--- a/quarkdown-test/src/test/kotlin/com/quarkdown/test/DestructuringTest.kt
+++ b/quarkdown-test/src/test/kotlin/com/quarkdown/test/DestructuringTest.kt
@@ -120,22 +120,22 @@ class DestructuringTest {
                     "<p><strong>Llion Jones</strong><br />Google Research<br />" +
                     "<span style=\"font-size: var(--qd-size-small, 1em);\">" +
                     "<a href=\"llion@google.com\">llion@google.com</a></span>" +
-                    "<br /><span>&nbsp;</span></p>" +
+                    "<br /><span class=\"whitespace\">&nbsp;</span></p>" +
                     "</div><div class=\"container\">" +
                     "<p><strong>Aidan N. Gomez</strong><br />University of Toronto<br />" +
                     "<span style=\"font-size: var(--qd-size-small, 1em);\">" +
                     "<a href=\"aidan@cs.toronto.edu\">aidan@cs.toronto.edu</a></span>" +
-                    "<br /><span>&nbsp;</span></p>" +
+                    "<br /><span class=\"whitespace\">&nbsp;</span></p>" +
                     "</div><div class=\"container\">" +
                     "<p><strong>Łukasz Kaiser</strong><br />Google Brain<br />" +
                     "<span style=\"font-size: var(--qd-size-small, 1em);\">" +
                     "<a href=\"lukaszkaiser@google.com\">lukaszkaiser@google.com</a></span>" +
-                    "<br /><span>&nbsp;</span></p>" +
+                    "<br /><span class=\"whitespace\">&nbsp;</span></p>" +
                     "</div><div class=\"container\">" +
                     "<p><strong>Illia Polosukhin</strong><br />-<br />" +
                     "<span style=\"font-size: var(--qd-size-small, 1em);\">" +
                     "<a href=\"illia.polosukhin@gmail.com\">illia.polosukhin@gmail.com</a></span>" +
-                    "<br /><span>&nbsp;</span></p>" +
+                    "<br /><span class=\"whitespace\">&nbsp;</span></p>" +
                     "</div></div>",
                 it,
             )

--- a/quarkdown-test/src/test/kotlin/com/quarkdown/test/LinkTest.kt
+++ b/quarkdown-test/src/test/kotlin/com/quarkdown/test/LinkTest.kt
@@ -20,11 +20,18 @@ class LinkTest {
     @Test
     fun `text link`() {
         execute(".text {Hello} size:{tiny} url:{https://example.com}") {
-            assertEquals("<a href=\"https://example.com\"><span style=\"font-size: var(--qd-size-tiny, 1em);\">Hello</span></a>", it)
+            assertEquals("<p><a href=\"https://example.com\"><span style=\"font-size: var(--qd-size-tiny, 1em);\">Hello</span></a></p>", it)
         }
 
         execute(".text {Hello} size:{tiny} url:{.concatenate {https://example} {\\.com}}") {
-            assertEquals("<a href=\"https://example.com\"><span style=\"font-size: var(--qd-size-tiny, 1em);\">Hello</span></a>", it)
+            assertEquals("<p><a href=\"https://example.com\"><span style=\"font-size: var(--qd-size-tiny, 1em);\">Hello</span></a></p>", it)
+        }
+
+        execute("Inline .text {Hello} size:{tiny} url:{https://example.com} link") {
+            assertEquals(
+                "<p>Inline <a href=\"https://example.com\"><span style=\"font-size: var(--qd-size-tiny, 1em);\">Hello</span></a> link</p>",
+                it,
+            )
         }
     }
 

--- a/quarkdown-test/src/test/kotlin/com/quarkdown/test/OptionalityTest.kt
+++ b/quarkdown-test/src/test/kotlin/com/quarkdown/test/OptionalityTest.kt
@@ -253,7 +253,7 @@ class OptionalityTest {
     @Test
     fun `node as fallback`() {
         execute(".none::otherwise {.text {hi}}") {
-            assertEquals("<span>hi</span>", it)
+            assertEquals("<p><span>hi</span></p>", it)
         }
 
         execute(".none::otherwise {a .text {hi}}") {

--- a/quarkdown-test/src/test/kotlin/com/quarkdown/test/PaperLibTest.kt
+++ b/quarkdown-test/src/test/kotlin/com/quarkdown/test/PaperLibTest.kt
@@ -68,7 +68,7 @@ class PaperLibTest {
                 "<p><strong>Theorem 0.1.</strong> This is my theorem.</p>" +
                     "<p><strong>Proof 0.i.</strong> And this is my proof.</p>" +
                     "<div class=\"container fullwidth\" style=\"justify-items: end; text-align: end;\">" +
-                    "<span style=\"font-size: var(--qd-size-huge, 1em);\">∎</span>" +
+                    "<p><span style=\"font-size: var(--qd-size-huge, 1em);\">∎</span></p>" +
                     "</div>",
                 it,
             )
@@ -96,7 +96,7 @@ class PaperLibTest {
             assertEquals(
                 "<p><strong>Proof a:</strong> This is my proof.</p>" +
                     "<div class=\"container fullwidth\" style=\"justify-items: end; text-align: end;\">" +
-                    "<span style=\"font-size: var(--qd-size-huge, 1em);\">#</span>" +
+                    "<p><span style=\"font-size: var(--qd-size-huge, 1em);\">#</span></p>" +
                     "</div>",
                 it,
             )

--- a/quarkdown-test/src/test/kotlin/com/quarkdown/test/TextTest.kt
+++ b/quarkdown-test/src/test/kotlin/com/quarkdown/test/TextTest.kt
@@ -113,6 +113,16 @@ class TextTest {
     }
 
     @Test
+    fun `block text is wrapped in a paragraph`() {
+        execute(".text {some text} size:{tiny}") {
+            assertEquals(
+                "<p><span style=\"font-size: var(--qd-size-tiny, 1em);\">some text</span></p>",
+                it,
+            )
+        }
+    }
+
+    @Test
     fun `text with body argument`() {
         execute(
             """
@@ -121,7 +131,7 @@ class TextTest {
             """.trimIndent(),
         ) {
             assertEquals(
-                "<span style=\"font-size: var(--qd-size-tiny, 1em); font-variant: small-caps;\">small text</span>",
+                "<p><span style=\"font-size: var(--qd-size-tiny, 1em); font-variant: small-caps;\">small text</span></p>",
                 it,
             )
         }
@@ -148,18 +158,43 @@ class TextTest {
             Line 2 after a long break
             """.trimIndent(),
         ) {
-            assertEquals("<p>Line 1</p><span>&nbsp;</span><p>Line 2 after a long break</p>", it)
+            assertEquals("<p>Line 1</p><div class=\"whitespace\">&nbsp;</div><p>Line 2 after a long break</p>", it)
         }
     }
 
     @Test
-    fun `sized whitespace`() {
+    fun `inline whitespace`() {
+        execute("A .whitespace B") {
+            assertEquals("<p>A <span class=\"whitespace\">&nbsp;</span> B</p>", it)
+        }
+    }
+
+    @Test
+    fun `sized inline whitespace`() {
         execute("A .whitespace width:{1cm} B") {
-            assertEquals("<p>A <div style=\"width: 1.0cm;\"></div> B</p>", it)
+            assertEquals("<p>A <span class=\"whitespace\" style=\"width: 1.0cm;\"></span> B</p>", it)
         }
 
         execute("A .whitespace width:{1cm} height:{3mm} B") {
-            assertEquals("<p>A <div style=\"width: 1.0cm; height: 3.0mm;\"></div> B</p>", it)
+            assertEquals("<p>A <span class=\"whitespace\" style=\"width: 1.0cm; height: 3.0mm;\"></span> B</p>", it)
+        }
+    }
+
+    @Test
+    fun `sized block whitespace`() {
+        execute(
+            """
+            Line 1
+            
+            .whitespace width:{1cm} height:{3mm}
+            
+            Line 2
+            """.trimIndent(),
+        ) {
+            assertEquals(
+                "<p>Line 1</p><div class=\"whitespace\" style=\"width: 1.0cm; height: 3.0mm;\"></div><p>Line 2</p>",
+                it,
+            )
         }
     }
 


### PR DESCRIPTION
- [X] I have read the [contributing guidelines](https://github.com/iamgio/quarkdown/blob/main/CONTRIBUTING.md).
- [X] I have tested the changes locally.
- [ ] An issue for this change exists, and it was discussed with maintainers. This is required for new features and non-trivial changes. If present, append `Closes #ISSUE_NUMBER` at the end of this PR description.
- [ ] (Optional) I have added necessary documentation to [`docs`](https://github.com/iamgio/quarkdown/tree/main/docs) and [`CHANGELOG.md`](https://github.com/iamgio/quarkdown/blob/main/CHANGELOG.md)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed `.text` and `.whitespace` behavior so output adapts correctly to its location.
  - Improved paragraph wrapping and spacing for block-level text and links.
  - Corrected whitespace rendering for inline and block contexts, including sized whitespace.

- **Tests**
  - Added coverage for paragraph wrapping, whitespace layout, sizing, and HTML output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->