### PR TITLE
fix(docs): make long tables scrollable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,10 @@ Breaking change: calling `.doclang` without a parameter now returns the *English
 
 ### Fixed
 
+#### Wide tables in `docs` documents scroll horizontally
+
+In `docs` documents, a table wider than the content area now scrolls horizontally within its own area.
+
 #### `slides` PDF export improvements
 
 PDF artifacts generated from `slides` documents now feature a more polished layout. 
@@ -98,7 +102,7 @@ Blank (headerless) slides are now spaced correctly.
 
 #### Block-aware [`.text`](https://quarkdown.com/wiki/text), `.codespan` and `.whitespace`
 
-The `.text` and `.whitespace` functions now adapt to where they are called.
+The `.text`, `.codespan` and `.whitespace` functions now adapt to where they are called.
 This fixes spacing issues when invoked as block-level functions.
 
 #### Layout themes: bold weight and leaner font artifacts

--- a/docs/themes.qd
+++ b/docs/themes.qd
@@ -2,7 +2,7 @@
 .include {docs}
 
 .css 
-    figure { width: 300px; }
+    figure { width: 200px; }
 
 A theme defines the look and feel of your Quarkdown document. More themes are planned for the future.
 

--- a/quarkdown-html/src/main/scss/components/_docs.scss
+++ b/quarkdown-html/src/main/scss/components/_docs.scss
@@ -93,6 +93,11 @@
     }
   }
 
+  // `ScrollableTables` handler for scrollable tables.
+  .table-scroll-area {
+    overflow-x: auto;
+  }
+
   // Previous/Next page buttons
   #sibling-pages-button-area {
     display: flex;

--- a/quarkdown-html/src/main/typescript/document/handlers/docs/__tests__/scrollable-tables.spec.ts
+++ b/quarkdown-html/src/main/typescript/document/handlers/docs/__tests__/scrollable-tables.spec.ts
@@ -1,0 +1,75 @@
+import {beforeEach, describe, expect, it} from 'vitest';
+import {ScrollableTables} from "../scrollable-tables";
+
+class DummyDoc {
+}
+
+async function run() {
+    await new ScrollableTables(new DummyDoc() as any).onPostRendering();
+}
+
+describe('ScrollableTables', () => {
+    beforeEach(() => {
+        document.body.className = 'quarkdown quarkdown-docs';
+        document.body.innerHTML = '';
+    });
+
+    it('wraps a content table in a scroll area, preserving its position', async () => {
+        document.body.innerHTML = `
+            <div class="content-wrapper">
+                <main>
+                    <p>Before</p>
+                    <table><tbody><tr><td>Cell</td></tr></tbody></table>
+                    <p>After</p>
+                </main>
+            </div>`;
+
+        await run();
+
+        const wrapper = document.querySelector('main > .table-scroll-area');
+        expect(wrapper).not.toBeNull();
+        expect(wrapper!.querySelector('table')).not.toBeNull();
+        expect(wrapper!.previousElementSibling?.textContent).toBe('Before');
+        expect(wrapper!.nextElementSibling?.textContent).toBe('After');
+    });
+
+    it('does not wrap tables inside code blocks', async () => {
+        document.body.innerHTML = `
+            <div class="content-wrapper">
+                <main>
+                    <pre><code><table><tbody><tr><td>1</td></tr></tbody></table></code></pre>
+                </main>
+            </div>`;
+
+        await run();
+
+        expect(document.querySelector('.table-scroll-area')).toBeNull();
+    });
+
+    it('does not wrap tables outside the main content area', async () => {
+        document.body.innerHTML = `
+            <div class="content-wrapper">
+                <aside><table><tbody><tr><td>Nav</td></tr></tbody></table></aside>
+                <main></main>
+            </div>`;
+
+        await run();
+
+        expect(document.querySelector('.table-scroll-area')).toBeNull();
+    });
+
+    it('does not wrap the same table twice', async () => {
+        document.body.innerHTML = `
+            <div class="content-wrapper">
+                <main>
+                    <table><tbody><tr><td>Cell</td></tr></tbody></table>
+                </main>
+            </div>`;
+
+        await run();
+        await run();
+
+        expect(document.querySelectorAll('.table-scroll-area').length).toBe(1);
+        expect(document.querySelector('.table-scroll-area .table-scroll-area')).toBeNull();
+    });
+});

--- a/quarkdown-html/src/main/typescript/document/handlers/docs/scrollable-tables.ts
+++ b/quarkdown-html/src/main/typescript/document/handlers/docs/scrollable-tables.ts
@@ -1,0 +1,37 @@
+import {DocumentHandler} from "../../document-handler";
+
+/**
+ * Class of the scroll container that tables are wrapped in.
+ * Styled in the docs stylesheet with horizontal overflow scrolling.
+ */
+const WRAPPER_CLASS = "table-scroll-area";
+
+/**
+ * Document handler that wraps each content table in a horizontally scrollable container.
+ *
+ * Tables cannot act as scroll containers themselves, so a table wider than the content
+ * area would otherwise overlap the sidebar and make the whole page horizontally scrollable.
+ *
+ * Tables inside code blocks (e.g. line-numbered code) are excluded.
+ */
+export class ScrollableTables extends DocumentHandler {
+    async onPostRendering() {
+        document
+            .querySelectorAll<HTMLTableElement>(".quarkdown-docs > .content-wrapper > main table")
+            .forEach((table) => this.wrap(table));
+    }
+
+    /**
+     * Wraps a table in a scrollable container, unless it is part of a code block
+     * or already wrapped.
+     * @param table - The table to wrap
+     */
+    private wrap(table: HTMLTableElement) {
+        if (table.closest("pre") || table.parentElement?.classList.contains(WRAPPER_CLASS)) return;
+
+        const wrapper = document.createElement("div");
+        wrapper.className = WRAPPER_CLASS;
+        table.replaceWith(wrapper);
+        wrapper.appendChild(table);
+    }
+}

--- a/quarkdown-html/src/main/typescript/document/type/docs-document.ts
+++ b/quarkdown-html/src/main/typescript/document/type/docs-document.ts
@@ -7,6 +7,7 @@ import {FootnotesDocs} from "../handlers/footnotes/footnotes-docs";
 import {SiblingPagesButtons} from "../handlers/docs/sibling-pages-buttons";
 import {PageListAutoscroll} from "../handlers/docs/page-list-autoscroll";
 import {TocActiveTracking} from "../handlers/docs/toc-active-tracking";
+import {ScrollableTables} from "../handlers/docs/scrollable-tables";
 
 /**
  * 'Docs' document implementation for HTML documents targeting documentation sites and wikis.
@@ -22,6 +23,7 @@ export class DocsDocument extends PlainDocument {
             new FootnotesDocs(this),
             new PageListAutoscroll(this),
             new TocActiveTracking(this),
+            new ScrollableTables(this),
         ];
     }
 }

--- a/quarkdown-html/src/test/e2e/docs/content-width/content-width.spec.ts
+++ b/quarkdown-html/src/test/e2e/docs/content-width/content-width.spec.ts
@@ -1,4 +1,9 @@
+import {test as base} from "@playwright/test";
 import {suite} from "../../quarkdown";
+
+// Tests in this file compile the same document to the same output directory,
+// so they must not run in parallel.
+base.describe.configure({mode: "default"});
 
 const {test, expect} = suite(__dirname);
 
@@ -57,3 +62,60 @@ test("layout widths match between simple content and long code block", async (pa
     expect(longCodeWidths.contentMain).toBe(simpleWidths.contentMain);
     expect(longCodeWidths.contentAsideLast).toBe(simpleWidths.contentAsideLast);
 }, {subpath: "simple"});
+
+test("wide table scrolls within the content area without affecting layout", async (page) => {
+    // Get widths from simple page
+    const simpleWidths = await getLayoutWidths(page);
+
+    // Navigate to wide-table page
+    await page.goto(page.url().replace("/simple/", "/wide-table/"));
+    await page.waitForFunction(() => (window as any).isReady());
+
+    // The wide table does not alter the overall layout.
+    const wideTableWidths = await getLayoutWidths(page);
+    expect(wideTableWidths.contentMain).toBe(simpleWidths.contentMain);
+    expect(wideTableWidths.contentAsideFirst).toBe(simpleWidths.contentAsideFirst);
+    expect(wideTableWidths.contentAsideLast).toBe(simpleWidths.contentAsideLast);
+
+    // The document itself is not horizontally scrollable.
+    const documentOverflow = await page.evaluate(
+        () => document.documentElement.scrollWidth - document.documentElement.clientWidth,
+    );
+    expect(documentOverflow).toBe(0);
+
+    // The table scrolls within its own wrapper.
+    const scrollArea = page.locator(".quarkdown-docs > .content-wrapper > main .table-scroll-area");
+    await expect(scrollArea).toHaveCSS("overflow-x", "auto");
+    expect(await scrollArea.evaluate((el: Element) => el.scrollWidth > el.clientWidth)).toBe(true);
+
+    // The scroll area does not overlap the right sidebar.
+    const scrollAreaBox = await scrollArea.boundingBox();
+    const asideBox = await page.locator(".quarkdown-docs > .content-wrapper > aside:last-child").boundingBox();
+    expect(scrollAreaBox!.x + scrollAreaBox!.width).toBeLessThanOrEqual(asideBox!.x);
+}, {subpath: "simple"});
+
+test("regular table is unaffected by the scroll wrapper", async (page) => {
+    const scrollArea = page.locator(".quarkdown-docs > .content-wrapper > main .table-scroll-area");
+    await expect(scrollArea).toHaveCount(1);
+
+    // The wrapper has nothing to scroll.
+    expect(await scrollArea.evaluate((el: Element) => el.scrollWidth <= el.clientWidth)).toBe(true);
+
+    // The document itself is not horizontally scrollable.
+    const documentOverflow = await page.evaluate(
+        () => document.documentElement.scrollWidth - document.documentElement.clientWidth,
+    );
+    expect(documentOverflow).toBe(0);
+
+    const tableBox = await scrollArea.locator("table").boundingBox();
+    const mainBox = await page.locator(".quarkdown-docs > .content-wrapper > main").boundingBox();
+
+    // The table keeps its natural shrink-to-fit width.
+    expect(tableBox!.width).toBeLessThan(mainBox!.width);
+
+    // The table stays horizontally centered within the content area,
+    // as the default layout theme centers tables.
+    const leftGap = tableBox!.x - mainBox!.x;
+    const rightGap = mainBox!.x + mainBox!.width - (tableBox!.x + tableBox!.width);
+    expect(Math.abs(leftGap - rightGap)).toBeLessThanOrEqual(2);
+}, {subpath: "regular-table"});

--- a/quarkdown-html/src/test/e2e/docs/content-width/main.qd
+++ b/quarkdown-html/src/test/e2e/docs/content-width/main.qd
@@ -5,6 +5,8 @@
     .navigation role:{pagelist}
         - [Simple](simple.qd)
         - [Long Code](long-code.qd)
+        - [Wide Table](wide-table.qd)
+        - [Regular Table](regular-table.qd)
 
 .pagemargin {righttop}
     .tableofcontents

--- a/quarkdown-html/src/test/e2e/docs/content-width/regular-table.qd
+++ b/quarkdown-html/src/test/e2e/docs/content-width/regular-table.qd
@@ -1,0 +1,6 @@
+.include {main.qd}
+
+| Column A | Column B | Column C |
+|----------|----------|----------|
+| aaa      | bbb      | ccc      |
+| ddd      | eee      | fff      |

--- a/quarkdown-html/src/test/e2e/docs/content-width/wide-table.qd
+++ b/quarkdown-html/src/test/e2e/docs/content-width/wide-table.qd
@@ -1,0 +1,5 @@
+.include {main.qd}
+
+| Column A | Column B | Column C | Column D | Column E | Column F | Column G | Column H |
+|----------|----------|----------|----------|----------|----------|----------|----------|
+| aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa | bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb | cccccccccccccccccccccccccccccccccccccccc | dddddddddddddddddddddddddddddddddddddddd | eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee | ffffffffffffffffffffffffffffffffffffffff | gggggggggggggggggggggggggggggggggggggggg | hhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhh |


### PR DESCRIPTION
- [x] I have read the [contributing guidelines](https://github.com/iamgio/quarkdown/blob/main/CONTRIBUTING.md).
- [x] I have tested the changes locally.
- [ ] An issue for this change exists, and it was discussed with maintainers. This is required for new features and non-trivial changes. If present, append `Closes #ISSUE_NUMBER` at the end of this PR description.
- [x] (Optional) I have added necessary documentation to [`docs`](https://github.com/iamgio/quarkdown/tree/main/docs) and [`CHANGELOG.md`](https://github.com/iamgio/quarkdown/blob/main/CHANGELOG.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Wide tables in documentation now scroll horizontally within the content area, preventing sidebar overlap and page overflow.
  - Regular tables retain their existing centered, shrink-to-fit behavior.
  - Documentation theme examples now display figures at a narrower width.

- **Documentation**
  - Added guidance covering horizontal scrolling for wide documentation tables.

- **Tests**
  - Added coverage for wide-table scrolling, regular-table layout, and table handling in protected content areas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->