### PR TITLE
feat: let .row and .column inherit page alignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,11 +23,15 @@ The new `callouts` argument of the `.code` function attaches numbered markers to
 
 #### PDF export without Node.js [ecosystem breaking change]
 
-Exporting to PDF no longer requires Node.js, npm, and Puppeteer. Quarkdown now communicates directly with a Chromium-family browser, which makes PDF generation faster to start and much simpler to set up.
+Exporting to PDF no longer requires Node.js, npm, and Puppeteer. Quarkdown now communicates directly with a Chromium-family browser, which makes PDF generation much faster and simpler to set up.
 
 Package manager installations download a headless Chrome shell automatically. If you installed Quarkdown manually, download it from the [Chrome for Testing](https://googlechromelabs.github.io/chrome-for-testing/) page, or point Quarkdown to an existing Chromium-family installation with the new `--chrome-path` option or the `QD_CHROME_PATH` environment variable.
 
 > Migration note: the `--node-path` and `--npm-path` options, along with the `QD_NPM_PREFIX` and `NODE_PATH` environment variables, are no longer used. `quarkdown doctor env` now reports the browser's status.
+
+#### [`.row` and `.column`](https://quarkdown.com/wiki/stacks) inherit global alignment by default
+
+When `alignment` isn't explicitly set, `.row` and `.column` now inherit the parent's alignment (e.g. `center` in centered slides) instead of defaulting to `start`.
 
 #### Reflectionless function calls
 

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/quarkdown/block/Stacked.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/ast/quarkdown/block/Stacked.kt
@@ -18,8 +18,8 @@ import com.quarkdown.core.visitor.node.NodeVisitor
  */
 class Stacked(
     val layout: Layout,
-    val mainAxisAlignment: MainAxisAlignment,
-    val crossAxisAlignment: CrossAxisAlignment,
+    val mainAxisAlignment: MainAxisAlignment?,
+    val crossAxisAlignment: CrossAxisAlignment?,
     val rowGap: Size?,
     val columnGap: Size?,
     @Diverge override val children: List<Node>,

--- a/quarkdown-html/src/main/scss/components/_alignment.scss
+++ b/quarkdown-html/src/main/scss/components/_alignment.scss
@@ -1,4 +1,5 @@
 @use "util/media-queries";
+@use "util/heading-selectors" as *;
 
 .quarkdown {
   text-align: var(--qd-horizontal-alignment-global);
@@ -6,6 +7,7 @@
   // Local alignment (e.g. justification) is applied to specific elements instead of the whole document (#123).
   p:not(.page-margin-content p, .mermaid p) {
     text-align: var(--qd-horizontal-alignment-local);
+
     &:not([data-split-to]) {
       text-align-last: var(--qd-horizontal-alignment-global);
     }
@@ -19,6 +21,10 @@
   caption, figcaption {
     text-align: var(--qd-horizontal-alignment-local);
     text-align-last: center;
+  }
+
+  .stack {
+    justify-content: var(--qd-horizontal-alignment-global);
   }
 
   [style*="text-align"] > :is(p, li, span) {

--- a/quarkdown-html/src/main/scss/components/_stack.scss
+++ b/quarkdown-html/src/main/scss/components/_stack.scss
@@ -1,6 +1,10 @@
 @use "util/misc-selectors" as *;
 
 .quarkdown {
+  .stack {
+    align-items: center;
+  }
+
   .stack > #{$margin-reset} {
     margin: 0 !important;
   }

--- a/quarkdown-html/src/test/e2e/stack/alignment-inheritance-centered/alignment-inheritance-centered.spec.ts
+++ b/quarkdown-html/src/test/e2e/stack/alignment-inheritance-centered/alignment-inheritance-centered.spec.ts
@@ -1,0 +1,14 @@
+import {suite} from "../../quarkdown";
+
+const {test, expect} = suite(__dirname);
+
+test("row inherits a centered global alignment", async (page) => {
+    const row = page.locator(".stack.stack-row");
+    await expect(row).toHaveCSS("justify-content", "center");
+
+    const stackBox = (await row.boundingBox())!;
+    const childBox = (await row.locator("p").boundingBox())!;
+    const stackCenter = stackBox.x + stackBox.width / 2;
+    const childCenter = childBox.x + childBox.width / 2;
+    expect(childCenter).toBeCloseTo(stackCenter, 0);
+});

--- a/quarkdown-html/src/test/e2e/stack/alignment-inheritance-centered/main.qd
+++ b/quarkdown-html/src/test/e2e/stack/alignment-inheritance-centered/main.qd
@@ -1,0 +1,4 @@
+.pageformat alignment:{center}
+
+.row
+    First

--- a/quarkdown-html/src/test/e2e/stack/alignment-inheritance/alignment-inheritance.spec.ts
+++ b/quarkdown-html/src/test/e2e/stack/alignment-inheritance/alignment-inheritance.spec.ts
@@ -1,0 +1,32 @@
+import {evaluateComputedStyle} from "../../__util/css";
+import {suite} from "../../quarkdown";
+
+const {testMatrix, expect} = suite(__dirname);
+
+testMatrix("row without explicit alignment inherits the global alignment", ["plain", "slides"], async (page, docType) => {
+    const row = page.locator(".stack.stack-row").first();
+    const globalAlignment = (await evaluateComputedStyle(page.locator("body.quarkdown"))).textAlign;
+    await expect(row).toHaveCSS("justify-content", globalAlignment);
+
+    if (docType === "plain") {
+        // Start-aligned document: the row's content starts at the leading edge.
+        const stackBox = (await row.boundingBox())!;
+        const childBox = (await row.locator("p").boundingBox())!;
+        expect(childBox.x).toBeCloseTo(stackBox.x, 0);
+    }
+});
+
+testMatrix("explicit alignment overrides the inherited one", ["plain", "slides"], async (page) => {
+    const row = page.locator(".stack.stack-row").nth(1);
+    await expect(row).toHaveCSS("justify-content", "flex-end");
+
+    const stackBox = (await row.boundingBox())!;
+    const childBox = (await row.locator("p").boundingBox())!;
+    expect(childBox.x + childBox.width).toBeCloseTo(stackBox.x + stackBox.width, 0);
+});
+
+testMatrix("cross axis defaults to center", ["plain", "slides"], async (page) => {
+    for (const stack of await page.locator(".stack").all()) {
+        await expect(stack).toHaveCSS("align-items", "center");
+    }
+});

--- a/quarkdown-html/src/test/e2e/stack/alignment-inheritance/main.qd
+++ b/quarkdown-html/src/test/e2e/stack/alignment-inheritance/main.qd
@@ -1,0 +1,8 @@
+.row
+    First
+
+.row alignment:{end}
+    Second
+
+.column
+    Third

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Layout.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Layout.kt
@@ -208,8 +208,8 @@ fun float(
  */
 private fun stack(
     layout: Stacked.Layout,
-    mainAxisAlignment: Stacked.MainAxisAlignment = Stacked.MainAxisAlignment.START,
-    crossAxisAlignment: Stacked.CrossAxisAlignment = Stacked.CrossAxisAlignment.CENTER,
+    mainAxisAlignment: Stacked.MainAxisAlignment? = null,
+    crossAxisAlignment: Stacked.CrossAxisAlignment? = null,
     rowGap: Size? = null,
     columnGap: Size? = null,
     body: MarkdownContent,
@@ -218,7 +218,7 @@ private fun stack(
 /**
  * Stacks content horizontally.
  *
- * @param mainAxisAlignment content alignment along the main axis
+ * @param mainAxisAlignment content alignment along the main axis. If unset, it inherits the parent's alignment
  * @param crossAxisAlignment content alignment along the cross axis
  * @param gap blank space between children. If omitted, the default value is used
  * @param body content to stack
@@ -227,8 +227,8 @@ private fun stack(
  */
 @QFunction
 fun row(
-    @Name("alignment") mainAxisAlignment: Stacked.MainAxisAlignment = Stacked.MainAxisAlignment.START,
-    @Name("cross") crossAxisAlignment: Stacked.CrossAxisAlignment = Stacked.CrossAxisAlignment.CENTER,
+    @Name("alignment") mainAxisAlignment: Stacked.MainAxisAlignment? = null,
+    @Name("cross") crossAxisAlignment: Stacked.CrossAxisAlignment? = null,
     @LikelyNamed gap: Size? = null,
     @Body body: MarkdownContent,
 ) = stack(Stacked.Row, mainAxisAlignment, crossAxisAlignment, null, gap, body)
@@ -236,7 +236,7 @@ fun row(
 /**
  * Stacks content vertically.
  *
- * @param mainAxisAlignment content alignment along the main axis
+ * @param mainAxisAlignment content alignment along the main axis. If unset, it inherits the parent's alignment
  * @param crossAxisAlignment content alignment along the cross axis
  * @param gap blank space between children. If omitted, the default value is used
  * @param body content to stack
@@ -245,8 +245,8 @@ fun row(
  */
 @QFunction
 fun column(
-    @Name("alignment") mainAxisAlignment: Stacked.MainAxisAlignment = Stacked.MainAxisAlignment.START,
-    @Name("cross") crossAxisAlignment: Stacked.CrossAxisAlignment = Stacked.CrossAxisAlignment.CENTER,
+    @Name("alignment") mainAxisAlignment: Stacked.MainAxisAlignment? = null,
+    @Name("cross") crossAxisAlignment: Stacked.CrossAxisAlignment? = null,
     @LikelyNamed gap: Size? = null,
     @Body body: MarkdownContent,
 ) = stack(Stacked.Column, mainAxisAlignment, crossAxisAlignment, gap, null, body)

--- a/quarkdown-test/src/test/kotlin/com/quarkdown/test/IterableTest.kt
+++ b/quarkdown-test/src/test/kotlin/com/quarkdown/test/IterableTest.kt
@@ -267,7 +267,7 @@ class IterableTest {
             """.trimIndent(),
         ) {
             assertEquals(
-                "<div style=\"justify-content: flex-start; align-items: center;\" class=\"stack stack-row\">" +
+                "<div class=\"stack stack-row\">" +
                     "<p>text</p>" +
                     "<p><em>italic</em></p>" +
                     "<p><strong>bold</strong></p>" +

--- a/quarkdown-test/src/test/kotlin/com/quarkdown/test/LayoutTest.kt
+++ b/quarkdown-test/src/test/kotlin/com/quarkdown/test/LayoutTest.kt
@@ -45,7 +45,7 @@ class LayoutTest {
             """.trimIndent(),
         ) {
             assertEquals(
-                "<div style=\"justify-content: flex-start; align-items: center;\" class=\"stack stack-row\">" +
+                "<div class=\"stack stack-row\">" +
                     "<p>Hello 1 Hello 2</p><p>Hello 3</p>" +
                     "</div>",
                 it,
@@ -98,10 +98,10 @@ class LayoutTest {
         ) {
             assertEquals(
                 "<div style=\"justify-content: center; align-items: center; column-gap: 200.0px;\" class=\"stack stack-row\">" +
-                    "<div style=\"justify-content: flex-start; align-items: flex-end;\" class=\"stack stack-column\">" +
+                    "<div style=\"align-items: flex-end;\" class=\"stack stack-column\">" +
                     "<h2>Quarkdown</h2><p>A cool language</p>" +
                     "</div>" +
-                    "<div style=\"justify-content: flex-start; align-items: center; row-gap: 1.0cm;\" class=\"stack stack-column\">" +
+                    "<div style=\"row-gap: 1.0cm;\" class=\"stack stack-column\">" +
                     "<div class=\"clip clip-circle\"><div class=\"container\">" +
                     "<figure><img src=\"img1.png\" alt=\"\" /></figure>" +
                     "</div></div>" +


### PR DESCRIPTION
- [X] I have read the [contributing guidelines](https://github.com/iamgio/quarkdown/blob/main/CONTRIBUTING.md).
- [X] I have tested the changes locally.
- [ ] An issue for this change exists, and it was discussed with maintainers. This is required for new features and non-trivial changes. If present, append `Closes #ISSUE_NUMBER` at the end of this PR description.
- [ ] (Optional) I have added necessary documentation to [`docs`](https://github.com/iamgio/quarkdown/tree/main/docs) and [`CHANGELOG.md`](https://github.com/iamgio/quarkdown/blob/main/CHANGELOG.md)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Rows and columns now inherit alignment from their parent when no explicit alignment is set.
  - Stack content is centered across the cross axis by default.
  - Explicit alignment settings continue to override inherited values.
  - PDF generation now starts much faster.

- **Documentation**
  - Updated layout documentation to describe alignment inheritance behavior.

- **Tests**
  - Added coverage for inherited, centered, and explicitly overridden alignment in plain documents and slides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->