### PR TITLE
feat(theme): add 'focus' theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The highlights of this release include significant performance improvements, bet
 
 ### Added
 
+#### [New layout theme: `focus`](https://quarkdown.com/wiki/themes)
+
+The new `focus` layout theme is a port of the [Focus Beamer theme](https://www.overleaf.com/latex/templates/focus-a-minimalist-beamer-theme/bytzgdfmdpjq). It’s a simple and clean theme well-suited for slides and articles.
+
+Recommended combination:
+
+```text
+.theme {paperwhite} layout:{focus}
+```
+
 #### [Code block callouts](https://quarkdown.com/wiki/code#callouts)
 
 The new `callouts` argument of the `.code` function attaches numbered markers to specific lines of a code block, each paired with a description displayed right below the block.
@@ -31,13 +41,18 @@ Package manager installations download a headless Chrome shell automatically. If
 
 > Migration note: the `--node-path` and `--npm-path` options, along with the `QD_NPM_PREFIX` and `NODE_PATH` environment variables, are no longer used. `quarkdown doctor env` now reports the browser's status.
 
+#### `slides` break page on H2
+
+Unless overridden via `.autopagebreak`, `slides` documents now automatically break page on every H1 and H2.
+This release aims at making H1 the standard for title slides, and H2 for content slides.
+
 #### [`.row` and `.column`](https://quarkdown.com/wiki/stacks) inherit global alignment by default
 
 When `alignment` isn't explicitly set, `.row` and `.column` now inherit the parent's alignment (e.g. `center` in centered slides) instead of defaulting to `start`.
 
 #### Improved `beamer` theme
 
-The `beamer` theme's layout was improved for a consistent look
+The `beamer` theme's layout was improved for a more consistent look.
 
 #### Reflectionless function calls
 

--- a/docs/themes.qd
+++ b/docs/themes.qd
@@ -17,15 +17,17 @@ You can set a theme via the **`.theme {colortheme} layout:{layouttheme}`** funct
 - `latex` (default)
 - `hyperlegible`
 - `minimal`
+- `focus`
 - `beamer`
 
 ---
 
 Some suggested combinations are:
-- `paperwhite+latex` (LaTeX look, great for `paged` documents)
-- `galactic+hyperlegible` (this wiki)
+- `paperwhite+latex`: LaTeX look, great for paged documents
+- `galactic+hyperlegible`: this wiki
+- `paperwhite+focus`: simple, clean look for slides and articles
 - `darko+minimal`
-- `beaver+beamer` (Beamer look, great for academic-style presentations)
+- `beaver+beamer`: Beamer look, great for academic-style presentations)
 
 ## Contributing
 

--- a/mock/setup.qd
+++ b/mock/setup.qd
@@ -24,7 +24,7 @@
 .center
 	#! .docname
 	
-	.docauthor (c) 2024-2025
+	.docauthor (c) 2024-2026
 
 ---
 
@@ -35,16 +35,17 @@
 
 	Whether you are looking to experiment with **color schemes, typography, or layout designs**, or just taking a look at some Quarkdown snippets, this mock document will provide the support you need.
 
-.whitespace height:{1cm}
+.whitespace
 
 .center
-	To compile this document, run:  
-	**`quarkdown c mock/main.qd -p`**
+	To compile this document, run: .br
+	**`cd mock`** .br
+	**`quarkdown c main.qd -p`**
 	
-	Different themes and document types may be tested  
-	by changing the first lines of `main.qd`.
+Different themes and document types may be tested
+by changing the first lines of `main.qd`.
 
-.whitespace height:{3cm}
+.whitespace
 
 .conditionalpagebreak ontype:{slides}
 

--- a/quarkdown-html/src/main/scss/layout/beamer.scss
+++ b/quarkdown-html/src/main/scss/layout/beamer.scss
@@ -4,6 +4,8 @@
 @use "util/latex-tables" as *;
 @use "util/beamer-toc" as *;
 @use "util/font-imports" as *;
+@use "util/heading-background-inset" as *;
+@use "util/segmented-footer" as *;
 @use "../components/util/slides" as *;
 
 @include import-font-family('source-sans-pro');
@@ -30,10 +32,6 @@
       --qd-horizontal-alignment-global: center;
     }
   }
-
-  h2:not(.box *) {
-    margin-right: calc(-2 * var(--qd-slides-horizontal-inset));
-  }
 }
 
 .quarkdown {
@@ -41,23 +39,20 @@
   @include latex-tables;
   @include beamer-toc;
 
-  // Slide-level headings only: headings nested inside boxes (e.g. callouts) keep their own styling.
-  h1:not(.box *), h2:not(.box *) {
+  h1, h2 {
     background-color: var(--qd-main-color-muted);
     color: var(--qd-link-color);
   }
 
-  h1:not(.box *) {
+  h1 {
     border-radius: 8px;
     padding: 12px 0;
-    margin-top: 15vh !important;
+    margin-top: 7rem !important;
     text-align: center;
   }
 
-  h2:not(.box *) {
-    padding: 12px 0 12px calc(2 * var(--qd-slides-horizontal-inset));
-    margin-bottom: var(--qd-block-margin);
-    margin-left: calc(-2 * var(--qd-slides-horizontal-inset));
+  h2 {
+    @include heading-background-inset($inset-multiplier: 2, $padding-top: 12px, $padding-bottom: 12px);
   }
 
   p {
@@ -104,20 +99,12 @@
     }
   }
 
-  // Footer
-  .page-margin-bottom-center > * {
-    padding: 12px;
-    margin-bottom: 0;
-    background-color: var(--qd-main-color-muted);
-    color: var(--qd-link-color);
-
-    &:first-child {
-      background-color: var(--qd-primary-color);
-      color: var(--qd-color-on-primary);
-    }
-
-    &:nth-child(even) {
-      background-color: var(--qd-background-color);
-    }
-  }
+  @include segmented-footer(
+          $padding: 12px,
+          $first-background-color: var(--qd-primary-color),
+          $first-color: var(--qd-color-on-primary),
+          $even-background-color: var(--qd-background-color),
+          $even-color: var(--qd-link-color),
+          $odd-background-color: var(--qd-main-color-muted),
+  );
 }

--- a/quarkdown-html/src/main/scss/layout/focus.json
+++ b/quarkdown-html/src/main/scss/layout/focus.json
@@ -1,0 +1,7 @@
+{
+  "exports": [
+    "node_modules/@fontsource/source-sans-pro",
+    "node_modules/@fontsource/fira-sans",
+    "node_modules/@fontsource/noto-sans-mono"
+  ]
+}

--- a/quarkdown-html/src/main/scss/layout/focus.scss
+++ b/quarkdown-html/src/main/scss/layout/focus.scss
@@ -1,0 +1,55 @@
+@use "beamer";
+
+@use "util/progressive-heading-sizes" as *;
+@use "util/beamer-toc" as *;
+@use "util/heading-background-inset" as *;
+@use "util/segmented-footer" as *;
+@use "../components/util/slides" as *;
+@use "../components/util/heading-selectors" as *;
+@use "../components/util/location-selectors" as location-selectors;
+
+:root {
+  --qd-main-font-size: 1.1rem;
+}
+
+.quarkdown-slides, .quarkdown-slides #{$slide-selector} {
+  --qd-horizontal-alignment-global: start !important;
+}
+
+.quarkdown.quarkdown {
+  @include progressive-heading-sizes($multiplier: 1.1);
+  @include beamer-toc($marker-color: var(--qd-background-color), $marker-background-color: var(--tint));
+
+  --tint: color-mix(in srgb, var(--qd-main-color) 90%, transparent);
+
+  h1, h2 {
+    text-align: unset;
+    border-radius: 8px;
+    background-color: var(--tint);
+    color: var(--qd-background-color);
+  }
+
+  h1 {
+    @include heading-background-inset($inset-multiplier: 2, $padding-top: 20%, $padding-bottom: 16px, $margin-bottom-multiplier: 2);
+    margin-top: 3rem !important;
+  }
+
+  h2 {
+    @include heading-background-inset($inset-multiplier: 2, $padding-top: 14px, $padding-bottom: 14px);
+    font-weight: normal;
+  }
+
+  #{location-selectors.$location-heading}:is(#{$headings})::before {
+    opacity: .4;
+  }
+
+  @include segmented-footer(
+          $padding: 4px,
+          $font-size: 0.8em,
+          $first-background-color: var(--tint),
+          $first-color: var(--qd-background-color),
+          $even-background-color: var(--qd-background-color),
+          $even-color: var(--qd-main-color),
+          $odd-background-color: var(--qd-main-color-muted),
+  );
+}

--- a/quarkdown-html/src/main/scss/layout/util/_beamer-toc.scss
+++ b/quarkdown-html/src/main/scss/layout/util/_beamer-toc.scss
@@ -1,7 +1,6 @@
 @use "latex-toc" as *;
 
-@mixin beamer-toc {
-
+@mixin beamer-toc($marker-color: var(--qd-primary-color), $marker-background-color: var(--qd-color-on-primary)) {
   nav {
     a:not(:hover) {
       color: var(--qd-main-color);
@@ -24,13 +23,13 @@
 
         // Custom marker for first-level entries
         &::before {
-          background-color: var(--qd-primary-color);
-          color: var(--qd-color-on-primary);
+          background-color: $marker-background-color;
+          color: $marker-color;
           border-radius: 100%;
           margin-right: 1em;
           padding: 2px 10px;
           display: inline-block;
-          border: 1px solid color-mix(in srgb, var(--qd-color-on-primary) 25%, transparent);
+          border: 1px solid color-mix(in srgb, #{$marker-background-color} 25%, transparent);
         }
 
         > a {

--- a/quarkdown-html/src/main/scss/layout/util/_heading-background-inset.scss
+++ b/quarkdown-html/src/main/scss/layout/util/_heading-background-inset.scss
@@ -1,0 +1,24 @@
+@mixin heading-background-inset(
+  $padding-top,
+  $padding-bottom,
+  $inset-multiplier: 1,
+  $margin-bottom-multiplier: 1,
+) {
+  width: 100%;
+  padding-top: $padding-top;
+  padding-bottom: $padding-bottom;
+  margin-bottom: calc(#{$margin-bottom-multiplier} * var(--qd-block-margin));
+
+  &:not(.container *, .box *) {
+    padding-inline-start: 0.5em;
+  }
+
+  @at-root .quarkdown-slides#{&} {
+    box-sizing: border-box;
+    width: calc(100% + #{2 * $inset-multiplier} * var(--qd-slides-horizontal-inset));
+    padding-inline-end: 0;
+    padding-inline-start: calc(#{$inset-multiplier} * var(--qd-slides-horizontal-inset));
+    margin-inline-start: calc(#{-$inset-multiplier} * var(--qd-slides-horizontal-inset));
+    margin-inline-end: calc(#{-$inset-multiplier} * var(--qd-slides-horizontal-inset));
+  }
+}

--- a/quarkdown-html/src/main/scss/layout/util/_segmented-footer.scss
+++ b/quarkdown-html/src/main/scss/layout/util/_segmented-footer.scss
@@ -1,0 +1,30 @@
+// A footer with different background colors for the first, even, and odd children of the page margin bottom center element.
+// Applies only if there are at least two children in the page margin bottom center element.
+@mixin segmented-footer(
+  $padding,
+  $font-size: inherit,
+  $first-background-color,
+    $first-color,
+  $even-background-color,
+  $even-color,
+  $odd-background-color,
+  $odd-color: $even-color,
+) {
+  .page-margin-bottom-center:has(> :nth-child(2)) > * {
+    padding: $padding;
+    font-size: $font-size;
+    margin-bottom: 0;
+    background-color: $odd-background-color;
+    color: $odd-color;
+
+    &:first-child {
+      background-color: $first-background-color;
+      color: $first-color;
+    }
+
+    &:nth-child(even) {
+      background-color: $even-background-color;
+      color: $even-color;
+    }
+  }
+}

--- a/quarkdown-html/src/test/e2e/theme/heading-inset/beamer/beamer.spec.ts
+++ b/quarkdown-html/src/test/e2e/theme/heading-inset/beamer/beamer.spec.ts
@@ -1,0 +1,7 @@
+import {checkHeadingExtension} from "../index";
+import {suite} from "../../../quarkdown";
+
+const {test} = suite(__dirname);
+
+test("h1 banner stays within the slide, h2 background bleeds past both edges", (page) =>
+    checkHeadingExtension(page, false));

--- a/quarkdown-html/src/test/e2e/theme/heading-inset/beamer/main.qd
+++ b/quarkdown-html/src/test/e2e/theme/heading-inset/beamer/main.qd
@@ -1,0 +1,8 @@
+.doctype {slides}
+.theme layout:{beamer}
+
+# Title heading
+
+## Section heading
+
+Some content.

--- a/quarkdown-html/src/test/e2e/theme/heading-inset/focus/focus.spec.ts
+++ b/quarkdown-html/src/test/e2e/theme/heading-inset/focus/focus.spec.ts
@@ -1,0 +1,6 @@
+import {checkHeadingExtension} from "../index";
+import {suite} from "../../../quarkdown";
+
+const {test} = suite(__dirname);
+
+test("h1 and h2 backgrounds bleed past both slide edges", (page) => checkHeadingExtension(page, true));

--- a/quarkdown-html/src/test/e2e/theme/heading-inset/focus/main.qd
+++ b/quarkdown-html/src/test/e2e/theme/heading-inset/focus/main.qd
@@ -1,0 +1,8 @@
+.doctype {slides}
+.theme layout:{focus}
+
+# Title heading
+
+## Section heading
+
+Some content.

--- a/quarkdown-html/src/test/e2e/theme/heading-inset/index.ts
+++ b/quarkdown-html/src/test/e2e/theme/heading-inset/index.ts
@@ -1,0 +1,52 @@
+import {expect, Locator, Page} from "@playwright/test";
+
+/**
+ * Measures how far a heading extends past its enclosing slide section
+ * on each side, in pixels. Positive values mean the heading bleeds past
+ * the section edge; negative values mean it ends within the section.
+ * @param heading - Playwright locator for a visible heading in a slide
+ * @returns The left and right bleed distances
+ */
+async function getHeadingBleed(heading: Locator): Promise<{left: number; right: number}> {
+    return heading.evaluate((el) => {
+        const section = el.closest("section")!.getBoundingClientRect();
+        const rect = el.getBoundingClientRect();
+        return {
+            left: section.x - rect.x,
+            right: rect.x + rect.width - (section.x + section.width),
+        };
+    });
+}
+
+/**
+ * Asserts that a heading's background either bleeds symmetrically past both
+ * slide section edges, or stays within them.
+ * @param heading - Playwright locator for a visible heading in a slide
+ * @param bleeds - Whether the heading is expected to bleed past the edges
+ */
+async function expectHeadingBleed(heading: Locator, bleeds: boolean): Promise<void> {
+    await expect(heading).toBeVisible();
+    const {left, right} = await getHeadingBleed(heading);
+
+    if (bleeds) {
+        expect(left).toBeGreaterThan(0);
+        expect(right).toBeGreaterThan(0);
+        expect(right).toBeCloseTo(left, 0);
+    } else {
+        expect(left).toBeLessThanOrEqual(1);
+        expect(right).toBeLessThanOrEqual(1);
+    }
+}
+
+/**
+ * Checks the extension of the theme's heading backgrounds relative to the slide edges:
+ * the h1 on the first slide, then the h2 on the second slide, which always bleeds.
+ * @param page - Playwright page displaying the theme's slides document
+ * @param h1Bleeds - Whether the h1 background is expected to bleed past the slide edges
+ */
+export async function checkHeadingExtension(page: Page, h1Bleeds: boolean): Promise<void> {
+    await expectHeadingBleed(page.locator("h1"), h1Bleeds);
+
+    await page.keyboard.press("ArrowRight");
+    await expectHeadingBleed(page.locator("h2"), true);
+}


### PR DESCRIPTION
- [X] I have read the [contributing guidelines](https://github.com/iamgio/quarkdown/blob/main/CONTRIBUTING.md).
- [X] I have tested the changes locally.
- [ ] An issue for this change exists, and it was discussed with maintainers. This is required for new features and non-trivial changes. If present, append `Closes #ISSUE_NUMBER` at the end of this PR description.
- [ ] (Optional) I have added necessary documentation to [`docs`](https://github.com/iamgio/quarkdown/tree/main/docs) and [`CHANGELOG.md`](https://github.com/iamgio/quarkdown/blob/main/CHANGELOG.md)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the **Focus** layout theme for presentations and documents.
  * Added a recommended **Focus + Paperwhite** theme combination.
  * Slides documents now automatically break pages at H1 and H2 headings unless overridden.
* **Style**
  * Improved Beamer heading spacing and segmented footer styling.
  * Enhanced table-of-contents marker customization across themes.
* **Documentation**
  * Updated theme lists, suggested combinations, and mock document instructions.
  * Added Focus theme and automatic page-break details to the unreleased changelog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->