### PR TITLE
ci: generate jpg of each theme combination [generate-pdf]

### DIFF
--- a/.github/workflows/generate-pdf.yml
+++ b/.github/workflows/generate-pdf.yml
@@ -9,9 +9,14 @@ on:
       - 'LICENSE'
       - '.github/FUNDING.yml'
   workflow_dispatch:
+  pull_request:
+    types: [ opened, synchronize, reopened, edited ]
 
 jobs:
   build:
+
+    # On pull requests, runs only when the PR title opts in via the "[generate-pdf]" tag.
+    if: github.event_name != 'pull_request' || contains(github.event.pull_request.title, '[generate-pdf]')
 
     runs-on: ubuntu-latest
 
@@ -30,7 +35,7 @@ jobs:
     - name: Setup staging directory
       run: |
         rm -rf pdf
-        mkdir -p pdf/mock
+        mkdir -p pdf/mock pdf/mock-jpg
 
     - name: Generate theme combinations
       run: |
@@ -48,13 +53,38 @@ jobs:
         rm -rf pdf/mock/*/
         ls -d $PWD/pdf/*
 
-    - name: Upload artifact
+    # Extracts the "Alerts" page from each generated PDF as a JPG image, for theme previews.
+    # The page is located by its text content, as its page number varies across themes.
+    - name: Extract Alert page as JPG
+      run: |
+        if ! command -v pdftoppm > /dev/null; then
+          sudo apt-get update -qq && sudo apt-get install -y -qq poppler-utils
+        fi
+        for pdf in pdf/mock/*.pdf; do
+          name=$(basename "$pdf" .pdf)
+          page=$(pdftotext "$pdf" - | awk -v RS='\f' '/Alerts/ && /use what happens/ { print NR; exit }')
+          if [ -z "$page" ]; then
+            echo "Could not locate the Alerts page in $pdf"
+            exit 1
+          fi
+          pdftoppm -jpeg -r 150 -f "$page" -l "$page" -singlefile "$pdf" "pdf/mock-jpg/$name"
+        done
+        ls -d $PWD/pdf/mock-jpg/*
+
+    - name: Upload PDF artifact
       uses: actions/upload-artifact@v4
       with:
         name: mock-pdf
         path: pdf/mock
 
-    - name: Push to generated repo
+    - name: Upload JPG artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: mock-jpg
+        path: pdf/mock-jpg
+
+    - name: Push PDFs to generated repo
+      if: github.event_name != 'pull_request'
       uses: cpina/github-action-push-to-another-repository@v1.7.2
       env:
         API_TOKEN_GITHUB: ${{ secrets.COMMITTER_TOKEN }}
@@ -64,5 +94,19 @@ jobs:
         destination-repository-name: generated
         target-directory: mock
         commit-message: "Generate Mock PDF files from ${{ github.sha }}"
+        user-name: "github-actions[bot]"
+        user-email: "github-actions[bot]@users.noreply.github.com"
+
+    - name: Push JPGs to generated repo
+      if: github.event_name != 'pull_request'
+      uses: cpina/github-action-push-to-another-repository@v1.7.2
+      env:
+        API_TOKEN_GITHUB: ${{ secrets.COMMITTER_TOKEN }}
+      with:
+        source-directory: pdf/mock-jpg
+        destination-github-username: quarkdown-labs
+        destination-repository-name: generated
+        target-directory: mock-jpg
+        commit-message: "Generate Mock JPG previews from ${{ github.sha }}"
         user-name: "github-actions[bot]"
         user-email: "github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/generate-pdf/layout.txt
+++ b/.github/workflows/generate-pdf/layout.txt
@@ -1,4 +1,5 @@
 latex
 minimal
+focus
 beamer
 hyperlegible

--- a/docs/themes.qd
+++ b/docs/themes.qd
@@ -7,18 +7,28 @@ Themes are split into two groups: *color* themes, which define the color scheme 
 
 You can set a theme via the **`.theme {colortheme} layout:{layouttheme}`** function.
 
+.var {colorthemes}
+    - paperwhite
+    - darko
+    - galactic
+    - beaver
+
+.var {layoutthemes}
+    - latex
+    - hyperlegible
+    - minimal
+    - focus
+    - beamer
+
 ### Color themes
-- `paperwhite` (default)
-- `darko`
-- `galactic`
-- `beaver`
+
+.colorthemes::foreach
+    .1::codespan
 
 ### Layout themes
-- `latex` (default)
-- `hyperlegible`
-- `minimal`
-- `focus`
-- `beamer`
+
+.layoutthemes::foreach
+    .1::codespan
 
 ---
 
@@ -29,8 +39,25 @@ Some suggested combinations are:
 - `darko+minimal`
 - `beaver+beamer`: Beamer look, great for academic-style presentations)
 
+The table below shows how each combination renders the same page of the .repolink {Mock document} {tree/main/mock#readme}. Click a preview to open the full PDF.
+
+.function {mockpreview}
+    color layout:
+    .var {name} {{.color}_{.layout}}
+
+    .link url:{https://github.com/quarkdown-labs/generated/blob/main/mock/.name.pdf}
+        .image url:{https://raw.githubusercontent.com/quarkdown-labs/generated/main/mock-jpg/.name.jpg} \
+               label:{.color, .layout}
+
+.tablebyrows headers:{.layoutthemes}
+    .layoutthemes::foreach
+        layouttheme:
+        .colorthemes::foreach
+            colortheme:
+            .mockpreview {.colortheme} {.layouttheme}
+
 ## Contributing
 
 .repolink {Theme contributions} {tree/main/quarkdown-html/src/main/scss} are welcome.
 
-Please make sure themes work well with all three document types before submitting. The .repolink {Mock document} {tree/main/mock#readme} is a great way to test themes against a variety of different elements.
+Please make sure themes work well with all four document types before submitting. The .repolink {Mock document} {tree/main/mock#readme} is a great way to test themes against a variety of different elements.


### PR DESCRIPTION
- [X] I have read the [contributing guidelines](https://github.com/iamgio/quarkdown/blob/main/CONTRIBUTING.md).
- [X] I have tested the changes locally.
- [ ] An issue for this change exists, and it was discussed with maintainers. This is required for new features and non-trivial changes. If present, append `Closes #ISSUE_NUMBER` at the end of this PR description.
- [ ] (Optional) I have added necessary documentation to [`docs`](https://github.com/iamgio/quarkdown/tree/main/docs) and [`CHANGELOG.md`](https://github.com/iamgio/quarkdown/blob/main/CHANGELOG.md)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a themes showcase with clickable previews for available color and layout combinations.
  - Generated document previews now include PDF files and JPG snapshots of the Alerts page.
  - Added the `focus` layout option to PDF generation.

- **Documentation**
  - Expanded theme documentation with visual examples and an additional suggested combination.
  - Updated contribution guidance to cover all four document types.

- **Improvements**
  - PDF generation for pull requests can be selectively triggered using a title tag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->