### PR TITLE
fix(slides): fix explicit page size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ After creating a new project via [`quarkdown create`](https://quarkdown.com/wiki
 
 The *Citation Style Language* processor, bibliography management and style catalog were extracted and offloaded to the new [`kotlin-bibliographer`](https://github.com/quarkdown-labs/kotlin-bibliographer), Quarkdown's own Kotlin Multiplatform open source library.
 
+### Fixed
+
+#### Page size in `slides`
+
+In `slides` documents, the page size set via `.pageformat` now correctly defines the presentation's base resolution.
+
 ## [2.6.0] - 2026-09-08
 
 The highlights of this release include significant performance improvements, better portability thanks to reduced binary size and less external dependencies, and enhanced `slides` artifacts.

--- a/quarkdown-html/src/main/kotlin/com/quarkdown/rendering/html/post/document/HtmlDocumentStylesheet.kt
+++ b/quarkdown-html/src/main/kotlin/com/quarkdown/rendering/html/post/document/HtmlDocumentStylesheet.kt
@@ -111,9 +111,9 @@ class HtmlDocumentStylesheet(
                     "margin" value format.margin
                 }
 
-                rule("body.quarkdown-slides.quarkdown-slides .reveal") {
-                    "width" value format.pageWidth
-                    "height" value format.pageHeight
+                rule("body.quarkdown-slides.quarkdown-slides") {
+                    "--qd-slides-width" value format.pageWidth
+                    "--qd-slides-height" value format.pageHeight
                 }
             }
 

--- a/quarkdown-html/src/main/typescript/document/type/slides-document.ts
+++ b/quarkdown-html/src/main/typescript/document/type/slides-document.ts
@@ -33,6 +33,29 @@ export class SlidesDocument implements PagedLikeQuarkdownDocument<SlidesPage> {
     }
 
     /**
+     * Resolves a CSS size (injected by Quarkdown's `.pageformat` function) into a value
+     * accepted by Reveal.js as the presentation size: percentages are passed through,
+     * while any other unit is measured and converted to pixels.
+     * @returns The resolved size, or `undefined` if the CSS size is empty,
+     *          letting Reveal.js fall back to its default.
+     */
+    private resolvePresentationSize(cssSize: string): number | string | undefined {
+        const size = cssSize.trim();
+        if (!size) return undefined;
+        if (size.endsWith("%")) return size;
+
+        // Units such as cm or pt are converted to pixels by measuring a probe element.
+        const probe = document.createElement("div");
+        probe.style.position = "absolute";
+        probe.style.visibility = "hidden";
+        probe.style.width = size;
+        document.body.appendChild(probe);
+        const pixels = Math.round(probe.getBoundingClientRect().width);
+        probe.remove();
+        return pixels > 0 ? pixels : undefined;
+    }
+
+    /**
      * @returns The parent slide element of the given element.
      */
     getParentViewport(element: Element): HTMLElement | undefined {
@@ -109,8 +132,16 @@ export class SlidesDocument implements PagedLikeQuarkdownDocument<SlidesPage> {
         if (!slidesDiv) return;
         new PageChunker(slidesDiv).chunk();
 
+        // The page size set via `.pageformat` becomes the presentation size,
+        // scaled to fit the screen while preserving the aspect ratio.
+        const bodyStyle = getComputedStyle(document.body);
+        const width = this.resolvePresentationSize(bodyStyle.getPropertyValue("--qd-slides-width"));
+        const height = this.resolvePresentationSize(bodyStyle.getPropertyValue("--qd-slides-height"));
+
         // Initialize Reveal.js with the updated DOM.
         Reveal.initialize({
+            ...(width !== undefined && {width}),
+            ...(height !== undefined && {height}),
             // If the center property is not explicitly set, it defaults to true unless the `--reveal-center-vertically` CSS variable of `:root` is set to `false`.
             center: this.getConfigProperty(
                 "center",

--- a/quarkdown-html/src/test/e2e/page-format/index.ts
+++ b/quarkdown-html/src/test/e2e/page-format/index.ts
@@ -9,6 +9,24 @@ export const A4_HEIGHT_PX = 297 * 96 / 25.4; // ~1122.52px
 export const A5_WIDTH_PX = 148 * 96 / 25.4; // ~559.37px
 export const A5_HEIGHT_PX = 210 * 96 / 25.4; // ~793.7px
 
+/**
+ * In slides, the page size is not applied via CSS: it is forwarded to Reveal.js
+ * as the presentation size, which Reveal applies in pixels to the slides container,
+ * scaling it to fit the viewport while preserving the aspect ratio.
+ * Since scaling happens via transform, the computed width/height stay the configured size.
+ */
+export function getPresentationSizeTarget(page: Page): Locator {
+    return page.locator(".reveal .slides");
+}
+
+/**
+ * @returns The pixel size Reveal.js is expected to apply, given a possibly fractional
+ *          page size in pixels, as the runtime rounds it before initializing Reveal.
+ */
+export function asPresentationSize(pixels: number): string {
+    return `${Math.round(pixels)}px`;
+}
+
 export function getPageSizeTarget(page: Page, docType: DocumentType): Locator {
     switch (docType) {
         case "plain":

--- a/quarkdown-html/src/test/e2e/page-format/size/format-and-width/format-and-width.spec.ts
+++ b/quarkdown-html/src/test/e2e/page-format/size/format-and-width/format-and-width.spec.ts
@@ -1,5 +1,5 @@
 import {suite} from "../../../quarkdown";
-import {A5_HEIGHT_PX, A5_WIDTH_PX, getPageSizeTarget} from "../../index";
+import {asPresentationSize, A5_HEIGHT_PX, A5_WIDTH_PX, getPageSizeTarget, getPresentationSizeTarget} from "../../index";
 
 const {testMatrix, expect} = suite(__dirname);
 
@@ -7,13 +7,19 @@ testMatrix(
     "applies default format with width override",
     ["paged", "slides"],
     async (page, docType) => {
-        const target = getPageSizeTarget(page, docType);
-        const isPortrait = docType === "paged";
+        // Slides use the landscape orientation by default.
+        if (docType === "slides") {
+            const target = getPresentationSizeTarget(page);
+            await expect(target).toHaveCSS("width", "100px");
+            await expect(target).toHaveCSS("height", asPresentationSize(A5_WIDTH_PX));
+            return;
+        }
 
+        const target = getPageSizeTarget(page, docType);
         await expect(target).toHaveCSS("width", "100px");
 
         const box = await target.boundingBox();
         expect(box).not.toBeNull();
-        expect(box!.height).toBeCloseTo(isPortrait ? A5_HEIGHT_PX : A5_WIDTH_PX, 0);
+        expect(box!.height).toBeCloseTo(A5_HEIGHT_PX, 0);
     }
 );

--- a/quarkdown-html/src/test/e2e/page-format/size/format/format.spec.ts
+++ b/quarkdown-html/src/test/e2e/page-format/size/format/format.spec.ts
@@ -1,5 +1,5 @@
 import {suite} from "../../../quarkdown";
-import {A5_HEIGHT_PX, A5_WIDTH_PX, getPageSizeTarget} from "../../index";
+import {asPresentationSize, A5_HEIGHT_PX, A5_WIDTH_PX, getPageSizeTarget, getPresentationSizeTarget} from "../../index";
 
 const {testMatrix, expect} = suite(__dirname);
 
@@ -7,12 +7,17 @@ testMatrix(
     "applies A5 format with width override",
     ["paged", "slides"],
     async (page, docType) => {
-        const target = getPageSizeTarget(page, docType);
-        const isPortrait = docType === "paged";
+        // Slides use the landscape orientation by default.
+        if (docType === "slides") {
+            const target = getPresentationSizeTarget(page);
+            await expect(target).toHaveCSS("width", asPresentationSize(A5_HEIGHT_PX));
+            await expect(target).toHaveCSS("height", asPresentationSize(A5_WIDTH_PX));
+            return;
+        }
 
-        const box = await target.boundingBox();
+        const box = await getPageSizeTarget(page, docType).boundingBox();
         expect(box).not.toBeNull();
-        expect(box!.width).toBeCloseTo(isPortrait ? A5_WIDTH_PX : A5_HEIGHT_PX, 0);
-        expect(box!.height).toBeCloseTo(isPortrait ? A5_HEIGHT_PX : A5_WIDTH_PX, 0);
+        expect(box!.width).toBeCloseTo(A5_WIDTH_PX, 0);
+        expect(box!.height).toBeCloseTo(A5_HEIGHT_PX, 0);
     }
 );

--- a/quarkdown-html/src/test/e2e/page-format/size/height/height.spec.ts
+++ b/quarkdown-html/src/test/e2e/page-format/size/height/height.spec.ts
@@ -1,5 +1,5 @@
 import {suite} from "../../../quarkdown";
-import {A4_WIDTH_PX, getPageSizeTarget} from "../../index";
+import {A4_WIDTH_PX, getPageSizeTarget, getPresentationSizeTarget} from "../../index";
 
 const {testMatrix, expect} = suite(__dirname);
 
@@ -7,7 +7,7 @@ testMatrix(
     "applies page height to correct element",
     ["paged", "slides"],
     async (page, docType) => {
-        const target = getPageSizeTarget(page, docType);
+        const target = docType === "slides" ? getPresentationSizeTarget(page) : getPageSizeTarget(page, docType);
 
         await expect(target).toHaveCSS("height", "100px");
 

--- a/quarkdown-html/src/test/e2e/page-format/size/width-and-height/width-and-height.spec.ts
+++ b/quarkdown-html/src/test/e2e/page-format/size/width-and-height/width-and-height.spec.ts
@@ -1,5 +1,5 @@
 import {suite} from "../../../quarkdown";
-import {getPageSizeTarget} from "../../index";
+import {getPageSizeTarget, getPresentationSizeTarget} from "../../index";
 
 const {testMatrix, expect} = suite(__dirname);
 
@@ -7,7 +7,7 @@ testMatrix(
     "applies both width and height",
     ["paged", "slides"],
     async (page, docType) => {
-        const target = getPageSizeTarget(page, docType);
+        const target = docType === "slides" ? getPresentationSizeTarget(page) : getPageSizeTarget(page, docType);
 
         await expect(target).toHaveCSS("width", "100px");
         await expect(target).toHaveCSS("height", "100px");

--- a/quarkdown-html/src/test/e2e/page-format/size/width/width.spec.ts
+++ b/quarkdown-html/src/test/e2e/page-format/size/width/width.spec.ts
@@ -1,5 +1,5 @@
 import {suite} from "../../../quarkdown";
-import {A4_HEIGHT_PX, getPageSizeTarget} from "../../index";
+import {A4_HEIGHT_PX, getPageSizeTarget, getPresentationSizeTarget} from "../../index";
 
 const {testMatrix, expect} = suite(__dirname);
 
@@ -42,9 +42,7 @@ testMatrix(
                 }
                 break;
             case "slides":
-                const slide = await target.boundingBox();
-                expect(slide).not.toBeNull();
-                expect(slide!.width).toBeCloseTo(EXPECTED_WIDTH, 0);
+                await expect(getPresentationSizeTarget(page)).toHaveCSS("width", `${EXPECTED_WIDTH}px`);
         }
     }
 );

--- a/quarkdown-html/src/test/kotlin/com/quarkdown/rendering/html/HtmlPostRendererTest.kt
+++ b/quarkdown-html/src/test/kotlin/com/quarkdown/rendering/html/HtmlPostRendererTest.kt
@@ -233,6 +233,7 @@ class HtmlPostRendererTest {
             )
         val result = postRenderer().wrap("")
         assertTrue("--qd-content-width: 8.5in" in result)
+        assertTrue("--qd-slides-width: 8.5in" in result)
     }
 
     @Test


### PR DESCRIPTION
- [X] I have read the [contributing guidelines](https://github.com/iamgio/quarkdown/blob/main/CONTRIBUTING.md).
- [X] I have tested the changes locally.
- [ ] An issue for this change exists, and it was discussed with maintainers. This is required for new features and non-trivial changes. If present, append `Closes #ISSUE_NUMBER` at the end of this PR description.
- [ ] (Optional) I have added necessary documentation to [`docs`](https://github.com/iamgio/quarkdown/tree/main/docs) and [`CHANGELOG.md`](https://github.com/iamgio/quarkdown/blob/main/CHANGELOG.md)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed slide presentations so dimensions set with `.pageformat` correctly determine the presentation’s base resolution.
  - Improved handling of slide dimensions across supported units, including percentage-based sizes.
  - Ensured sizing is applied consistently for width, height, and combined page-format settings.

- **Tests**
  - Added and updated coverage for rendered slide dimensions across common page formats and custom sizing.
  - Added validation for presentation sizing in both CSS and rendered output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->