### PR TITLE
feat(stdlib): add .appended and .prepended

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,27 @@ The new `callouts` argument of the `.code` function attaches numbered markers to
 
 Creating a new `slides` project via `quarkdown create` now generates starter content designed for presentations.
 
+#### [New collection operations: `prepended` and `appended`](https://quarkdown.com/wiki/iterable)
+
+The new `prepended` and `appended` functions add an element at the beginning or end of a collection, respectively,
+without affecting the original collection.
+
+```markdown
+.var {letters}
+    - B
+    - C
+
+.foreach {.letters::prepended {A}::appended {D}}
+    .1
+```
+> Output:
+> ```text
+> A
+> B
+> C
+> D
+> ```
+
 ### Changed
 
 #### PDF export without Node.js [ecosystem breaking change]
@@ -75,7 +96,7 @@ Breaking change: calling `.doclang` without a parameter now returns the *English
 PDF artifacts generated from `slides` documents now feature a more polished layout. 
 Blank (headerless) slides are now spaced correctly.
 
-#### Block-aware [`.text`](https://quarkdown.com/wiki/text) and `.whitespace`
+#### Block-aware [`.text`](https://quarkdown.com/wiki/text), `.codespan` and `.whitespace`
 
 The `.text` and `.whitespace` functions now adapt to where they are called.
 This fixes spacing issues when invoked as block-level functions.

--- a/docs/iterable.qd
+++ b/docs/iterable.qd
@@ -50,4 +50,14 @@ An integer [`Range`](range.qd) is a valid ordered iterable value.
 
 Assuming `myiterable` is an iterable, you can access useful operations such as `getat`, `sorted`, `average`, and many more via [function call chaining](syntax-of-a-function-call.qd#chaining-calls) as `.myiterable::operation`.
 
+Operations are immutable and never modify the original iterable. For instance, `prepended` and `appended` produce a new collection with an extra element at the beginning or end, respectively.
+
+.examplemirror
+    .var {letters}
+        - B
+        - C
+
+    .foreach {.letters::prepended {A}::appended {D}}
+        .1
+
 For a complete list of operations, refer to the standard library's [`Collection` documentation](https://quarkdown.com/docs/quarkdown-stdlib/com.quarkdown.stdlib.module.Collection).

--- a/docs/themes.qd
+++ b/docs/themes.qd
@@ -1,6 +1,9 @@
 .docname {Themes}
 .include {docs}
 
+.css 
+    figure { width: 300px; }
+
 A theme defines the look and feel of your Quarkdown document. More themes are planned for the future.
 
 Themes are split into two groups: *color* themes, which define the color scheme of a document, and *layout* themes, which set the general structural rules of the layout. Combining them allows you to create a document that truly stands out.
@@ -22,13 +25,11 @@ You can set a theme via the **`.theme {colortheme} layout:{layouttheme}`** funct
 
 ### Color themes
 
-.colorthemes::foreach
-    .1::codespan
+.colorthemes
 
 ### Layout themes
 
-.layoutthemes::foreach
-    .1::codespan
+.layoutthemes
 
 ---
 
@@ -49,12 +50,14 @@ The table below shows how each combination renders the same page of the .repolin
         .image url:{https://raw.githubusercontent.com/quarkdown-labs/generated/main/mock-jpg/.name.jpg} \
                label:{.color, .layout}
 
-.tablebyrows headers:{.layoutthemes}
-    .layoutthemes::foreach
-        layouttheme:
-        .colorthemes::foreach
-            colortheme:
-            .mockpreview {.colortheme} {.layouttheme}
+.tablebyrows headers:{.layoutthemes::prepended {.whitespace}}
+    .colorthemes::foreach
+        colortheme:
+        .var {previews}
+            .layoutthemes::foreach
+                layouttheme:
+                .mockpreview {.colortheme} {.layouttheme}
+        .previews::prepended {**.colortheme**}
 
 ## Contributing
 

--- a/quarkdown-core/src/main/kotlin/com/quarkdown/core/function/value/output/node/BlockNodeOutputValueVisitor.kt
+++ b/quarkdown-core/src/main/kotlin/com/quarkdown/core/function/value/output/node/BlockNodeOutputValueVisitor.kt
@@ -3,6 +3,7 @@ package com.quarkdown.core.function.value.output.node
 import com.quarkdown.core.ast.InlineMarkdownContent
 import com.quarkdown.core.ast.Node
 import com.quarkdown.core.ast.base.block.Paragraph
+import com.quarkdown.core.ast.base.inline.CodeSpan
 import com.quarkdown.core.ast.base.inline.Link
 import com.quarkdown.core.ast.quarkdown.inline.TextTransform
 import com.quarkdown.core.ast.quarkdown.inline.Whitespace
@@ -48,7 +49,7 @@ class BlockNodeOutputValueVisitor(
     override fun visit(value: NodeValue) =
         when (val node = value.unwrappedValue) {
             is InlineMarkdownContent -> Paragraph(node.children)
-            is TextTransform, is Link -> node.inParagraph()
+            is TextTransform, is CodeSpan, is Link -> node.inParagraph()
             is Whitespace -> node.diverge(isBlock = true)
             else -> node
         }

--- a/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Collection.kt
+++ b/quarkdown-stdlib/src/main/kotlin/com/quarkdown/stdlib/Collection.kt
@@ -171,13 +171,16 @@ fun collectionSorted(
         }
 
     return when {
-        sorting != null ->
+        sorting != null -> {
             collection.sortedBy {
                 val selector = sorting.invokeDynamic(it)
                 toComparable(selector)
             }
+        }
 
-        else -> collection.sortedBy { toComparable(it) }
+        else -> {
+            collection.sortedBy { toComparable(it) }
+        }
     }.wrappedAsValue()
 }
 
@@ -204,12 +207,57 @@ fun collectionGroup(
     @Name("from") collection: Iterable<OutputValue<*>>,
 ): IterableValue<IterableValue<OutputValue<*>>> =
     collection
-        .asSequence()
         .groupBy { it }
         .mapValues { it.value.toList() }
         .mapValues { it.value.wrappedAsValue() }
         .values
         .let(::GeneralCollectionValue)
+
+/**
+ * Adds an element at the beginning of a collection. The original collection is not modified.
+ *
+ * ```
+ * .var {letters}
+ *     - B
+ *     - C
+ *
+ * .letters::prepended {A} <!-- A, B, C -->
+ * ```
+ *
+ * @param collection collection to add the element to
+ * @param value element to add at the beginning of the collection
+ * @return a new collection containing [value] followed by the elements of the original collection
+ */
+@QFunction
+@Name("prepended")
+@LikelyChained
+fun collectionPrepend(
+    @Name("to") collection: Iterable<OutputValue<*>>,
+    @Name("value") value: DynamicValue,
+): IterableValue<OutputValue<*>> = GeneralCollectionValue(listOf(value) + collection)
+
+/**
+ * Adds an element at the end of a collection. The original collection is not modified.
+ *
+ * ```
+ * .var {letters}
+ *     - A
+ *     - B
+ *
+ * .letters::appended {C} <!-- A, B, C -->
+ * ```
+ *
+ * @param collection collection to add the element to
+ * @param value element to add at the end of the collection
+ * @return a new collection containing the elements of the original collection followed by [value]
+ */
+@QFunction
+@Name("appended")
+@LikelyChained
+fun collectionAppend(
+    @Name("to") collection: Iterable<OutputValue<*>>,
+    @Name("value") value: DynamicValue,
+): IterableValue<OutputValue<*>> = GeneralCollectionValue(collection + value)
 
 /**
  * Creates a new pair.

--- a/quarkdown-test/src/test/kotlin/com/quarkdown/test/IterableTest.kt
+++ b/quarkdown-test/src/test/kotlin/com/quarkdown/test/IterableTest.kt
@@ -227,6 +227,34 @@ class IterableTest {
     }
 
     @Test
+    fun prepend() {
+        execute("$letters.foreach {.abc::prepended {Z}}\n\t.1") {
+            assertEquals("<p>Z</p><p>A</p><p>B</p><p>C</p>", it)
+        }
+    }
+
+    @Test
+    fun append() {
+        execute("$letters.foreach {.abc::appended {D}}\n\t.1") {
+            assertEquals("<p>A</p><p>B</p><p>C</p><p>D</p>", it)
+        }
+    }
+
+    @Test
+    fun `prepend and append chained`() {
+        execute("$letters.foreach {.abc::prepended {Z}::appended {D}}\n\t.1") {
+            assertEquals("<p>Z</p><p>A</p><p>B</p><p>C</p><p>D</p>", it)
+        }
+    }
+
+    @Test
+    fun `prepend and append do not modify the original collection`() {
+        execute("$letters.abc::prepended {Z}::appended {D}::size\n\n.abc::size") {
+            assertEquals("<p>5</p><p>3</p>", it)
+        }
+    }
+
+    @Test
     fun `handle pairs`() {
         execute(
             """


### PR DESCRIPTION
- [x] I have read the [contributing guidelines](https://github.com/iamgio/quarkdown/blob/main/CONTRIBUTING.md).
- [x] I have tested the changes locally.
- [ ] An issue for this change exists, and it was discussed with maintainers. This is required for new features and non-trivial changes. If present, append `Closes #ISSUE_NUMBER` at the end of this PR description.
- [x] (Optional) I have added necessary documentation to [`docs`](https://github.com/iamgio/quarkdown/tree/main/docs) and [`CHANGELOG.md`](https://github.com/iamgio/quarkdown/blob/main/CHANGELOG.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
    - Added `prepended` and `appended` collection operations for adding elements to the beginning or end of a collection.
    - These operations preserve the original collection and support chaining.
- **Bug Fixes**
    - Code spans now render correctly as inline content within blocks.
- **Documentation**
    - Added usage examples and clarified that iterable operations are immutable.
    - Improved theme previews, styling, and layout presentation.
    - Updated changelog entries to document the new collection operations and block-aware code span behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->