### PR TITLE
feat(creator): add slides-specific initial content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,11 +31,15 @@ The new `callouts` argument of the `.code` function attaches numbered markers to
 
 <img width="660" alt="Callout" src="https://github.com/user-attachments/assets/99521edd-4ef0-4566-b114-3027c4fb5c91" />
 
+#### Slides-tailored project creation
+
+Creating a new `slides` project via `quarkdown create` now generates starter content designed for presentations.
+
 ### Changed
 
 #### PDF export without Node.js [ecosystem breaking change]
 
-Exporting to PDF no longer requires Node.js, npm, and Puppeteer. Quarkdown now communicates directly with a Chromium-family browser, which makes PDF generation much faster and simpler to set up.
+Exporting to PDF no longer requires Node.js, npm, and Puppeteer. Quarkdown now communicates directly with a Chromium-family browser, which makes PDF generation significantly faster and simpler to set up.
 
 Package manager installations download a headless Chrome shell automatically. If you installed Quarkdown manually, download it from the [Chrome for Testing](https://googlechromelabs.github.io/chrome-for-testing/) page, or point Quarkdown to an existing Chromium-family installation with the new `--chrome-path` option or the `QD_CHROME_PATH` environment variable.
 

--- a/quarkdown-cli/src/main/kotlin/com/quarkdown/cli/creator/command/CreateProjectCommand.kt
+++ b/quarkdown-cli/src/main/kotlin/com/quarkdown/cli/creator/command/CreateProjectCommand.kt
@@ -18,6 +18,7 @@ import com.quarkdown.cli.creator.content.DefaultProjectCreatorInitialContentSupp
 import com.quarkdown.cli.creator.content.DefaultTheme
 import com.quarkdown.cli.creator.content.DocsProjectCreatorInitialContentSupplier
 import com.quarkdown.cli.creator.content.EmptyProjectCreatorInitialContentSupplier
+import com.quarkdown.cli.creator.content.SlidesProjectCreatorInitialContentSupplier
 import com.quarkdown.cli.creator.template.DefaultProjectCreatorTemplateProcessorFactory
 import com.quarkdown.cli.creator.template.DocsProjectCreatorTemplateProcessorFactory
 import com.quarkdown.core.document.DocumentAuthor
@@ -133,6 +134,7 @@ class CreateProjectCommand : CliktCommand("create") {
     private fun createProjectCreator(): ProjectCreator {
         val mainFileName = this.mainFileName ?: DEFAULT_MAIN_FILE_NAME
         val documentInfo = this.createDocumentInfo()
+        val isSlides = documentInfo.type == DocumentType.SLIDES
         val isDocs = documentInfo.type == DocumentType.DOCS
         return ProjectCreator(
             templateProcessorFactory =
@@ -143,6 +145,7 @@ class CreateProjectCommand : CliktCommand("create") {
             initialContentSupplier =
                 when {
                     noInitialContent -> EmptyProjectCreatorInitialContentSupplier()
+                    isSlides -> SlidesProjectCreatorInitialContentSupplier()
                     isDocs -> DocsProjectCreatorInitialContentSupplier()
                     else -> DefaultProjectCreatorInitialContentSupplier()
                 },

--- a/quarkdown-cli/src/main/kotlin/com/quarkdown/cli/creator/content/DefaultTheme.kt
+++ b/quarkdown-cli/src/main/kotlin/com/quarkdown/cli/creator/content/DefaultTheme.kt
@@ -9,6 +9,7 @@ import com.quarkdown.core.document.DocumentType
 object DefaultTheme {
     private const val DEFAULT_LAYOUT_THEME = "latex"
     private const val DEFAULT_DOCS_LAYOUT_THEME = "hyperlegible"
+    private const val DEFAULT_SLIDES_LAYOUT_THEME = "focus"
 
     private const val DEFAULT_COLOR_THEME = "paperwhite"
     private const val DEFAULT_DOCS_COLOR_THEME = "galactic"
@@ -20,6 +21,7 @@ object DefaultTheme {
     fun getLayoutTheme(type: DocumentType): String =
         when (type) {
             DocumentType.DOCS -> DEFAULT_DOCS_LAYOUT_THEME
+            DocumentType.SLIDES -> DEFAULT_SLIDES_LAYOUT_THEME
             else -> DEFAULT_LAYOUT_THEME
         }
 

--- a/quarkdown-cli/src/main/kotlin/com/quarkdown/cli/creator/content/SlidesProjectCreatorInitialContentSupplier.kt
+++ b/quarkdown-cli/src/main/kotlin/com/quarkdown/cli/creator/content/SlidesProjectCreatorInitialContentSupplier.kt
@@ -1,0 +1,13 @@
+package com.quarkdown.cli.creator.content
+
+private const val CODE_TEMPLATE_NAME = "creator/slides/initialcontent.qd.jte"
+
+/**
+ * A [ProjectCreatorInitialContentSupplier] that provides initial content for `slides` projects:
+ * a presentation-oriented snippet with a page footer, a title slide, and a couple of example slides,
+ * along with the same image assets supplied by [DefaultProjectCreatorInitialContentSupplier].
+ */
+class SlidesProjectCreatorInitialContentSupplier :
+    ProjectCreatorInitialContentSupplier by DefaultProjectCreatorInitialContentSupplier() {
+    override val templateName: String = CODE_TEMPLATE_NAME
+}

--- a/quarkdown-cli/src/test/kotlin/com/quarkdown/cli/DefaultThemeTest.kt
+++ b/quarkdown-cli/src/test/kotlin/com/quarkdown/cli/DefaultThemeTest.kt
@@ -1,0 +1,27 @@
+package com.quarkdown.cli
+
+import com.quarkdown.cli.creator.content.DefaultTheme
+import com.quarkdown.core.document.DocumentType
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Tests for the default theme components assigned to new projects by [DefaultTheme].
+ */
+class DefaultThemeTest {
+    @Test
+    fun `layout theme per document type`() {
+        assertEquals("latex", DefaultTheme.getLayoutTheme(DocumentType.PLAIN))
+        assertEquals("latex", DefaultTheme.getLayoutTheme(DocumentType.PAGED))
+        assertEquals("focus", DefaultTheme.getLayoutTheme(DocumentType.SLIDES))
+        assertEquals("hyperlegible", DefaultTheme.getLayoutTheme(DocumentType.DOCS))
+    }
+
+    @Test
+    fun `color theme per document type`() {
+        assertEquals("paperwhite", DefaultTheme.getColorTheme(DocumentType.PLAIN))
+        assertEquals("paperwhite", DefaultTheme.getColorTheme(DocumentType.PAGED))
+        assertEquals("paperwhite", DefaultTheme.getColorTheme(DocumentType.SLIDES))
+        assertEquals("galactic", DefaultTheme.getColorTheme(DocumentType.DOCS))
+    }
+}

--- a/quarkdown-cli/src/test/kotlin/com/quarkdown/cli/ProjectCreatorCommandTest.kt
+++ b/quarkdown-cli/src/test/kotlin/com/quarkdown/cli/ProjectCreatorCommandTest.kt
@@ -45,9 +45,9 @@ class ProjectCreatorCommandTest : TempDirectory() {
             "--authors",
             "Aaa, Bbb,Ccc",
             "--type",
-            "slides",
+            "plain",
             "--description",
-            if (includeDescription) "A test document for slides" else "",
+            if (includeDescription) "A test document" else "",
             "--lang",
             "en",
             "--color-theme",
@@ -73,7 +73,7 @@ class ProjectCreatorCommandTest : TempDirectory() {
                 .toString()
         assertTrue(main.startsWith(".docname {test}"))
         if (includeDescription) {
-            assertTrue(".docdescription {A test document for slides}" in main)
+            assertTrue(".docdescription {A test document}" in main)
         }
         if (includeKeywords) {
             assertTrue(".dockeywords\n  - testing\n  - slides\n  - quarkdown" in main)
@@ -81,7 +81,7 @@ class ProjectCreatorCommandTest : TempDirectory() {
         assertTrue("- Aaa" in main)
         assertTrue("- Bbb" in main)
         assertTrue("- Ccc" in main)
-        assertTrue(".doctype {slides}" in main)
+        assertTrue(".doctype {plain}" in main)
         assertTrue(".doclang {English}" in main)
         assertTrue(".theme {darko} layout:{latex}" in main)
 
@@ -123,6 +123,47 @@ class ProjectCreatorCommandTest : TempDirectory() {
     fun `no keywords`() {
         val main = test(includeKeywords = false)
         assertTrue(".dockeywords" !in main)
+    }
+
+    @Test
+    fun slides() {
+        command.test(
+            directory.resolve(".").absolutePath,
+            "--name",
+            "test",
+            "--authors",
+            "Aaa",
+            "--type",
+            "slides",
+            "--description",
+            "A presentation",
+            "--lang",
+            "",
+            "--main-file",
+            "main",
+        )
+        assertTrue(directory.exists())
+
+        // Slides projects supply the main file and the image assets.
+        val fileNames = directory.listFiles()!!.map { it.name }
+        assertEquals(setOf("main.qd", "image"), fileNames.toSet())
+
+        val main =
+            directory
+                .resolve("main.qd")
+                .readText()
+                .normalizeLineSeparators()
+                .toString()
+        assertContains(main, ".doctype {slides}")
+        // Default theme for slides.
+        assertContains(main, ".theme {paperwhite} layout:{focus}")
+        // Slides starter content.
+        assertContains(main, ".footer")
+        assertContains(main, "# .docname")
+        assertContains(main, ".text {.docdescription} variant:{smallcaps}")
+        assertContains(main, "\n## First slide\n")
+        assertContains(main, "\n## Second slide\n")
+        assertContains(main, "image/logo.png")
     }
 
     @Test

--- a/quarkdown-cli/src/test/kotlin/com/quarkdown/cli/ProjectCreatorTest.kt
+++ b/quarkdown-cli/src/test/kotlin/com/quarkdown/cli/ProjectCreatorTest.kt
@@ -4,6 +4,7 @@ import com.quarkdown.cli.creator.ProjectCreator
 import com.quarkdown.cli.creator.content.DefaultProjectCreatorInitialContentSupplier
 import com.quarkdown.cli.creator.content.DocsProjectCreatorInitialContentSupplier
 import com.quarkdown.cli.creator.content.EmptyProjectCreatorInitialContentSupplier
+import com.quarkdown.cli.creator.content.SlidesProjectCreatorInitialContentSupplier
 import com.quarkdown.cli.creator.template.DefaultProjectCreatorTemplateProcessorFactory
 import com.quarkdown.cli.creator.template.DocsProjectCreatorTemplateProcessorFactory
 import com.quarkdown.core.document.DocumentAuthor
@@ -46,6 +47,13 @@ class ProjectCreatorTest {
         if (includeInitialContent) DocsProjectCreatorInitialContentSupplier() else EmptyProjectCreatorInitialContentSupplier(),
         mainFileName = "main",
     )
+
+    private fun slidesProjectCreator(info: DocumentInfo) =
+        ProjectCreator(
+            DefaultProjectCreatorTemplateProcessorFactory(info),
+            SlidesProjectCreatorInitialContentSupplier(),
+            mainFileName = "main",
+        )
 
     @Test
     fun empty() {
@@ -390,5 +398,44 @@ class ProjectCreatorTest {
         assertTrue(resources.any { it.name == "page-1.qd" })
         assertTrue(resources.any { it.name == "page-2.qd" })
         assertTrue(resources.any { it.name == "page-3.qd" })
+    }
+
+    @Test
+    fun `slides with initial content`() {
+        val creator =
+            slidesProjectCreator(
+                DocumentInfo(name = "Test", description = "My slides", type = DocumentType.SLIDES),
+            )
+        val resources = creator.createResources()
+        assertEquals(2, resources.size)
+
+        // The logo image is supplied, like in default projects.
+        val images = resources.filterIsInstance<OutputResourceGroup>().single { it.name == "image" }
+        assertEquals("logo.png", images.resources.single().name)
+
+        val main = resources.first { it is TextOutputArtifact }
+        val content = main.textContent
+
+        assertContains(content, ".docname {Test}")
+        assertContains(content, ".doctype {slides}")
+
+        // Slide-specific structure.
+        assertContains(content, ".footer\n    .docauthor\n\n    .docname\n\n    .currentpage / .totalpages")
+        assertContains(content, "# .docname")
+        assertContains(content, ".text {.docdescription} variant:{smallcaps}")
+        assertContains(content, "\n## First slide\n")
+        assertContains(content, "\n## Second slide\n")
+
+        // Shared getting-started content.
+        assertContains(content, "quarkdown c main.qd")
+        assertContains(content, "official wiki")
+
+        // The second slide lays out text and a formula in a row, followed by the logo.
+        assertContains(content, ".row alignment:{spacebetween}\n    This is a multi-column layout.")
+        assertContains(content, "!(25%)[Quarkdown](image/logo.png)")
+
+        // No docs sections or heading with raw name.
+        assertFalse("## Compiling" in content)
+        assertFalse("# Test" in content)
     }
 }

--- a/quarkdown-template/src/main/jte/creator/gettingstarted.jte
+++ b/quarkdown-template/src/main/jte/creator/gettingstarted.jte
@@ -1,0 +1,19 @@
+@param boolean docs = false
+@param String mainFile = null
+Welcome to [Quarkdown](https://github.com/iamgio/quarkdown)! This is the starting point of your document.
+
+@if(docs)
+## Compiling
+
+@endif
+- To compile this document, please `cd` to this file's parent directory and run:
+  `quarkdown c ${mainFile}.qd`
+
+- To enable live preview, run:
+  `quarkdown c ${mainFile}.qd -p -w`
+
+@if(docs)
+## Wiki
+
+@endif
+For further information and guides, please check out the [official wiki](https://quarkdown.com/wiki).

--- a/quarkdown-template/src/main/jte/creator/initialcontent.qd.jte
+++ b/quarkdown-template/src/main/jte/creator/initialcontent.qd.jte
@@ -8,27 +8,7 @@
 
 @endif
 
-Welcome to [Quarkdown](https://github.com/iamgio/quarkdown)! This is the starting point of your document.
-
-@if(docs)
-## Compiling
-@endif
-
-
-- To compile this document, please `cd` to this file's parent directory and run:
-  `quarkdown c ${mainFile}.qd`
-
-- To enable live preview, run:
-  `quarkdown c ${mainFile}.qd -p -w`
-
-@if(docs)
-
-## Wiki
-
-@endif
-
-For further information and guides, please check out the [official wiki](https://quarkdown.com/wiki).
-
+@template.creator.gettingstarted(docs = docs, mainFile = mainFile)
 @if(!docs)
 !(50%)[Quarkdown](image/logo.png)
 @else

--- a/quarkdown-template/src/main/jte/creator/slides/initialcontent.qd.jte
+++ b/quarkdown-template/src/main/jte/creator/slides/initialcontent.qd.jte
@@ -1,0 +1,32 @@
+@param String description = null
+@param String mainFile = null
+.footer
+    .docauthor
+
+    .docname
+
+    .currentpage / .totalpages
+
+# .docname
+
+.docauthors::foreach
+    name info:
+    .name
+
+@if(description != null)
+.whitespace
+
+.text {.docdescription} variant:{smallcaps}
+
+@endif
+## First slide
+
+@template.creator.gettingstarted(mainFile = mainFile)
+## Second slide
+
+.row alignment:{spacebetween}
+    This is a multi-column layout.
+
+    $ \int_{-\infty}^{\infty} e^{-x^2} dx = \sqrt{\pi} $
+
+!(25%)[Quarkdown](image/logo.png)


### PR DESCRIPTION
- [X] I have read the [contributing guidelines](https://github.com/iamgio/quarkdown/blob/main/CONTRIBUTING.md).
- [X] I have tested the changes locally.
- [ ] An issue for this change exists, and it was discussed with maintainers. This is required for new features and non-trivial changes. If present, append `Closes #ISSUE_NUMBER` at the end of this PR description.
- [ ] (Optional) I have added necessary documentation to [`docs`](https://github.com/iamgio/quarkdown/tree/main/docs) and [`CHANGELOG.md`](https://github.com/iamgio/quarkdown/blob/main/CHANGELOG.md)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for creating slide-deck projects with `quarkdown create`.
  - New slide projects include presentation-focused starter content, getting-started guidance, and an example formula slide.
  - Slide projects use the “focus” layout theme by default.
  - Added shared getting-started instructions with compilation and live-preview commands.
- **Changed**
  - Slide documents now automatically add page breaks after H1 and H2 headings unless overridden.
- **Documentation**
  - Updated PDF export changelog wording to describe generation as significantly faster.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->