### PR TITLE
fix(pdf): fail pipeline on missing chrome

### DIFF
--- a/quarkdown-cli/src/test/kotlin/com/quarkdown/cli/CompileCommandTest.kt
+++ b/quarkdown-cli/src/test/kotlin/com/quarkdown/cli/CompileCommandTest.kt
@@ -4,6 +4,7 @@ import com.github.ajalt.clikt.core.parse
 import com.github.ajalt.clikt.testing.CliktCommandTestResult
 import com.github.ajalt.clikt.testing.test
 import com.quarkdown.cli.exec.CompileCommand
+import com.quarkdown.core.IO_ERROR_EXIT_CODE
 import com.quarkdown.core.TIMEOUT_EXIT_CODE
 import com.quarkdown.core.UNRESOLVED_REFERENCE_EXIT_CODE
 import com.quarkdown.core.permissions.Permission
@@ -435,6 +436,21 @@ class CompileCommandTest : TempDirectory() {
         assumePdfEnvironmentInstalled()
         val (_, _) = test("--render", "html-pdf", "--pdf-no-sandbox")
         checkPdf()
+    }
+
+    @Test
+    fun `pdf with missing chrome fails the pipeline`() {
+        val result =
+            CompileCommand().test(
+                main.absolutePath,
+                "-o",
+                outputDirectory.absolutePath,
+                "--pdf",
+                "--chrome-path",
+                "not-a-chrome-executable",
+            )
+        assertEquals(IO_ERROR_EXIT_CODE, result.statusCode)
+        assertFalse(File(outputDirectory, "$DEFAULT_OUTPUT_DIRECTORY_NAME.pdf").exists())
     }
 
     @Test

--- a/quarkdown-html-pdf/src/main/kotlin/com/quarkdown/rendering/html/pdf/ChromiumPdfGeneratorScript.kt
+++ b/quarkdown-html-pdf/src/main/kotlin/com/quarkdown/rendering/html/pdf/ChromiumPdfGeneratorScript.kt
@@ -1,6 +1,7 @@
 package com.quarkdown.rendering.html.pdf
 
 import com.quarkdown.core.log.Log
+import com.quarkdown.core.pipeline.error.IOPipelineException
 import com.quarkdown.interaction.cdp.ChromiumInteraction
 import com.quarkdown.interaction.executable.ChromiumWrapper
 import com.quarkdown.server.LocalFileWebServer
@@ -59,8 +60,8 @@ class ChromiumPdfGeneratorScript(
                 } catch (e: InterruptedException) {
                     throw e
                 } catch (e: Exception) {
-                    Log.error("Failed to export PDF: ${e.message}")
                     Log.debug(e)
+                    throw IOPipelineException("Failed to export PDF: ${e.message}")
                 } finally {
                     server.stop()
                 }

--- a/quarkdown-html-pdf/src/main/kotlin/com/quarkdown/rendering/html/pdf/HtmlPdfExporter.kt
+++ b/quarkdown-html-pdf/src/main/kotlin/com/quarkdown/rendering/html/pdf/HtmlPdfExporter.kt
@@ -1,6 +1,6 @@
 package com.quarkdown.rendering.html.pdf
 
-import com.quarkdown.core.log.Log
+import com.quarkdown.core.pipeline.error.IOPipelineException
 import com.quarkdown.interaction.executable.ChromiumWrapper
 import java.io.File
 
@@ -17,6 +17,7 @@ class HtmlPdfExporter(
      * Exports a PDF from the given source directory.
      * @param sourcesDirectory the directory containing the HTML source files
      * @param out the output file for the generated PDF
+     * @throws IOPipelineException if the browser is not available or the export fails
      */
     fun export(
         sourcesDirectory: File,
@@ -31,10 +32,9 @@ class HtmlPdfExporter(
                 options.noSandbox,
             ).launch()
         } catch (e: IllegalArgumentException) {
-            // Rejected by ChromiumWrapper's validation, e.g. a blank path.
-            Log.error("Invalid Chrome path: ${e.message}")
+            throw IOPipelineException("Invalid Chrome path: ${e.message}")
         } catch (e: IllegalStateException) {
-            Log.error(e.message!!)
+            throw IOPipelineException(e.message ?: "Chrome executable is not available")
         }
     }
 }

--- a/quarkdown-html-pdf/src/main/kotlin/com/quarkdown/rendering/html/pdf/PdfHtmlPostRendererDecorator.kt
+++ b/quarkdown-html-pdf/src/main/kotlin/com/quarkdown/rendering/html/pdf/PdfHtmlPostRendererDecorator.kt
@@ -1,6 +1,7 @@
 package com.quarkdown.rendering.html.pdf
 
 import com.quarkdown.core.document.sub.getOutputFileName
+import com.quarkdown.core.pipeline.error.IOPipelineException
 import com.quarkdown.core.pipeline.output.BinaryOutputArtifact
 import com.quarkdown.core.pipeline.output.OutputResource
 import com.quarkdown.core.pipeline.output.OutputResourceGroup
@@ -27,21 +28,24 @@ class PdfHtmlPostRendererDecorator(
                 .createTempDirectory(prefix = "quarkdown-pdf")
                 .toFile()
 
-        val sourcesDirectory: File = OutputResourceGroup("sources", resources).saveTo(tempDirectory)
-        val outName = postRenderer.context.subdocument.getOutputFileName(postRenderer.context)
-        val out: File = tempDirectory.resolve("$outName.pdf")
+        try {
+            val sourcesDirectory: File = OutputResourceGroup("sources", resources).saveTo(tempDirectory)
+            val outName = postRenderer.context.subdocument.getOutputFileName(postRenderer.context)
+            val out: File = tempDirectory.resolve("$outName.pdf")
 
-        HtmlPdfExporter(options).export(sourcesDirectory, out)
+            HtmlPdfExporter(options).export(sourcesDirectory, out)
 
-        // In order to comply with the pipeline's contract, the output PDF is wrapped in an OutputResource.
-        // It is deleted along with its temporary directory, and will be recreated in the output directory
-        // by the pipeline's final process.
-        return out
-            .takeIf { it.exists() }
-            ?.let(BinaryOutputArtifact::fromFile)
-            .also { tempDirectory.deleteRecursively() }
-            ?.let(::setOf)
-            ?: emptySet()
+            if (!out.exists()) {
+                throw IOPipelineException("PDF export did not produce an output file")
+            }
+
+            // In order to comply with the pipeline's contract, the output PDF is wrapped in an OutputResource.
+            // It is deleted along with its temporary directory, and will be recreated in the output directory
+            // by the pipeline's final process.
+            return setOf(BinaryOutputArtifact.fromFile(out))
+        } finally {
+            tempDirectory.deleteRecursively()
+        }
     }
 
     override fun wrapResources(

--- a/quarkdown-html-pdf/src/test/kotlin/com/quarkdown/rendering/html/pdf/HtmlToPdfTest.kt
+++ b/quarkdown-html-pdf/src/test/kotlin/com/quarkdown/rendering/html/pdf/HtmlToPdfTest.kt
@@ -1,5 +1,6 @@
 package com.quarkdown.rendering.html.pdf
 
+import com.quarkdown.core.pipeline.error.IOPipelineException
 import com.quarkdown.interaction.executable.ChromiumWrapper
 import org.apache.pdfbox.Loader
 import org.apache.pdfbox.text.PDFTextStripper
@@ -9,6 +10,7 @@ import kotlin.io.path.createTempDirectory
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -33,9 +35,20 @@ class HtmlToPdfTest {
     }
 
     @Test
-    fun `export with blank browser path fails gracefully`() {
+    fun `export with blank chrome path fails the pipeline`() {
         val out = File(directory, "out.pdf")
-        HtmlPdfExporter(options.copy(chromePath = " ")).export(directory, out)
+        assertFailsWith<IOPipelineException> {
+            HtmlPdfExporter(options.copy(chromePath = " ")).export(directory, out)
+        }
+        assertFalse(out.exists())
+    }
+
+    @Test
+    fun `export with missing chrome fails the pipeline`() {
+        val out = File(directory, "out.pdf")
+        assertFailsWith<IOPipelineException> {
+            HtmlPdfExporter(options.copy(chromePath = "not-a-chrome-executable")).export(directory, out)
+        }
         assertFalse(out.exists())
     }
 


### PR DESCRIPTION
- [X] I have read the [contributing guidelines](https://github.com/iamgio/quarkdown/blob/main/CONTRIBUTING.md).
- [X] I have tested the changes locally.
- [ ] An issue for this change exists, and it was discussed with maintainers. This is required for new features and non-trivial changes. If present, append `Closes #ISSUE_NUMBER` at the end of this PR description.
- [ ] (Optional) I have added necessary documentation to [`docs`](https://github.com/iamgio/quarkdown/tree/main/docs) and [`CHANGELOG.md`](https://github.com/iamgio/quarkdown/blob/main/CHANGELOG.md)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * PDF export failures now report a clear I/O error instead of only logging the problem.
  * Invalid, missing, or unavailable Chrome executables no longer produce incomplete PDF output.
  * Failed PDF generation no longer leaves temporary files behind.
  * Successful PDF exports continue to produce the expected output file.
  * PDF export now consistently reports failures when the expected output file is not created.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->